### PR TITLE
use same overview size calculation as in GDAL

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,8 @@
 
 NEXT (TBD)
 ----------
-- reduce memory footprint of expression tiler (#18d4acc)
+- reduce memory footprint of expression tiler
+- fix wrong calculation for overview size in `raster_get_stats` (#116)
 
 1.2.10 (2019-07-18)
 -------------------

--- a/tests/test_cbers.py
+++ b/tests/test_cbers.py
@@ -64,14 +64,14 @@ def test_metadata_valid_default(monkeypatch):
     assert meta["sceneid"] == CBERS_MUX_SCENE
     assert len(meta["bounds"]["value"]) == 4
     assert len(meta["statistics"].items()) == 4
-    assert meta["statistics"]["5"]["pc"] == [28, 93]
+    assert meta["statistics"]["5"]["pc"] == [28, 91]
 
     meta = cbers.metadata(CBERS_MUX_SCENE, histogram_bins=20)
     assert meta["sceneid"] == CBERS_MUX_SCENE
     assert len(meta["bounds"]["value"]) == 4
     assert len(meta["statistics"].items()) == 4
     assert len(meta["statistics"]["5"]["histogram"][0]) == 20
-    assert meta["statistics"]["5"]["pc"] == [28, 93]
+    assert meta["statistics"]["5"]["pc"] == [28, 91]
 
     meta = cbers.metadata(CBERS_AWFI_SCENE)
     assert meta["sceneid"] == CBERS_AWFI_SCENE
@@ -100,7 +100,7 @@ def test_metadata_valid_custom(monkeypatch):
     meta = cbers.metadata(CBERS_MUX_SCENE, pmin=5, pmax=95)
     assert meta.get("sceneid") == CBERS_MUX_SCENE
     assert len(meta["bounds"]["value"]) == 4
-    assert meta["statistics"]["5"]["pc"] == [29, 59]
+    assert meta["statistics"]["5"]["pc"] == [29, 60]
 
 
 def test_tile_valid_default(monkeypatch):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -43,7 +43,7 @@ def test_metadata_valid():
     assert len(meta["band_descriptions"]) == 3
     assert (1, "band1") == meta["band_descriptions"][0]
     assert len(meta["statistics"].items()) == 3
-    assert meta["statistics"][1]["pc"] == [12, 198]
+    assert meta["statistics"][1]["pc"] == [11, 199]
 
 
 def test_metadata_valid_custom():
@@ -56,7 +56,7 @@ def test_metadata_valid_custom():
     assert len(meta["bounds"]["value"]) == 4
     assert len(meta["statistics"].items()) == 3
     assert len(meta["statistics"][1]["histogram"][0]) == 20
-    assert meta["statistics"][1]["pc"] == [30, 191]
+    assert meta["statistics"][1]["pc"] == [28, 192]
 
 
 def test_tile_valid_default():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -681,8 +681,8 @@ def test_raster_get_stats_valid():
     assert stats["bounds"]
     assert stats["bounds"]["crs"] == CRS({"init": "EPSG:4326"})
     assert len(stats["statistics"]) == 3
-    assert stats["statistics"][1]["pc"] == [12, 198]
-    assert stats["statistics"][2]["pc"] == [27, 201]
+    assert stats["statistics"][1]["pc"] == [11, 199]
+    assert stats["statistics"][2]["pc"] == [26, 201]
     assert stats["statistics"][3]["pc"] == [54, 192]
     assert stats["minzoom"]
     assert stats["maxzoom"]
@@ -709,9 +709,9 @@ def test_raster_get_stats_validAlpha():
     with pytest.warns(NoOverviewWarning):
         stats = utils.raster_get_stats(S3_ALPHA_PATH)
     assert len(stats["statistics"]) == 3
-    assert stats["statistics"][1]["pc"] == [12, 199]
-    assert stats["statistics"][2]["pc"] == [29, 201]
-    assert stats["statistics"][3]["pc"] == [56, 193]
+    assert stats["statistics"][1]["pc"] == [10, 200]
+    assert stats["statistics"][2]["pc"] == [27, 202]
+    assert stats["statistics"][3]["pc"] == [55, 193]
 
 
 def test_raster_get_stats_validNodata():
@@ -720,16 +720,16 @@ def test_raster_get_stats_validNodata():
         stats = utils.raster_get_stats(S3_NODATA_PATH)
     assert stats["bounds"]
     assert len(stats["statistics"]) == 3
-    assert stats["statistics"][1]["pc"] == [12, 198]
-    assert stats["statistics"][2]["pc"] == [28, 201]
+    assert stats["statistics"][1]["pc"] == [13, 199]
+    assert stats["statistics"][2]["pc"] == [27, 202]
     assert stats["statistics"][3]["pc"] == [56, 192]
 
     with pytest.warns(NoOverviewWarning):
         stats = utils.raster_get_stats(S3_NODATA_PATH, nodata=0)
     assert stats["bounds"]
     assert len(stats["statistics"]) == 3
-    assert stats["statistics"][1]["pc"] == [12, 198]
-    assert stats["statistics"][2]["pc"] == [28, 201]
+    assert stats["statistics"][1]["pc"] == [13, 199]
+    assert stats["statistics"][2]["pc"] == [27, 202]
     assert stats["statistics"][3]["pc"] == [56, 192]
 
 


### PR DESCRIPTION
closes #116 

This PR do: 
- use `_div_round_up` to make use we use the same overview size as in GDAL
- add `resampling_method` in `raster_get_stats`
