### PR TITLE
add non_alpha_indexes utility function

### DIFF
--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -320,6 +320,20 @@ def has_alpha_band(src_dst):
     return False
 
 
+def non_alpha_indexes(src_dst):
+    """Return indexes of non-alpha bands."""
+    return tuple(
+        (
+            b
+            for ix, b in enumerate(src_dst.indexes)
+            if (
+                src_dst.mask_flag_enums[ix] is not MaskFlags.alpha
+                and src_dst.colorinterp[ix] is not ColorInterp.alpha
+            )
+        )
+    )
+
+
 def _tile_read(
     src_dst,
     bounds,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -950,3 +950,12 @@ def test_tile_read_vrt_option():
     )
     assert arr.shape == (1, 16, 16)
     assert mask.shape == (16, 16)
+
+
+def test_find_non_alpha():
+    """Return valid indexes."""
+    with rasterio.open(S3_ALPHA_PATH) as src_dst:
+        assert utils.non_alpha_indexes(src_dst) == (1, 2, 3)
+
+    with rasterio.open(PIX4D_PATH) as src_dst:
+        assert utils.non_alpha_indexes(src_dst) == (1, 2, 3)


### PR DESCRIPTION
Ref: #127 

This PR adds a utility function to find non-alpha band indexes.