### PR TITLE
Fix mask datatype bug in `rio_tiler.utils.array_to_image`

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+Next (TBD)
+----------
+- Fix mask datatype bug in `rio_tiler.utils.array_to_image`
+
+
 1.0.0 (2019-02-11)
 ------------------
 - add missing Landsat panchromatic band (08) min/max fetch in `rio_tiler.landsat8.metadata` (#58)

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -401,7 +401,7 @@ def array_to_image(
 
             # Use Mask as an alpha band
             if mask is not None and img_format != "jpeg":
-                dst.write(mask.astype(np.uint8), indexes=nbands)
+                dst.write(mask.astype(arr.dtype), indexes=nbands)
 
         return memfile.read()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -527,6 +527,13 @@ def test_array_to_image_valid_options():
     assert utils.array_to_image(arr, mask=mask, img_format="png", ZLEVEL=9)
 
 
+def test_array_to_image_geotiff16Bytes():
+    """Creates GeoTIFF image buffer from 3 bands array."""
+    arr = np.random.randint(0, 255, size=(3, 512, 512), dtype=np.uint16)
+    mask = np.zeros((512, 512), dtype=np.uint8) + 255
+    assert utils.array_to_image(arr, mask=mask, img_format="GTiff")
+
+
 def test_array_to_image_geotiff():
     """Creates GeoTIFF image buffer from 3 bands array."""
     arr = np.random.randint(0, 255, size=(3, 512, 512), dtype=np.uint8)


### PR DESCRIPTION
We don't need to force the mask to be in `np.uint8` if the data itself is in something else 