### PR TITLE
re-order part function to remove useless transform_bounds

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+2.0a3 (TBD)
+------------------
+- only use `transform_bounds` when needed in rio_tiler.reader.part
+
+
 2.0a2 (2020-03-20)
 ------------------
 - Fall back to gdal/rasterio calculate_default_transform for dateline separation crossing dataset (ref #164)

--- a/rio_tiler/reader.py
+++ b/rio_tiler/reader.py
@@ -183,16 +183,24 @@ def part(
 
     bounds = transform_bounds(bounds_crs, dst_crs, *bounds, densify_pts=21)
 
-    src_bounds = transform_bounds(src_dst.crs, dst_crs, *src_dst.bounds, densify_pts=21)
-    x_overlap = max(0, min(src_bounds[2], bounds[2]) - max(src_bounds[0], bounds[0]))
-    y_overlap = max(0, min(src_bounds[3], bounds[3]) - max(src_bounds[1], bounds[1]))
-    cover_ratio = (x_overlap * y_overlap) / (
-        (bounds[2] - bounds[0]) * (bounds[3] - bounds[1])
-    )
-    if minimum_overlap and cover_ratio < minimum_overlap:
-        raise TileOutsideBounds(
-            "Dataset covers less than {:.0f}% of tile".format(cover_ratio * 100)
+    if minimum_overlap:
+        src_bounds = transform_bounds(
+            src_dst.crs, dst_crs, *src_dst.bounds, densify_pts=21
         )
+        x_overlap = max(
+            0, min(src_bounds[2], bounds[2]) - max(src_bounds[0], bounds[0])
+        )
+        y_overlap = max(
+            0, min(src_bounds[3], bounds[3]) - max(src_bounds[1], bounds[1])
+        )
+        cover_ratio = (x_overlap * y_overlap) / (
+            (bounds[2] - bounds[0]) * (bounds[3] - bounds[1])
+        )
+
+        if cover_ratio < minimum_overlap:
+            raise TileOutsideBounds(
+                "Dataset covers less than {:.0f}% of tile".format(cover_ratio * 100)
+            )
 
     vrt_transform, vrt_width, vrt_height = get_vrt_transform(
         src_dst, bounds, dst_crs=dst_crs

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ extra_reqs = {
 
 setup(
     name="rio-tiler",
-    version="2.0a2",
+    version="2.0a3",
     python_requires=">=3",
     description=u"""Get mercator tile from CloudOptimized GeoTIFF and other cloud hosted raster such as CBERS-4, Sentinel-2, Sentinel-1 and Landsat-8 AWS PDS""",
     long_description=readme,


### PR DESCRIPTION
ref: https://github.com/cogeotiff/rio-tiler/pull/154/files/bf35b488c2d9c7c004940ee1f72e54b315c3d320?file-filters%5B%5D=.py#r396761191

Thanks @kylebarron