### PR TITLE
Export modules from top-level package

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
-    -   
+    -
         repo: https://github.com/pre-commit/mirrors-isort
-        rev: v4.3.21
+        rev: v5.4.0
         hooks:
             - id: isort
               language_version: python3.7
@@ -14,7 +14,7 @@ repos:
               language_version: python3.7
     -
         repo: 'https://github.com/pre-commit/pre-commit-hooks'
-        rev: v2.4.0 
+        rev: v2.4.0
         hooks:
             - id: flake8
               language_version: python3.7
@@ -36,7 +36,7 @@ repos:
                  # Don't require docstrings for tests
                  '--match=(?!test).*\.py']
 
-    -   
+    -
         repo: https://github.com/pre-commit/mirrors-mypy
         rev: 'v0.770'
         hooks:

--- a/rio_tiler/__init__.py
+++ b/rio_tiler/__init__.py
@@ -2,4 +2,18 @@
 
 import pkg_resources
 
+from . import (  # noqa
+    colormap,
+    constants,
+    errors,
+    expression,
+    io,
+    mercator,
+    mosaic,
+    profiles,
+    reader,
+    tasks,
+    utils,
+)
+
 version = pkg_resources.get_distribution(__package__).version

--- a/rio_tiler/mosaic/__init__.py
+++ b/rio_tiler/mosaic/__init__.py
@@ -1,3 +1,4 @@
 """rio-tiler.mosaic."""
 
+from . import methods  # noqa
 from .reader import mosaic_reader, mosaic_tiler  # noqa

--- a/rio_tiler/mosaic/methods/__init__.py
+++ b/rio_tiler/mosaic/methods/__init__.py
@@ -1,1 +1,10 @@
 """rio-tiler.mosaic.methods: Mosaic filling methods."""
+
+from .defaults import (  # noqa
+    FirstMethod,
+    HighestMethod,
+    LowestMethod,
+    MeanMethod,
+    MedianMethod,
+    StdevMethod,
+)

--- a/setup.py
+++ b/setup.py
@@ -18,14 +18,7 @@ inst_reqs = [
 
 extra_reqs = {
     "test": ["pytest", "pytest-benchmark", "pytest-cov", "rio-cogeo"],
-    "dev": [
-        "pytest",
-        "pytest-benchmark",
-        "pytest-cov",
-        "rio-cogeo",
-        "pre-commit",
-        "isort>=5.4.0",
-    ],
+    "dev": ["pytest", "pytest-benchmark", "pytest-cov", "rio-cogeo", "pre-commit"],
     "docs": ["mkdocs", "mkdocs-material"],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,14 @@ inst_reqs = [
 
 extra_reqs = {
     "test": ["pytest", "pytest-benchmark", "pytest-cov", "rio-cogeo"],
-    "dev": ["pytest", "pytest-benchmark", "pytest-cov", "rio-cogeo", "pre-commit"],
+    "dev": [
+        "pytest",
+        "pytest-benchmark",
+        "pytest-cov",
+        "rio-cogeo",
+        "pre-commit",
+        "isort>=5.4.0",
+    ],
     "docs": ["mkdocs", "mkdocs-material"],
 }
 

--- a/tox.ini
+++ b/tox.ini
@@ -25,9 +25,7 @@ no_strict_optional = True
 ignore_missing_imports = True
 
 [tool:isort]
-include_trailing_comma = True
-multi_line_output = 3
-line_length = 90
+profile=black
 known_first_party = rio_tiler
 known_third_party = rasterio,mercantile,supermercado,affine
 default_section = THIRDPARTY


### PR DESCRIPTION
This PR re-exports selected modules for ease of use.

This allows accessing modules after a global import:
```py
import rio_tiler
rio_tiler.io.COGReader()
```

and mosaic methods with a shorter import
```py
from rio_tiler.mosaic.methods import FirstMethod
```

**Before:**
```py
import rio_tiler; dir(rio_tiler)
['__builtins__',
 '__cached__',
 '__doc__',
 '__file__',
 '__loader__',
 '__name__',
 '__package__',
 '__path__',
 '__spec__',
 'pkg_resources',
 'version']
```

**After:**
```py
import rio_tiler; dir(rio_tiler)
['__builtins__',
 '__cached__',
 '__doc__',
 '__file__',
 '__loader__',
 '__name__',
 '__package__',
 '__path__',
 '__spec__',
 '_pkg_resources',
 'cmap_data',
 'colormap',
 'constants',
 'errors',
 'expression',
 'io',
 'mercator',
 'mosaic',
 'profiles',
 'reader',
 'tasks',
 'utils',
 'version']
```