### PR TITLE
add options forwarding to tile_read function

### DIFF
--- a/rio_tiler/main.py
+++ b/rio_tiler/main.py
@@ -58,7 +58,7 @@ def metadata(address, pmin=2, pmax=98, **kwargs):
     return info
 
 
-def tile(address, tile_x, tile_y, tile_z, indexes=None, tilesize=256, nodata=None):
+def tile(address, tile_x, tile_y, tile_z, tilesize=256, **kwargs):
     """
     Create mercator tile from any images.
 
@@ -72,12 +72,10 @@ def tile(address, tile_x, tile_y, tile_z, indexes=None, tilesize=256, nodata=Non
         Mercator tile Y index.
     tile_z : int
         Mercator tile ZOOM level.
-    indexes : tuple, int, optional (default: (1, 2, 3))
-        Bands indexes for the RGB combination.
     tilesize : int, optional (default: 256)
         Output image size.
-    nodata: int or float, optional
-        Overwrite nodata value for mask creation.
+    kwargs: dict, optional
+        These will be passed to the 'rio_tiler.utils._tile_read' function.
 
     Returns
     -------
@@ -97,6 +95,4 @@ def tile(address, tile_x, tile_y, tile_z, indexes=None, tilesize=256, nodata=Non
 
         mercator_tile = mercantile.Tile(x=tile_x, y=tile_y, z=tile_z)
         tile_bounds = mercantile.xy_bounds(mercator_tile)
-        return utils.tile_read(
-            src, tile_bounds, tilesize, indexes=indexes, nodata=nodata
-        )
+        return utils.tile_read(src, tile_bounds, tilesize, **kwargs)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -98,6 +98,16 @@ def test_tile_valid_bands():
     assert data.shape == (1, 256, 256)
 
 
+def test_tile_valid_resampling():
+    """Should return an array and a mask."""
+    tile_z = 21
+    tile_x = 438217
+    tile_y = 801835
+    data, mask = main.tile(ADDRESS, tile_x, tile_y, tile_z, resampling_method="nearest")
+    assert data.shape == (3, 256, 256)
+    assert mask.all()
+
+
 def test_tile_valid_internal_alpha():
     """Should return a 3 bands array and a partial valid mask."""
     # non-boundless tile covering the alpha masked part


### PR DESCRIPTION
ref #85 
This PR allows options forwarding to `tile_read` function (nodata, indexes, resampling_method)