### PR TITLE
Optionally return minimal overlapping subset of tile and asset

### DIFF
--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -589,3 +589,35 @@ def pansharpening_brovey(
     with numpy.errstate(invalid="ignore", divide="ignore"):
         ratio = _calculateRatio(rgb, pan, weight)
         return numpy.clip(ratio * rgb, 0, numpy.iinfo(pan_dtype).max).astype(pan_dtype)
+
+
+def intersect_bounds(
+    bounds1: Tuple[float, float, float, float],
+    bounds2: Tuple[float, float, float, float],
+) -> Optional[Tuple[float, float, float, float]]:
+    """Find intersection of two bounding boxes
+
+    Attributes
+    ----------
+    bounds1 : list
+        bounds (left, bottom, right, top).
+    bounds2 : list
+        bounds (left, bottom, right, top).
+
+    Returns
+    -------
+    bounds : list or None
+        bounds (left, bottom, right, top).
+
+        Returns None if the boxes do not intersect
+    """
+
+    minx = max(bounds1[0], bounds2[0])
+    miny = max(bounds1[1], bounds2[1])
+    maxx = min(bounds1[2], bounds2[2])
+    maxy = min(bounds1[3], bounds2[3])
+
+    if minx >= maxx or miny >= maxy:
+        return None
+
+    return [minx, miny, maxx, maxy]


### PR DESCRIPTION
ref #167; ref https://github.com/developmentseed/cogeo-mosaic-tiler/issues/4

Loading a local file on my own laptop doesn't improve performance as much as I'd like. 😢 With the example below, reading 7% of the pixels still takes 70% of the time.

**Example**

```py
import os
from rio_tiler.io.cogeo import tile

os.environ['AWS_REQUEST_PAYER'] ="requester"
address = 's3://naip-visualization/ca/2018/60cm/rgb/34118/m_3411861_ne_11_060_20180723_20190208.tif'
x = 701
y = 1635
z = 12
tilesize = 256
data, mask, pixel_bounds = tile(address, x, y, z, tilesize, minimal_subset=True)
```

<details>
<summary>Data shape</summary>

```
> data.shape
(3, 101, 48)
> mask.shape
(101, 48)
> pixel_bounds
[0, 155, 48, 256]

> data
array([[[102, 116, 112, ..., 106, 121,   0],
        [100,  97, 101, ..., 108, 128,   0],
        [107, 113, 116, ..., 107, 127,   0],
        ...,
        [135, 134, 115, ..., 114, 115, 110],
        [144, 137, 111, ...,   0,   0,   0],
        [  0,   0,   0, ...,   0,   0,   0]],

       [[110, 124, 118, ..., 110, 121,   0],
        [108, 105, 107, ..., 110, 123,   0],
        [115, 121, 122, ..., 110, 126,   0],
        ...,
        [139, 138, 119, ..., 122, 122, 114],
        [148, 141, 115, ...,   0,   0,   0],
        [  0,   0,   0, ...,   0,   0,   0]],

       [[112, 126, 120, ..., 115, 121,   0],
        [111, 107, 110, ..., 114, 121,   0],
        [118, 123, 125, ..., 114, 126,   0],
        ...,
        [140, 139, 120, ..., 124, 126, 123],
        [149, 142, 116, ...,   0,   0,   0],
        [  0,   0,   0, ...,   0,   0,   0]]], dtype=uint8)

> mask
array([[255, 255, 255, ..., 255, 255,   0],
       [255, 255, 255, ..., 255, 255,   0],
       [255, 255, 255, ..., 255, 255,   0],
       ...,
       [255, 255, 255, ..., 255, 255, 255],
       [255, 255, 255, ...,   0,   0,   0],
       [  0,   0,   0, ...,   0,   0,   0]], dtype=uint8)
```

</details>

**Benchmark**

```bash
aws s3 cp s3://naip-visualization/ca/2018/60cm/rgb/34118/m_3411861_ne_11_060_20180723_20190208.tif ./ --request-payer
```

```py
address = 'm_3411861_ne_11_060_20180723_20190208.tif'
tilesize = 512

%timeit tile(address, x, y, z, tilesize)
26.8 ms ± 975 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

%timeit tile(address, x, y, z, tilesize, minimal_subset=True)
19 ms ± 920 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```