### PR TITLE
force overview dataset for WarpedVRT

### DIFF
--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -355,6 +355,7 @@ def get_overview_level(
                 break
             if abs(ovrRes - target_res) < 1e-1:
                 break
+
     return ovr_idx
 
 
@@ -458,6 +459,11 @@ def _tile_read(
             )
 
     overview_level = get_overview_level(src_dst, bounds, tilesize)
+    if overview_level >= 0:
+        logger.debug(
+            "Selecting overview level {} for {}".format(overview_level, src_dst.name)
+        )
+
     options = {"overview_level": overview_level} if overview_level >= 0 else {}
     with rasterio.open(src_dst.name, **options) as ovr_dst:
         w, s, e, n = bounds

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -344,10 +344,12 @@ def get_overview_level(
     w, s, e, n = bounds
     vrt_transform = transform.from_bounds(w, s, e, n, tilesize, tilesize)
     target_res = vrt_transform.a
+    print(target_res)
 
     ovr_idx = -1
     if target_res > src_res:
         res = [src_res * decim for decim in src_dst.overviews(1)]
+        print(res)
         for ovr_idx in range(ovr_idx, len(res) - 1):
             ovrRes = src_res if ovr_idx < 0 else res[ovr_idx]
             nextRes = res[ovr_idx + 1]
@@ -355,6 +357,8 @@ def get_overview_level(
                 break
             if abs(ovrRes - target_res) < 1e-1:
                 break
+        else:
+            ovr_idx = len(res) - 1
 
     return ovr_idx
 

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -344,12 +344,11 @@ def get_overview_level(
     w, s, e, n = bounds
     vrt_transform = transform.from_bounds(w, s, e, n, tilesize, tilesize)
     target_res = vrt_transform.a
-    print(target_res)
 
     ovr_idx = -1
     if target_res > src_res:
         res = [src_res * decim for decim in src_dst.overviews(1)]
-        print(res)
+
         for ovr_idx in range(ovr_idx, len(res) - 1):
             ovrRes = src_res if ovr_idx < 0 else res[ovr_idx]
             nextRes = res[ovr_idx + 1]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -959,3 +959,18 @@ def test_find_non_alpha():
 
     with rasterio.open(PIX4D_PATH) as src_dst:
         assert utils.non_alpha_indexes(src_dst) == (1, 2, 3)
+
+
+def test_get_overview_level():
+    """Test overview level calculation."""
+    bounds = (
+        -11663507.036777973,
+        4715018.0897710975,
+        -11663487.927520901,
+        4715037.199028169,
+    )
+    with rasterio.open(S3_PATH) as src_dst:
+        assert utils.get_overview_level(src_dst, bounds, tilesize=8) == 2
+        assert utils.get_overview_level(src_dst, bounds, tilesize=16) == 1
+        assert utils.get_overview_level(src_dst, bounds, tilesize=32) == 0
+        assert utils.get_overview_level(src_dst, bounds, tilesize=64) == -1


### PR DESCRIPTION
**This is a major change**

While working on #95 and https://github.com/RemotePixel/amazonlinux/issues/10 I realized that maybe we were using WarpedVRT in an `unoptimized` way, when **(comparing warped kernel + GET requests)**

This goes back to https://github.com/mapbox/rasterio/issues/1373 and precisely https://github.com/mapbox/rasterio/issues/1373#issuecomment-398487266 

When looking at the `gdalwarp` command I realized the gdal use **specific overview level** to create the output dataset. This PR tries to implement such logic.

The first tests show that GET requests and output results are similar to gdalwarp outputs.

~@sgillies I'll need your help on this one (and I believe this will also fix the performance downgrade I saw in https://github.com/RemotePixel/amazonlinux/issues/10).~ (Edit the performance downgrade was due to SQLITE3 and centos) 
I'm not sure if this could also go directly to rasterio code base. (I know you have ton of stuff on your side so no stress, I'll continue to run some tests on my side).

tagging @dionhaefner @mojodna because it might be of your interest.
