### PR TITLE
Allow custom discrete colormap (ref: #91)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Next (TBD)
 Breacking Changes:
 
 - `expr` argument is now a required option in `rio_tiler.utils.expression`. (#88)
+- `rio_tiler.utils.get_colormap` returns a dictionary for "gdal" format (#91)
+- `rio_tiler.utils.array_to_image` 'color_map' option MUST be a dictionary (#91)
 
 1.1.4 (2019-03-11)
 ------------------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,11 +2,11 @@
 Next (TBD)
 ----------
 
+- `rio_tiler.utils.array_to_image`'s color_map arg can be a dictionary of discrete values (#91)
+
 Breacking Changes:
 
 - `expr` argument is now a required option in `rio_tiler.utils.expression`. (#88)
-- `rio_tiler.utils.get_colormap` returns a dictionary for "gdal" format (#91)
-- `rio_tiler.utils.array_to_image` 'color_map' option MUST be a dictionary (#91)
 
 1.1.4 (2019-03-11)
 ------------------

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -383,7 +383,12 @@ def array_to_image(
 
     if color_map is not None:
         # Apply colormap and transpose back to raster band-style
-        arr = np.transpose(color_map[arr][0], [2, 0, 1]).astype(np.uint8)
+        # arr = np.transpose(color_map[arr][0], [2, 0, 1]).astype(np.uint8)
+        res = np.zeros((arr.shape[1], arr.shape[2], 3), dtype=np.uint8)
+        for k, v in color_map.items():
+            res[arr[0] == k] = v
+        arr = np.transpose(res, [2, 0, 1])
+        del res
 
     # WEBP doesn't support 1band dataset so we must hack to create a RGB dataset
     if img_format == "webp" and arr.shape[0] == 1:
@@ -445,7 +450,8 @@ def get_colormap(name="cfastie", format="pil"):
     if format.lower() == "pil":
         return cmap
     elif format.lower() == "gdal":
-        return np.array(list(_chunks(cmap, 3)))
+        cmap = list(_chunks(cmap, 3))
+        return dict(enumerate(cmap))
     else:
         raise Exception("Unsupported {} colormap format".format(format))
 

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -345,6 +345,14 @@ def tile_exists(bounds, tile_z, tile_x, tile_y):
     )
 
 
+def _apply_colormap(arr, cmap):
+    """Apply discrete colormap."""
+    res = np.zeros((arr.shape[1], arr.shape[2], 3), dtype=np.uint8)
+    for k, v in cmap.items():
+        res[arr[0] == k] = v
+    return np.transpose(res, [2, 0, 1])
+
+
 def array_to_image(
     arr, mask=None, img_format="png", color_map=None, **creation_options
 ):
@@ -382,13 +390,7 @@ def array_to_image(
         arr = np.expand_dims(arr, axis=0)
 
     if color_map is not None:
-        # Apply colormap and transpose back to raster band-style
-        # arr = np.transpose(color_map[arr][0], [2, 0, 1]).astype(np.uint8)
-        res = np.zeros((arr.shape[1], arr.shape[2], 3), dtype=np.uint8)
-        for k, v in color_map.items():
-            res[arr[0] == k] = v
-        arr = np.transpose(res, [2, 0, 1])
-        del res
+        arr = _apply_colormap(arr, color_map)
 
     # WEBP doesn't support 1band dataset so we must hack to create a RGB dataset
     if img_format == "webp" and arr.shape[0] == 1:
@@ -450,8 +452,7 @@ def get_colormap(name="cfastie", format="pil"):
     if format.lower() == "pil":
         return cmap
     elif format.lower() == "gdal":
-        cmap = list(_chunks(cmap, 3))
-        return dict(enumerate(cmap))
+        return dict(enumerate(_chunks(cmap, 3)))
     else:
         raise Exception("Unsupported {} colormap format".format(format))
 

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -345,8 +345,27 @@ def tile_exists(bounds, tile_z, tile_x, tile_y):
     )
 
 
-def _apply_colormap(arr, cmap):
-    """Apply discrete colormap."""
+def _apply_discrete_colormap(arr, cmap):
+    """
+    Apply discrete colormap.
+
+    Attributes
+    ----------
+    arr : numpy.ndarray
+        1D image array to convert.
+    color_map: dict
+        Discrete ColorMap dictionary
+        e.g:
+        {
+            1: [255, 255, 255],
+            2: [255, 0, 0]
+        }
+
+    Returns
+    -------
+    arr: numpy.ndarray
+
+    """
     res = np.zeros((arr.shape[1], arr.shape[2], 3), dtype=np.uint8)
     for k, v in cmap.items():
         res[arr[0] == k] = v
@@ -374,8 +393,13 @@ def array_to_image(
     img_format: str, optional
         Image format to return (default: 'png').
         List of supported format by GDAL: https://www.gdal.org/formats_list.html
-    color_map: dict, optional
-        GDAL compatible ColorMap dictionary (see: rio_tiler.utils.get_colormap)
+    color_map: numpy.ndarray or dict, optional
+        color_map can be either a (256, 3) array or RGB triplet
+        (e.g. [[255, 255, 255],...]) mapping each 1D pixel value rescaled
+        from 0 to 255
+        OR
+        it can be a dictionary of discrete values
+        (e.g. { 1.3: [255, 255, 255], 2.5: [255, 0, 0]}) mapping any pixel value to a triplet
     creation_options: dict, optional
         Image driver creation options to pass to GDAL
 
@@ -389,8 +413,10 @@ def array_to_image(
     if len(arr.shape) < 3:
         arr = np.expand_dims(arr, axis=0)
 
-    if color_map is not None:
-        arr = _apply_colormap(arr, color_map)
+    if color_map is not None and isinstance(color_map, dict):
+        arr = _apply_discrete_colormap(arr, color_map)
+    elif color_map is not None:
+        arr = np.transpose(color_map[arr][0], [2, 0, 1]).astype(np.uint8)
 
     # WEBP doesn't support 1band dataset so we must hack to create a RGB dataset
     if img_format == "webp" and arr.shape[0] == 1:
@@ -452,7 +478,7 @@ def get_colormap(name="cfastie", format="pil"):
     if format.lower() == "pil":
         return cmap
     elif format.lower() == "gdal":
-        return dict(enumerate(_chunks(cmap, 3)))
+        return np.array(list(_chunks(cmap, 3)))
     else:
         raise Exception("Unsupported {} colormap format".format(format))
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -583,6 +583,24 @@ def test_array_to_image_valid_colormap():
     assert utils.array_to_image(arr, color_map=cmap)
 
 
+def test_array_to_image_valid_colormapDict():
+    """Create 'colormaped' PNG image buffer from one band array using discrete cmap."""
+    arr = np.random.randint(0, 255, size=(1, 512, 512), dtype=np.uint8)
+    cmap = {1: [255, 255, 255], 50: [255, 255, 0], 100: [255, 0, 0], 150: [0, 0, 255]}
+    assert utils.array_to_image(arr, color_map=cmap)
+
+
+def test_apply_discrete_colormap_valid():
+    """Apply discrete colormap to array."""
+    arr = np.random.randint(0, 255, size=(1, 512, 512), dtype=np.uint8)
+    arr[0, 0, 0] = 1
+    arr[0, 1, 1] = 100
+    cmap = {1: [255, 255, 255], 50: [255, 255, 0], 100: [255, 0, 0], 150: [0, 0, 255]}
+    res = utils._apply_discrete_colormap(arr, cmap)
+    assert res[:, 0, 0].tolist() == [255, 255, 255]
+    assert res[:, 1, 1].tolist() == [255, 0, 0]
+
+
 def test_array_to_image_valid_mask():
     """Creates image buffer from 3 bands array and mask."""
     arr = np.random.randint(0, 255, size=(3, 512, 512), dtype=np.uint8)


### PR DESCRIPTION
ref #91 

This is a first sketch of dictionary support for color maps

# TO DO 
- [x] benchmark 
- [x] update tests 
- [ ] coms 

This is a breaking change, I'm kinda hesitant to make a 2.0 release for this change but more inclined  to make a 1.2.0 release if we go forward with this.


Note: This change will enable custom discrete colormap like: 
```

        colormap = {
            322: [209, 46, 198],
            324: [51, 149, 229],
            328: [116, 193, 214],
            336: [132, 240, 110],
            352: [178, 204, 31],
            368: [29, 88, 215],
            386: [31, 211, 43],
            388: [119, 214, 192],
            392: [104, 226, 28],
            400: [228, 57, 100],
            416: [23, 40, 230],
            432: [237, 66, 14],
            480: [198, 89, 219],
            834: [201, 24, 148],
            836: [121, 210, 169],
            840: [230, 217, 73],
            848: [144, 106, 210],
            864: [212, 47, 127],
            880: [170, 119, 203],
            898: [204, 172, 103],
            900: [54, 28, 204],
            904: [210, 63, 63],
            912: [218, 147, 84],
            928: [55, 208, 208],
            944: [196, 239, 126],
            992: [101, 205, 132]
        }
```

cc @DanSchoppe 