### PR TITLE
make expr a required options

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,11 @@
 
+Next (TBD)
+----------
+
+Breacking Changes:
+
+- `expr` argument is now a required option in `rio_tiler.utils.expression`. (#88)
+
 1.1.4 (2019-03-11)
 ------------------
 - Add 'rplumbo' colormap (#90 by @DanSchoppe)

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -472,7 +472,7 @@ def mapzen_elevation_rgb(arr):
     return np.stack([r, g, b]).astype(np.uint8)
 
 
-def expression(sceneid, tile_x, tile_y, tile_z, expr, **kwargs):
+def expression(sceneid, tile_x, tile_y, tile_z, expr=None, **kwargs):
     """
     Apply expression on data.
 
@@ -487,7 +487,7 @@ def expression(sceneid, tile_x, tile_y, tile_z, expr, **kwargs):
         Mercator tile Y index.
     tile_z : int
         Mercator tile ZOOM level.
-    expr : str
+    expr : str, required
         Expression to apply (e.g '(B5+B4)/(B5-B4)')
         Band name should start with 'B'.
 
@@ -497,6 +497,9 @@ def expression(sceneid, tile_x, tile_y, tile_z, expr, **kwargs):
         Returns processed pixel value.
 
     """
+    if not expr:
+        raise Exception("Missing expression")
+
     bands_names = tuple(set(re.findall(r"b(?P<bands>[0-9A]{1,2})", expr)))
     rgb = expr.split(",")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -394,10 +394,7 @@ def test_expression_cbers_rgb(cbers_tile):
 
 
 def test_expression_main_ratio():
-    """
-    Should work as expected
-    """
-
+    """Should work as expected."""
     expr = "(b3 - b2) / (b3 + b2)"
     tile_z = 19
     tile_x = 109554
@@ -408,6 +405,10 @@ def test_expression_main_ratio():
         prefix
     )
     data, mask = utils.expression(sceneid, tile_x, tile_y, tile_z, expr)
+    data.shape == (1, 256, 256)
+    mask.shape == (256, 256)
+
+    data, mask = utils.expression(sceneid, tile_x, tile_y, tile_z, expr=expr)
     data.shape == (1, 256, 256)
     mask.shape == (256, 256)
 
@@ -448,6 +449,19 @@ def test_expression_main_kwargs():
     data, mask = utils.expression(sceneid, tile_x, tile_y, tile_z, expr, tilesize=512)
     data.shape == (1, 512, 512)
     mask.shape == (512, 512)
+
+
+def test_expression_missing():
+    """Should raise an exception on missing expression"""
+    tile_z = 19
+    tile_x = 109554
+    tile_y = 200458
+    prefix = os.path.join(os.path.dirname(__file__), "fixtures")
+    sceneid = "{}/my-bucket/hro_sources/colorado/201404_13SED190110_201404_0x1500m_CL_1.tif".format(
+        prefix
+    )
+    with pytest.raises(Exception):
+        utils.expression(sceneid, tile_x, tile_y, tile_z, tilesize=512)
 
 
 def test_get_vrt_transform_valid():


### PR DESCRIPTION
closes #88 
This is in fact not really a breaking change because `expr` was the last argument of the function so actual code should still work. 