### PR TITLE
issue 187 and more

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,9 @@
+2.0a10 (2020-05-29)
+------------------
+- Change default resampling to nearest for `_read` (#187)
+- add `rio_tiler.reader.stats` (return only array statistics)
+- remove default `dst_crs` in `rio_tiler.reader.part` to to fallback to dataset CRS.
+
 2.0a9 (2020-05-27)
 ------------------
 - Refactor colormap and add method to register custom colormap

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ extra_reqs = {
 
 setup(
     name="rio-tiler",
-    version="2.0a9",
+    version="2.0a10",
     python_requires=">=3",
     description=u"""Get mercator tile from CloudOptimized GeoTIFF and other cloud hosted raster such as CBERS-4, Sentinel-2, Sentinel-1 and Landsat-8 AWS PDS""",
     long_description=readme,

--- a/tests/test_io_cogeo.py
+++ b/tests/test_io_cogeo.py
@@ -70,7 +70,7 @@ def test_metadata_valid():
     assert len(meta["band_descriptions"]) == 3
     assert (1, "band1") == meta["band_descriptions"][0]
     assert len(meta["statistics"].items()) == 3
-    assert meta["statistics"][1]["pc"] == [12, 198]
+    assert meta["statistics"][1]["pc"] == [10, 199]
 
 
 def test_metadata_valid_custom():
@@ -81,7 +81,7 @@ def test_metadata_valid_custom():
     assert meta["address"] == ADDRESS
     assert len(meta["statistics"].items()) == 3
     assert len(meta["statistics"][1]["histogram"][0]) == 20
-    assert meta["statistics"][1]["pc"] == [41, 184]
+    assert meta["statistics"][1]["pc"] == [29, 192]
 
 
 def test_tile_valid_default():

--- a/tests/test_io_sentinel1.py
+++ b/tests/test_io_sentinel1.py
@@ -78,8 +78,8 @@ def test_metadata(rio):
     assert meta["sceneid"] == SENTINEL_SCENE
     assert len(meta["bounds"]) == 4
     assert len(meta["statistics"].items()) == 2
-    assert meta["statistics"]["vv"]["min"] == 1
-    assert meta["statistics"]["vh"]["max"] == 507
+    assert meta["statistics"]["vv"]["min"] == 4
+    assert meta["statistics"]["vh"]["max"] == 623
 
     meta = sentinel1.metadata(SENTINEL_SCENE, bands="vv")
     assert len(meta["statistics"].items()) == 1


### PR DESCRIPTION
this PR does:
- closes #187 and switch back to `nearest` resampling by default
- removed `rio_tiler.reader.part` default dst_crs to fallback to internal CRS
- add `rio_tiler.reader.stats` which is a simplified vertion or `rio_tiler.reader.metadata`