### PR TITLE
[Bug] Remove band duplicates while preserving order

### DIFF
--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -748,7 +748,7 @@ def expression(sceneid, tile_x, tile_y, tile_z, expr=None, **kwargs):
     if not expr:
         raise Exception("Missing expression")
 
-    bands_names = remove_duplicates(re.findall(r"b(?P<bands>[0-9A]{1,2})", expr))
+    bands_names = tuple(sorted(set(re.findall(r"b(?P<bands>[0-9A]{1,2})", expr))))
     rgb = expr.split(",")
 
     if sceneid.startswith("L"):
@@ -803,12 +803,3 @@ def pansharpening_brovey(rgb, pan, weight, pan_dtype):
         ratio = _calculateRatio(rgb, pan, weight)
         return np.clip(ratio * rgb, 0, np.iinfo(pan_dtype).max).astype(pan_dtype)
 
-
-def remove_duplicates(seq):
-    """
-    Remove duplicates from a sequence while preserving order.
-    Adapted from https://stackoverflow.com/a/480227
-    """
-    seen = set()
-    seen_add = seen.add
-    return tuple([x for x in seq if not (x in seen or seen_add(x))])

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -748,7 +748,7 @@ def expression(sceneid, tile_x, tile_y, tile_z, expr=None, **kwargs):
     if not expr:
         raise Exception("Missing expression")
 
-    bands_names = tuple(set(re.findall(r"b(?P<bands>[0-9A]{1,2})", expr)))
+    bands_names = remove_duplicates(re.findall(r"b(?P<bands>[0-9A]{1,2})", expr))
     rgb = expr.split(",")
 
     if sceneid.startswith("L"):
@@ -802,3 +802,13 @@ def pansharpening_brovey(rgb, pan, weight, pan_dtype):
     with np.errstate(invalid="ignore", divide="ignore"):
         ratio = _calculateRatio(rgb, pan, weight)
         return np.clip(ratio * rgb, 0, np.iinfo(pan_dtype).max).astype(pan_dtype)
+
+
+def remove_duplicates(seq):
+    """
+    Remove duplicates from a sequence while preserving order.
+    Adapted from https://stackoverflow.com/a/480227
+    """
+    seen = set()
+    seen_add = seen.add
+    return tuple([x for x in seq if not (x in seen or seen_add(x))])


### PR DESCRIPTION
Found this while troubleshooting a related problem. The `tuple(set(x))` expression is used to avoid duplicate band names, however, since the order of the bands is important in the subsequent `zip` call around https://github.com/cogeotiff/rio-tiler/blob/master/rio_tiler/utils.py#L779 this can cause impredictable behavior, since the ordering of `tuple(set(x))` is not guaranteed:

```python
a = ['c', 'a', 'b']
print("tuple(set(a)): %s" % str(tuple(set(a))))
print("tuple(sorted(set(a))): %s" % str(tuple(sorted(set(a)))))
```

```bash
# python --version
Python 3.6.9

# python tmp/test.py 
tuple(set(a)): ('a', 'b', 'c')
tuple(sorted(set(a))): ('a', 'b', 'c')

# python tmp/test.py 
tuple(set(a)): ('b', 'a', 'c')
tuple(sorted(set(a))): ('a', 'b', 'c')
```

This PR addresses this problem.