### PR TITLE
Kwargs

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,11 @@
+
+NEXT (TBD)
+----------
+
+- Add kwargs options in landsat8.tile, sentinel2.tile and cbers.tile functions to 
+allow `resampling_method` and `tile_edge_padding` options forwarding to utils._tile_read.
+
+
 1.2.7 (2019-05-14)
 ------------------
 

--- a/rio_tiler/cbers.py
+++ b/rio_tiler/cbers.py
@@ -195,7 +195,7 @@ def metadata(sceneid, pmin=2, pmax=98, **kwargs):
     return info
 
 
-def tile(sceneid, tile_x, tile_y, tile_z, bands=None, tilesize=256):
+def tile(sceneid, tile_x, tile_y, tile_z, bands=None, tilesize=256, **kwargs):
     """
     Create mercator tile from CBERS data.
 
@@ -214,6 +214,8 @@ def tile(sceneid, tile_x, tile_y, tile_z, bands=None, tilesize=256):
         defined for the instrument
     tilesize : int, optional (default: 256)
         Output image size.
+    kwargs: dict, optional
+        These will be passed to the 'rio_tiler.utils._tile_read' function.
 
     Returns
     -------
@@ -260,7 +262,9 @@ def tile(sceneid, tile_x, tile_y, tile_z, bands=None, tilesize=256):
         "{}/{}_BAND{}.tif".format(cbers_address, sceneid, band) for band in bands
     ]
 
-    _tiler = partial(utils.tile_read, bounds=tile_bounds, tilesize=tilesize, nodata=0)
+    _tiler = partial(
+        utils.tile_read, bounds=tile_bounds, tilesize=tilesize, nodata=0, **kwargs
+    )
     with futures.ThreadPoolExecutor(max_workers=MAX_THREADS) as executor:
         data, masks = zip(*list(executor.map(_tiler, addresses)))
         mask = np.all(masks, axis=0).astype(np.uint8) * 255

--- a/rio_tiler/landsat8.py
+++ b/rio_tiler/landsat8.py
@@ -328,7 +328,7 @@ def metadata(sceneid, pmin=2, pmax=98, **kwargs):
         metadata=meta_data,
         overview_level=1,
         percentiles=(pmin, pmax),
-        **kwargs,
+        **kwargs
     )
 
     with futures.ThreadPoolExecutor(max_workers=MAX_THREADS) as executor:
@@ -354,7 +354,7 @@ def tile(
     bands=("4", "3", "2"),
     tilesize=256,
     pan=False,
-    **kwargs,
+    **kwargs
 ):
     """
     Create mercator tile from Landsat-8 data.

--- a/rio_tiler/landsat8.py
+++ b/rio_tiler/landsat8.py
@@ -328,7 +328,7 @@ def metadata(sceneid, pmin=2, pmax=98, **kwargs):
         metadata=meta_data,
         overview_level=1,
         percentiles=(pmin, pmax),
-        **kwargs
+        **kwargs,
     )
 
     with futures.ThreadPoolExecutor(max_workers=MAX_THREADS) as executor:
@@ -347,7 +347,14 @@ def metadata(sceneid, pmin=2, pmax=98, **kwargs):
 
 
 def tile(
-    sceneid, tile_x, tile_y, tile_z, bands=("4", "3", "2"), tilesize=256, pan=False
+    sceneid,
+    tile_x,
+    tile_y,
+    tile_z,
+    bands=("4", "3", "2"),
+    tilesize=256,
+    pan=False,
+    **kwargs,
 ):
     """
     Create mercator tile from Landsat-8 data.
@@ -369,6 +376,8 @@ def tile(
         Output image size.
     pan : boolean, optional (default: False)
         If True, apply pan-sharpening.
+    kwargs: dict, optional
+        These will be passed to the 'rio_tiler.utils._tile_read' function.
 
     Returns
     -------
@@ -399,7 +408,9 @@ def tile(
 
     addresses = ["{}_B{}.TIF".format(landsat_address, band) for band in bands]
 
-    _tiler = partial(utils.tile_read, bounds=tile_bounds, tilesize=tilesize, nodata=0)
+    _tiler = partial(
+        utils.tile_read, bounds=tile_bounds, tilesize=tilesize, nodata=0, **kwargs
+    )
     with futures.ThreadPoolExecutor(max_workers=MAX_THREADS) as executor:
         data, masks = zip(*list(executor.map(_tiler, addresses)))
         data = np.concatenate(data)

--- a/rio_tiler/sentinel2.py
+++ b/rio_tiler/sentinel2.py
@@ -206,7 +206,9 @@ def metadata(sceneid, pmin=2, pmax=98, **kwargs):
     return info
 
 
-def tile(sceneid, tile_x, tile_y, tile_z, bands=("04", "03", "02"), tilesize=256):
+def tile(
+    sceneid, tile_x, tile_y, tile_z, bands=("04", "03", "02"), tilesize=256, **kwargs
+):
     """
     Create mercator tile from Sentinel-2 data.
 
@@ -224,6 +226,8 @@ def tile(sceneid, tile_x, tile_y, tile_z, bands=("04", "03", "02"), tilesize=256
         Bands index for the RGB combination.
     tilesize : int, optional (default: 256)
         Output image size.
+    kwargs: dict, optional
+        These will be passed to the 'rio_tiler.utils._tile_read' function.
 
     Returns
     -------
@@ -257,7 +261,9 @@ def tile(sceneid, tile_x, tile_y, tile_z, bands=("04", "03", "02"), tilesize=256
 
     addresses = ["{}/B{}.jp2".format(sentinel_address, band) for band in bands]
 
-    _tiler = partial(utils.tile_read, bounds=tile_bounds, tilesize=tilesize, nodata=0)
+    _tiler = partial(
+        utils.tile_read, bounds=tile_bounds, tilesize=tilesize, nodata=0, **kwargs
+    )
     with futures.ThreadPoolExecutor(max_workers=MAX_THREADS) as executor:
         data, masks = zip(*list(executor.map(_tiler, addresses)))
         mask = np.all(masks, axis=0).astype(np.uint8) * 255


### PR DESCRIPTION
Enable `resampling_method` and `tile_edge_padding` options forwarding to utils._tile_read from aws pds functions.