### PR TITLE
allow reading part of data at hight resolution and add area/point function in io.cogeo

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,13 @@
+2.0a7 (TBD)
+------------------
+- allow reading high resolution part of a raster (by making height, width args optional)
+- add `max_size` option in `rio_tiler.reader.part` to set a maximum output size when height and width are not set
+- add point and area function in rio_tiler.io.cogeo
+- fix width-height height-widht bug in `rio_tiler.reader.part`
+
+**depreciation**
+- deprecated `out_window` option in favor of `window` in rio_tiler.reader._read
+
 2.0a6 (2020-05-06)
 ------------------
 - fix unwanted breacking change with `img_profiles.get` not allowing default values

--- a/rio_tiler/io/cogeo.py
+++ b/rio_tiler/io/cogeo.py
@@ -1,10 +1,11 @@
 """rio_tiler.io.cogeo: raster processing."""
 
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Tuple, List, Optional
 
 import numpy
 
 import rasterio
+from rasterio.crs import CRS
 from rasterio.warp import transform_bounds
 
 from rio_tiler import reader
@@ -199,3 +200,75 @@ def tile(
     """
     with rasterio.open(address) as src_dst:
         return reader.tile(src_dst, tile_x, tile_y, tile_z, tilesize, **kwargs)
+
+
+def point(address: str, lon: float, lat: float, **kwargs: Any) -> List:
+    """
+    Read point value from a file.
+
+    Attributes
+    ----------
+    address: str
+        file url.
+    lon: float
+        Longitude
+    lat: float
+        Latittude.
+    kwargs: dict, optional
+        These will be passed to the 'rio_tiler.reader.point' function.
+
+    Returns
+    -------
+    point: list
+        List of pixel values per bands indexes.
+
+    """
+    with rasterio.open(address) as src_dst:
+        return reader.point(src_dst, (lon, lat), **kwargs)
+
+
+def area(
+    address: str,
+    bbox: Tuple[float, float, float, float],
+    dst_crs: Optional[CRS] = None,
+    bounds_crs: CRS = constants.WGS84_CRS,
+    max_size: int = 1024,
+    **kwargs: Any,
+) -> Tuple[numpy.ndarray, numpy.ndarray]:
+
+    """
+    Read value from a bbox.
+
+    Attributes
+    ----------
+    address: str
+        file url.
+    bbox: tuple
+        bounds to read (left, bottom, right, top) in "bounds_crs".
+    dst_crs: CRS or str, optional
+        Target coordinate reference system, default is the dataset CRS.
+    bounds_crs: CRS or str, optional
+        bounds coordinate reference system, default is "epsg:4326"
+    max_size: int, optional
+        Limit output size array, default is 1024.
+    kwargs: dict, optional
+        These will be passed to the 'rio_tiler.reader.part' function.
+
+    Returns
+    -------
+    data : numpy ndarray
+    mask: numpy array
+
+    """
+    with rasterio.open(address) as src_dst:
+        if not dst_crs:
+            dst_crs = src_dst.crs
+
+        return reader.part(
+            src_dst,
+            bbox,
+            max_size=max_size,
+            bounds_crs=bounds_crs,
+            dst_crs=dst_crs,
+            **kwargs,
+        )

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -23,10 +23,10 @@ from rio_tiler import constants
 from rio_tiler.colormap import apply_cmap
 
 
-def _chunks(l: Sequence, n: int):
+def _chunks(my_list: Sequence, chuck_size: int):
     """Yield successive n-sized chunks from l."""
-    for i in range(0, len(l), n):
-        yield l[i : i + n]
+    for i in range(0, len(my_list), chuck_size):
+        yield my_list[i : i + chuck_size]
 
 
 def _stats(

--- a/tests/test_io_cogeo.py
+++ b/tests/test_io_cogeo.py
@@ -5,6 +5,7 @@ import pytest
 
 from rio_tiler.io import cogeo
 from rio_tiler.errors import TileOutsideBounds
+from rio_tiler import constants
 
 PREFIX = os.path.join(os.path.dirname(__file__), "fixtures")
 ADDRESS = "{}/my-bucket/hro_sources/colorado/201404_13SED190110_201404_0x1500m_CL_1.tif".format(
@@ -31,6 +32,7 @@ def test_spatial_info_valid():
     assert meta.get("minzoom")
     assert meta.get("maxzoom")
     assert meta.get("center")
+    print(meta.get("center"))
     assert len(meta.get("bounds")) == 4
 
 
@@ -101,3 +103,28 @@ def test_tile_invalid_bounds():
 
     with pytest.raises(TileOutsideBounds):
         cogeo.tile(ADDRESS, tile_x, tile_y, tile_z)
+
+
+def test_point_valid():
+    """Read point."""
+    lon = -104.77499638118547
+    lat = 38.953606785685125
+    assert cogeo.point(ADDRESS, lon, lat)
+
+
+def test_area_valid():
+    """Read part of an image."""
+    bbox = (
+        -104.77506637573242,
+        38.95353532141205,
+        -104.77472305297852,
+        38.95366881479647,
+    )
+    data, mask = cogeo.area(ADDRESS, bbox)
+    assert data.shape == (3, 100, 199)
+
+    data, mask = cogeo.area(ADDRESS, bbox, max_size=100)
+    assert data.shape == (3, 51, 100)
+
+    data, mask = cogeo.area(ADDRESS, bbox, dst_crs=constants.WGS84_CRS)
+    assert data.shape == (3, 82, 210)

--- a/tests/test_io_cogeo.py
+++ b/tests/test_io_cogeo.py
@@ -32,7 +32,6 @@ def test_spatial_info_valid():
     assert meta.get("minzoom")
     assert meta.get("maxzoom")
     assert meta.get("center")
-    print(meta.get("center"))
     assert len(meta.get("bounds")) == 4
 
 

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -67,6 +67,31 @@ def test_tile_read_valid():
     assert arr.shape == (1, 16, 16)
     assert mask.shape == (16, 16)
 
+    # Read bounds at full resolution
+    with rasterio.open(f"{LANDSAT_PATH}_B2.TIF") as src_dst:
+        arr, mask = reader.part(src_dst, bounds)
+    assert arr.shape == (1, 73, 73)
+    assert mask.shape == (73, 73)
+
+    # set max_size for the returned array
+    with rasterio.open(f"{LANDSAT_PATH}_B2.TIF") as src_dst:
+        arr, mask = reader.part(src_dst, bounds, max_size=50)
+    assert arr.shape == (1, 50, 50)
+    assert mask.shape == (50, 50)
+
+    # If max_size is bigger than actual size, there is no effect
+    with rasterio.open(f"{LANDSAT_PATH}_B2.TIF") as src_dst:
+        arr, mask = reader.part(src_dst, bounds, max_size=80)
+    assert arr.shape == (1, 73, 73)
+    assert mask.shape == (73, 73)
+
+    # Incompatible max_size with height and width
+    with pytest.warns(UserWarning):
+        with rasterio.open(f"{LANDSAT_PATH}_B2.TIF") as src_dst:
+            arr, mask = reader.part(src_dst, bounds, max_size=50, width=25, height=25)
+    assert arr.shape == (1, 25, 25)
+    assert mask.shape == (25, 25)
+
 
 def test_tile_read_validResampling():
     """Should return a 1 band array and a mask."""


### PR DESCRIPTION
This PR does:
- allow reading high resolution part of a raster (by making height, width args optional)
- deprecated `out_window` in favor of `window` in `rio_tiler.reader._read`
- add `point` and `area` function in `rio_tiler.io.cogeo`
- add `max_size` option in `rio_tiler.reader.part` to fix a maximum output size when `height` and `width` are not set
