### PR TITLE
rename MultAssetReader and fix issue 229

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ print(tile.shape)
 > (1, 256, 256)
 ```
 
-Note: STACReader is based on `rio_tiler.io.base.MultiAssetsReader` class.
+Note: STACReader is based on `rio_tiler.io.base.MultiBaseReader` class.
 
 ## Working with multiple assets
 
@@ -444,16 +444,16 @@ data, mask = multi_part(assets, bbox, ...)
 data, mask = multi_preview(assets, ...)
 ```
 
-You can also use `rio_tiler.io.base.MultiAssetsReader` to build a custom asset reader:
+You can also use `rio_tiler.io.base.MultiBaseReader` to build a custom asset reader:
 
 ```python
 import attr
-from rio_tiler.io.base import MultiAssetsReader
+from rio_tiler.io.base import MultiBaseReader
 from rio_tiler.io import COGReader, BaseReader
 
 
 @attr.s
-class CustomReader(MultiAssetsReader):
+class CustomReader(MultiBaseReader):
 
     directory: str = attr.ib() # required arg
     reader: Type[BaseReader] = attr.ib(default=COGReader) # the default reader is COGReader

--- a/rio_tiler/io/__init__.py
+++ b/rio_tiler/io/__init__.py
@@ -1,5 +1,5 @@
 """rio-tiler.io"""
 
-from .base import BaseReader, MultiAssetsReader  # noqa
+from .base import BaseReader, MultiBaseReader  # noqa
 from .cogeo import COGReader  # noqa
 from .stac import STACReader  # noqa

--- a/rio_tiler/io/base.py
+++ b/rio_tiler/io/base.py
@@ -19,6 +19,8 @@ class BaseReader(metaclass=abc.ABCMeta):
     """Rio-tiler.io BaseReader."""
 
     bounds: Tuple[float, float, float, float] = attr.ib(init=False)
+    minzoom: int = attr.ib(init=False)
+    maxzoom: int = attr.ib(init=False)
 
     @abc.abstractmethod
     def __enter__(self):
@@ -28,16 +30,6 @@ class BaseReader(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def __exit__(self, exc_type, exc_value, traceback):
         """Support using with Context Managers."""
-        ...
-
-    @property
-    def minzoom(self) -> int:
-        """Dataset Min zoom."""
-        ...
-
-    @property
-    def maxzoom(self) -> int:
-        """Dataset Max zoom."""
         ...
 
     @property
@@ -108,8 +100,8 @@ class BaseReader(metaclass=abc.ABCMeta):
 
 
 @attr.s
-class MultiAssetsReader(metaclass=abc.ABCMeta):
-    """MultiAssets Reader."""
+class MultiBaseReader(BaseReader, metaclass=abc.ABCMeta):
+    """MultiBaseReader Reader."""
 
     reader: Type[BaseReader] = attr.ib()
     reader_options: Dict = attr.ib(factory=dict)

--- a/rio_tiler/io/stac.py
+++ b/rio_tiler/io/stac.py
@@ -10,7 +10,7 @@ import requests
 
 from ..errors import InvalidAssetName
 from ..utils import aws_get_object
-from .base import BaseReader, MultiAssetsReader
+from .base import BaseReader, MultiBaseReader
 from .cogeo import COGReader
 
 DEFAULT_VALID_TYPE = {
@@ -74,7 +74,7 @@ def _get_assets(
 
 
 @attr.s
-class STACReader(MultiAssetsReader):
+class STACReader(MultiBaseReader):
     """
     STAC + Cloud Optimized GeoTIFF Reader.
 

--- a/tests/test_io_cogeo.py
+++ b/tests/test_io_cogeo.py
@@ -28,10 +28,25 @@ def test_spatial_info_valid():
     """Should work as expected (get spatial info)"""
     with COGReader(COG_NODATA) as cog:
         meta = cog.spatial_info
-    assert meta.get("minzoom")
-    assert meta.get("maxzoom")
+    assert meta.get("minzoom") == 5
+    assert meta.get("maxzoom") == 8
     assert meta.get("center")
     assert len(meta.get("bounds")) == 4
+
+    with COGReader(COG_NODATA, minzoom=3) as cog:
+        meta = cog.spatial_info
+    assert meta.get("minzoom") == 3
+    assert meta.get("maxzoom") == 8
+
+    with COGReader(COG_NODATA, maxzoom=12) as cog:
+        meta = cog.spatial_info
+    assert meta.get("minzoom") == 5
+    assert meta.get("maxzoom") == 12
+
+    with COGReader(COG_NODATA, minzoom=3, maxzoom=12) as cog:
+        meta = cog.spatial_info
+    assert meta.get("minzoom") == 3
+    assert meta.get("maxzoom") == 12
 
 
 def test_bounds_valid():
@@ -48,6 +63,11 @@ def test_info_valid():
     assert meta.get("offset")
 
     with COGReader(COG_CMAP) as cog:
+        assert cog.colormap
+        meta = cog.info()
+    assert meta.get("colormap")
+
+    with COGReader(COG_NODATA, colormap={1: [0, 0, 0, 0]}) as cog:
         assert cog.colormap
         meta = cog.info()
     assert meta.get("colormap")


### PR DESCRIPTION
This PR does: 
- rename MultiAssetReader -> MultiBaseReader
- Make MultiBaseReader a subclass of BaseReader

closes #229
- add minzoom/maxzoom in BaseReader class definition and removes them from `properties` to allow setting them on Object creation