### PR TITLE
add img_to_buffer utility function

### DIFF
--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -545,8 +545,37 @@ def array_to_img(arr, mask=None, color_map=None):
     return img
 
 
+def img_to_buffer(img, image_format, image_options={}):
+    """Convert a Pillow image to io buffer.
+
+    Attributes
+    ----------
+    img : object
+        Pillow image
+    image_format : str
+        Image file formats
+    image_options : dict
+        Pillow image format options.
+        See https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html
+
+    Returns
+    -------
+    buffer
+
+    """
+
+    if image_format == "jpeg":
+        img = img.convert("RGB")
+
+    sio = BytesIO()
+    img.save(sio, image_format.upper(), **image_options)
+    sio.seek(0)
+    return sio.getvalue()
+
+
 def b64_encode_img(img, tileformat):
-    """Convert a Pillow image to an base64 encoded string
+    """Convert a Pillow image to an base64 encoded string.
+
     Attributes
     ----------
     img : object
@@ -558,6 +587,7 @@ def b64_encode_img(img, tileformat):
     -------
     out : str
         base64 encoded image.
+
     """
     params = TileProfiles.get(tileformat)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -701,3 +701,24 @@ def test_get_vrt_transform_valid4326():
     assert vrt_transform[5] == 38.954069293441066
     assert vrt_width == 420
     assert vrt_height == 327
+
+
+def test_img_to_buffer_valid_jpg():
+    """Should create a jpeg buffer."""
+    arr = np.random.randint(0, 255, size=(4, 512, 512), dtype=np.uint8)
+    img = utils.array_to_img(arr)
+    assert utils.img_to_buffer(img, "jpeg")
+
+
+def test_img_to_buffer_valid_png():
+    """Should create a png buffer."""
+    arr = np.random.randint(0, 255, size=(4, 512, 512), dtype=np.uint8)
+    img = utils.array_to_img(arr)
+    assert utils.img_to_buffer(img, "png")
+
+
+def test_img_to_buffer_valid_options():
+    """Should create a png buffer with compression options."""
+    arr = np.random.randint(0, 255, size=(4, 512, 512), dtype=np.uint8)
+    img = utils.array_to_img(arr)
+    assert utils.img_to_buffer(img, "png", image_options={"compress_level": 0})


### PR DESCRIPTION
This PR adds a new utility function to create a buffer from a pillow object. 

implemented and tested in https://github.com/RemotePixel/remotepixel-tiler/blob/master/remotepixel_tiler/landsat.py#L107-L108 because the latest version of https://github.com/vincentsarago/lambda-proxy is now taking care of base64 encoding 