### PR TITLE
Fixed PNG bands count

### DIFF
--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -620,7 +620,7 @@ def array_to_image(
     if img_format == "webp" and arr.shape[0] == 1:
         arr = np.repeat(arr, 3, axis=0)
 
-    if mask is not None and img_format != "jpeg":
+    if mask is not None and not img_format in ["jpeg", "png"]:
         nbands = arr.shape[0] + 1
     else:
         nbands = arr.shape[0]
@@ -639,7 +639,7 @@ def array_to_image(
             dst.write(arr, indexes=list(range(1, arr.shape[0] + 1)))
 
             # Use Mask as an alpha band
-            if mask is not None and img_format != "jpeg":
+            if mask is not None and not img_format in ["jpeg", "png"]:
                 dst.write(mask.astype(arr.dtype), indexes=nbands)
 
         return memfile.read()

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -620,10 +620,14 @@ def array_to_image(
     if img_format == "webp" and arr.shape[0] == 1:
         arr = np.repeat(arr, 3, axis=0)
 
-    if mask is not None and not img_format in ["jpeg", "png"]:
+    if mask is not None and img_format != "jpeg":
         nbands = arr.shape[0] + 1
     else:
         nbands = arr.shape[0]
+
+    # PNG can have at most 4 bands
+    if img_format == "png" and nbands > 4:
+        nbands = 4
 
     output_profile = dict(
         driver=img_format,
@@ -639,7 +643,7 @@ def array_to_image(
             dst.write(arr, indexes=list(range(1, arr.shape[0] + 1)))
 
             # Use Mask as an alpha band
-            if mask is not None and not img_format in ["jpeg", "png"]:
+            if mask is not None and img_format != "jpeg":
                 dst.write(mask.astype(arr.dtype), indexes=nbands)
 
         return memfile.read()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -827,6 +827,11 @@ def test_array_to_image_valid_mask():
     assert utils.array_to_image(arr, mask=mask)
     assert utils.array_to_image(arr, mask=mask, img_format="jpeg")
 
+def test_array_to_image_valid_mask_png():
+    """Creates PNG image buffer from 4 bands array and mask."""
+    arr = np.random.randint(0, 255, size=(4, 512, 512), dtype=np.uint8)
+    mask = np.zeros((512, 512), dtype=np.uint8)
+    assert utils.array_to_image(arr, mask=mask, img_format="png")
 
 def test_array_to_image_valid_options():
     """Creates image buffer with driver options."""


### PR DESCRIPTION
Hello :hand:

This PR fixes an issue I've encountered while implementing a Django tiler using rio-tiler. When serving PNG tiles with alpha, the band count is wrongly set to `5`?

The following changes allow the tiles to load properly.