### PR TITLE
Make sure nodata and Indexes are passed from datasource if not defined

### DIFF
--- a/rio_tiler/main.py
+++ b/rio_tiler/main.py
@@ -90,9 +90,6 @@ def tile(address, tile_x, tile_y, tile_z, indexes=None, tilesize=256, nodata=Non
             *[src.crs, "epsg:4326"] + list(src.bounds), densify_pts=21
         )
 
-        indexes = indexes if indexes is not None else src.indexes
-        nodata = nodata if nodata is not None else src.nodata
-
         if not utils.tile_exists(wgs_bounds, tile_z, tile_x, tile_y):
             raise TileOutsideBounds(
                 "Tile {}/{}/{} is outside image bounds".format(tile_z, tile_x, tile_y)

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -198,7 +198,7 @@ def has_alpha_band(src):
     return False
 
 
-def tile_read(source, bounds, tilesize, indexes=[1], nodata=None):
+def tile_read(source, bounds, tilesize, indexes=None, nodata=None):
     """
     Read data and mask.
 
@@ -226,16 +226,18 @@ def tile_read(source, bounds, tilesize, indexes=[1], nodata=None):
 
     vrt_params = dict(add_alpha=True, crs="epsg:3857", resampling=Resampling.bilinear)
 
-    if nodata is not None:
-        vrt_params.update(dict(nodata=nodata, add_alpha=False, src_nodata=nodata))
-
-    out_shape = (len(indexes), tilesize, tilesize)
-
     if isinstance(source, DatasetReader):
         vrt_transform, vrt_width, vrt_height = get_vrt_transform(source, bounds)
         vrt_params.update(
             dict(transform=vrt_transform, width=vrt_width, height=vrt_height)
         )
+
+        indexes = indexes if indexes is not None else source.indexes
+        out_shape = (len(indexes), tilesize, tilesize)
+
+        nodata = nodata if nodata is not None else source.nodata
+        if nodata is not None:
+            vrt_params.update(dict(nodata=nodata, add_alpha=False, src_nodata=nodata))
 
         if has_alpha_band(source):
             vrt_params.update(dict(add_alpha=False))
@@ -252,6 +254,15 @@ def tile_read(source, bounds, tilesize, indexes=[1], nodata=None):
             vrt_params.update(
                 dict(transform=vrt_transform, width=vrt_width, height=vrt_height)
             )
+
+            indexes = indexes if indexes is not None else src.indexes
+            out_shape = (len(indexes), tilesize, tilesize)
+
+            nodata = nodata if nodata is not None else src.nodata
+            if nodata is not None:
+                vrt_params.update(
+                    dict(nodata=nodata, add_alpha=False, src_nodata=nodata)
+                )
 
             if has_alpha_band(src):
                 vrt_params.update(dict(add_alpha=False))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -191,6 +191,26 @@ def test_tile_read_dataset():
     assert src.closed
 
 
+def test_tile_read_dataset_nodata():
+    """
+    Should work as expected (read rgb)
+    """
+    # non-boundless tile covering the nodata part 22-876431-1603670
+    bounds = (
+        -104.77532386779785,
+        38.95360206813569,
+        -104.77523803710938,
+        38.95366881479647,
+    )
+    tilesize = 16
+
+    with rasterio.open(S3_NODATA_PATH) as src:
+        arr, mask = utils.tile_read(src, bounds, tilesize)
+    assert arr.shape == (3, 16, 16)
+    assert not mask.all()
+    assert src.closed
+
+
 def test_linear_rescale_valid():
     """
     Should work as expected (read data band)


### PR DESCRIPTION
This PR does: 
- Remove useless nodata/indexes check in `rio_tiler.main.tile`
- add nodata/indexes checks in `tile_read` function to make sure 

**Important** 
- Remove default `[1]` indexes options in `rio_tiler.utils.tile_read` 