### PR TITLE
update expr band syntax docstring

### DIFF
--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -736,8 +736,8 @@ def expression(sceneid, tile_x, tile_y, tile_z, expr=None, **kwargs):
     tile_z : int
         Mercator tile ZOOM level.
     expr : str, required
-        Expression to apply (e.g '(B5+B4)/(B5-B4)')
-        Band name should start with 'B'.
+        Expression to apply (e.g '(b5+b4)/(b5-b4)')
+        Band name should start with 'b'.
 
     Returns
     -------


### PR DESCRIPTION
Expression only works with bands denoted 'b', not 'B'. Could support both cases, but this is easiest.

Issue: https://github.com/cogeotiff/rio-tiler/issues/146