### PR TITLE
Tile cover

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,6 @@
 
-NEXT (TBD)
-----------
+1.2.11 (2019-09-18)
+-------------------
 - reduce memory footprint of expression tiler
 - fix wrong calculation for overview size in `raster_get_stats` (#116)
 - Add Landsat 8 QA Band (#117).

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,8 @@
 
+NEXT (TBD)
+----------
+- add `minimum_tile_cover` option to filter dataset not covering a certain amount of the tile.
+
 1.2.11 (2019-09-18)
 -------------------
 - reduce memory footprint of expression tiler

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -22,7 +22,7 @@ from rasterio.warp import calculate_default_transform, transform_bounds
 
 from rio_tiler.mercator import get_zooms
 
-from rio_tiler.errors import NoOverviewWarning, DeprecationWarning
+from rio_tiler.errors import NoOverviewWarning, DeprecationWarning, TileOutsideBounds
 from affine import Affine
 
 logger = logging.getLogger(__name__)
@@ -304,6 +304,7 @@ def _tile_read(
     tile_edge_padding=2,
     dst_crs=CRS({"init": "EPSG:3857"}),
     bounds_crs=None,
+    minimum_tile_cover=None,
 ):
     """
     Read data and mask.
@@ -329,11 +330,14 @@ def _tile_read(
         Target coordinate reference system (default "epsg:3857").
     bounds_crs: CRS or str, optional
         Overwrite bounds coordinate reference system (default None, equal to dst_crs).
+    minimum_tile_cover: float, optional (default: None)
+        Minimum % overlap for which to raise an error with dataset not
+        covering enought of the tile.
 
     Returns
     -------
-    out : array, int
-        returns pixel value.
+    data : numpy ndarray
+    mask: numpy array
 
     """
     if isinstance(indexes, int):
@@ -344,7 +348,8 @@ def _tile_read(
     if not bounds_crs:
         bounds_crs = dst_crs
 
-    bounds = transform_bounds(*[bounds_crs, dst_crs] + list(bounds), densify_pts=21)
+    bounds = transform_bounds(bounds_crs, dst_crs, *bounds, densify_pts=21)
+    src_bounds = transform_bounds(src_dst.crs, dst_crs, *src_dst.bounds, densify_pts=21)
 
     vrt_params = dict(
         add_alpha=True, crs=dst_crs, resampling=Resampling[resampling_method]
@@ -357,6 +362,16 @@ def _tile_read(
     out_window = windows.Window(
         col_off=0, row_off=0, width=vrt_width, height=vrt_height
     )
+
+    x_overlap = max(0, min(src_bounds[2], bounds[2]) - max(src_bounds[0], bounds[0]))
+    y_overlap = max(0, min(src_bounds[3], bounds[3]) - max(src_bounds[1], bounds[1]))
+    cover_ratio = (x_overlap * y_overlap) / (
+        (bounds[2] - bounds[0]) * (bounds[3] - bounds[1])
+    )
+    if minimum_tile_cover and cover_ratio < minimum_tile_cover:
+        raise TileOutsideBounds(
+            "Dataset covers less than {:.0f}% of tile".format(cover_ratio * 100)
+        )
 
     if tile_edge_padding > 0 and not _requested_tile_aligned_with_internal_tile(
         src_dst, bounds, tilesize

--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,8 @@ extra_reqs = {
 
 setup(
     name="rio-tiler",
-    version="1.2.10",
-    description=u"""Get mercator tile from landsat,
-          sentinel or other AWS hosted raster""",
+    version="1.2.11",
+    description=u"""Get mercator tile from CloudOptimized GeoTIFF and other cloud hosted raster such as CBERS-4, Sentinel-2 and Landsat-8 AWS PDS""",
     long_description=readme,
     long_description_content_type="text/markdown",
     classifiers=[
@@ -28,7 +27,7 @@ setup(
         "Programming Language :: Python :: 2.7",
         "Topic :: Scientific/Engineering :: GIS",
     ],
-    keywords="raster aws tiler gdal rasterio",
+    keywords="COG cogeo raster aws map tiler gdal rasterio",
     author=u"Vincent Sarago",
     author_email="vincent@developmentseed.org",
     url="https://github.com/cogeotiff/rio-tiler",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,7 +15,7 @@ from rasterio.crs import CRS
 from rasterio.enums import Resampling
 
 from rio_tiler import utils
-from rio_tiler.errors import NoOverviewWarning, DeprecationWarning
+from rio_tiler.errors import NoOverviewWarning, DeprecationWarning, TileOutsideBounds
 
 from .conftest import requires_webp
 
@@ -377,6 +377,21 @@ def test_tile_read_dataset_nodata():
     assert arr.shape == (3, 16, 16)
     assert not mask.all()
     assert src.closed
+
+
+def test_tile_read_not_covering_the_whole_tile():
+    """Should raise an error when dataset doesn't cover more than 50% of the tile."""
+    address = "{}_B2.TIF".format(LANDSAT_PATH)
+
+    bounds = (
+        -9079495.967826376,
+        3991847.365165044,
+        -9001224.450862356,
+        4070118.882129065,
+    )
+    tilesize = 16
+    with pytest.raises(TileOutsideBounds):
+        utils.tile_read(address, bounds, tilesize, minimum_tile_cover=0.6)
 
 
 def test_linear_rescale_valid():


### PR DESCRIPTION
This PR adds `minimum_tile_cover` to `rio_tiler.utils._tile_read` to raise errors when the dataset doesn't cover a certain amount of the tile requested. 

By default `minimum_tile_cover` is set to `None`. This option is linked to some work on rio-tiler-mosaic. 