### PR TITLE
Band's name validation for Sentinel, Landsat and CBERS 

### DIFF
--- a/rio_tiler/errors.py
+++ b/rio_tiler/errors.py
@@ -23,3 +23,11 @@ class InvalidSentinelSceneId(RioTilerError):
 
 class InvalidCBERSSceneId(RioTilerError):
     """Invalid CBERS scene id."""
+
+
+class InvalidBandName(RioTilerError):
+    """Invalid band name."""
+
+
+class DeprecationWarning(UserWarning):
+    """Rio-tiler module deprecations warning."""

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -66,7 +66,7 @@ def landsat_min_max_worker(
         returns a list of the min/max histogram cut values.
 
     """
-    if int(band) > 9:  # TIRS
+    if band in ["10", "11"]:  # TIRS
         multi_rad = metadata["RADIOMETRIC_RESCALING"].get(
             "RADIANCE_MULT_BAND_{}".format(band)
         )
@@ -487,14 +487,22 @@ def cbers_parse_scene_id(sceneid):
     meta["scene"] = sceneid
 
     instrument_params = {
-        "MUX": {"reference_band": "6", "bands": ["5", "6", "7", "8"], "rgb": (7, 6, 5)},
+        "MUX": {
+            "reference_band": "6",
+            "bands": ["5", "6", "7", "8"],
+            "rgb": ("7", "6", "5"),
+        },
         "AWFI": {
             "reference_band": "14",
             "bands": ["13", "14", "15", "16"],
-            "rgb": (15, 14, 13),
+            "rgb": ("15", "14", "13"),
         },
-        "PAN10M": {"reference_band": "4", "bands": ["2", "3", "4"], "rgb": (3, 4, 2)},
-        "PAN5M": {"reference_band": "1", "bands": ["1"], "rgb": (1, 1, 1)},
+        "PAN10M": {
+            "reference_band": "4",
+            "bands": ["2", "3", "4"],
+            "rgb": ("3", "4", "2"),
+        },
+        "PAN5M": {"reference_band": "1", "bands": ["1"], "rgb": ("1", "1", "1")},
     }
     meta["reference_band"] = instrument_params[instrument]["reference_band"]
     meta["bands"] = instrument_params[instrument]["bands"]

--- a/tests/test_sentinel.py
+++ b/tests/test_sentinel.py
@@ -4,7 +4,7 @@ import os
 import pytest
 
 from rio_tiler import sentinel2
-from rio_tiler.errors import TileOutsideBounds
+from rio_tiler.errors import TileOutsideBounds, InvalidBandName
 
 SENTINEL_SCENE = "S2A_tile_20170729_19UDP_0"
 SENTINEL_BUCKET = os.path.join(os.path.dirname(__file__), "fixtures", "sentinel-s2-l1c")
@@ -84,11 +84,8 @@ def test_tile_valid_nrg(monkeypatch):
     assert mask.shape == (256, 256)
 
 
-def test_tile_valid_onband(monkeypatch):
-    """
-    Should work as expected
-    """
-
+def test_tile_valid_oneband(monkeypatch):
+    """Test when passing a string instead of a tuple."""
     monkeypatch.setattr(sentinel2, "SENTINEL_BUCKET", SENTINEL_BUCKET)
 
     tile_z = 8
@@ -99,6 +96,19 @@ def test_tile_valid_onband(monkeypatch):
     data, mask = sentinel2.tile(SENTINEL_SCENE, tile_x, tile_y, tile_z, bands=bands)
     assert data.shape == (1, 256, 256)
     assert mask.shape == (256, 256)
+
+
+def test_tile_invalid_band(monkeypatch):
+    """Should raise an error on invalid band name."""
+    monkeypatch.setattr(sentinel2, "SENTINEL_BUCKET", SENTINEL_BUCKET)
+
+    tile_z = 8
+    tile_x = 77
+    tile_y = 89
+    bands = "9A"
+
+    with pytest.raises(InvalidBandName):
+        data, mask = sentinel2.tile(SENTINEL_SCENE, tile_x, tile_y, tile_z, bands=bands)
 
 
 def test_tile_invalid_bounds(monkeypatch):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -387,10 +387,7 @@ def test_cbers_id_invalid():
 
 
 def test_cbers_id_valid():
-    """
-    Should work as expected (parse cbers scene id)
-    """
-
+    """Should work as expected (parse cbers scene id)."""
     scene = "CBERS_4_MUX_20171121_057_094_L2"
     expected_content = {
         "acquisitionDay": "21",
@@ -405,7 +402,7 @@ def test_cbers_id_valid():
         "scene": "CBERS_4_MUX_20171121_057_094_L2",
         "reference_band": "6",
         "bands": ["5", "6", "7", "8"],
-        "rgb": (7, 6, 5),
+        "rgb": ("7", "6", "5"),
         "satellite": "CBERS",
     }
 
@@ -425,7 +422,7 @@ def test_cbers_id_valid():
         "scene": "CBERS_4_AWFI_20171121_057_094_L2",
         "reference_band": "14",
         "bands": ["13", "14", "15", "16"],
-        "rgb": (15, 14, 13),
+        "rgb": ("15", "14", "13"),
         "satellite": "CBERS",
     }
 
@@ -445,7 +442,7 @@ def test_cbers_id_valid():
         "scene": "CBERS_4_PAN10M_20171121_057_094_L2",
         "reference_band": "4",
         "bands": ["2", "3", "4"],
-        "rgb": (3, 4, 2),
+        "rgb": ("3", "4", "2"),
         "satellite": "CBERS",
     }
 
@@ -465,7 +462,7 @@ def test_cbers_id_valid():
         "scene": "CBERS_4_PAN5M_20171121_057_094_L2",
         "reference_band": "1",
         "bands": ["1"],
-        "rgb": (1, 1, 1),
+        "rgb": ("1", "1", "1"),
         "satellite": "CBERS",
     }
 
@@ -664,6 +661,26 @@ def test_expression_landsat_rgb(landsat_tile):
     data.shape == (3, 512, 512)
     mask.shape == (512, 512)
     assert len(landsat_tile.call_args[1].get("bands")) == 3
+
+
+@patch("rio_tiler.cbers.tile")
+def test_expression_cbers_rgb(cbers_tile):
+    """Should read tile from CBERS data."""
+    cbers_tile.return_value = [
+        np.random.randint(0, 255, size=(3, 256, 256), dtype=np.uint8),
+        np.random.randint(0, 1, size=(256, 256), dtype=np.uint8) * 255,
+    ]
+
+    expr = "b8*0.8, b7*1.1, b6*0.8"
+    tile_z = 10
+    tile_x = 664
+    tile_y = 495
+
+    sceneid = "CBERS_4_MUX_20171121_057_094_L2"
+    data, mask = utils.expression(sceneid, tile_x, tile_y, tile_z, expr)
+    data.shape == (3, 512, 512)
+    mask.shape == (512, 512)
+    assert len(cbers_tile.call_args[1].get("bands")) == 3
 
 
 def test_expression_main_ratio():


### PR DESCRIPTION
closes #65 

This pr does: 
- Add band's names validations for Sentinel-2, CBERS-4 and Landsa-8
- Force ☝️ to be strings (we allowed integers before for CBERS and Landsat) ⚠️ **breacking change** 
- Add deprecation warning (will be removed in `1.0.0`) 

cc @fredliporace, This will impact you I think, I'll wait for your 👍 / 👎