### PR TITLE
Remove deprecated functions

### DIFF
--- a/docs/scripts/colormap_thumb.py
+++ b/docs/scripts/colormap_thumb.py
@@ -10,7 +10,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.colors import ListedColormap
 
-from rio_tiler.colormap import get_colormap, make_lut
+from rio_tiler.colormap import cmap, make_lut
 
 cmaps = [
     ("Custom", ["cfastie", "rplumbo", "schwarzwald"]),
@@ -128,9 +128,9 @@ gradient = np.vstack((gradient, gradient))
 def make_colormap(name):
     """Use rio-tiler colormap to create matplotlib colormap
     """
-    cmap = make_lut(get_colormap(name))
+    colormap = make_lut(cmap.get(name))
     # rescale to 0-1
-    return ListedColormap(cmap / 255, name=name)
+    return ListedColormap(colormap / 255, name=name)
 
 
 def plot_color_gradients(cmap_category, cmap_list):

--- a/rio_tiler/colormap.py
+++ b/rio_tiler/colormap.py
@@ -1,7 +1,6 @@
 """rio-tiler colormap functions."""
 
 import os
-import warnings
 from typing import Dict, List, Sequence, Tuple, Union
 
 import numpy

--- a/rio_tiler/colormap.py
+++ b/rio_tiler/colormap.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Sequence, Tuple, Union
 import numpy
 
 from .cmap_data import _default_cmaps
-from .errors import DeprecationWarning, InvalidColorMapName
+from .errors import InvalidColorMapName
 
 EMPTY_COLORMAP: Dict = {i: [0, 0, 0, 0] for i in range(256)}
 

--- a/rio_tiler/colormap.py
+++ b/rio_tiler/colormap.py
@@ -37,35 +37,6 @@ def _update_cmap(cmap: Dict, values: Dict) -> None:
         cmap[i] = color
 
 
-def get_colormap(name: str) -> Dict:
-    """
-    Return colormap dict.
-
-    Attributes
-    ----------
-    name : str, optional
-        Colormap name (default: cfastie)
-
-    Returns
-    -------
-    colormap : dict
-        GDAL RGBA Color Table dictionary.
-
-    """
-    warnings.warn(
-        "`rio_tiler.colormap.get_colormap` will be removed in version 2.0, Please use rio_tiler.colormap.cmap.get",
-        DeprecationWarning,
-    )
-    cmap_file = os.path.join(
-        os.path.dirname(__file__), "cmap_data", f"{name.lower()}.npy"
-    )
-    cmap = numpy.load(cmap_file)
-    assert cmap.shape == (256, 4)
-    assert cmap.dtype == numpy.uint8
-
-    return {idx: value.tolist() for idx, value in enumerate(cmap)}
-
-
 # From https://github.com/mojodna/marblecutter/blob/5b9040ba6c83562a465eabdbb6e8959e6a8bf041/marblecutter/utils.py#L35
 def make_lut(colormap: Dict) -> numpy.ndarray:
     """

--- a/rio_tiler/mosaic/__init__.py
+++ b/rio_tiler/mosaic/__init__.py
@@ -1,3 +1,3 @@
 """rio-tiler.mosaic."""
 
-from .reader import mosaic_reader, mosaic_tiler  # noqa
+from .reader import mosaic_reader  # noqa

--- a/rio_tiler/mosaic/reader.py
+++ b/rio_tiler/mosaic/reader.py
@@ -87,28 +87,3 @@ def mosaic_reader(
                 return pixel_selection.data, assets_used
 
     return pixel_selection.data, assets_used
-
-
-def mosaic_tiler(
-    assets: Sequence[str],
-    tile_x: int,
-    tile_y: int,
-    tile_z: int,
-    reader: Callable,
-    pixel_selection: Optional[MosaicMethodBase] = None,
-    chunk_size: Optional[int] = None,
-    threads: int = MAX_THREADS,
-    **kwargs,
-) -> Tuple[Tuple[numpy.ndarray, numpy.ndarray], Sequence[str]]:
-    """Wrapper around mosaic_reader from compatibility with previous rio_tiler_mosaic."""
-    return mosaic_reader(
-        assets,
-        reader,
-        tile_x,
-        tile_y,
-        tile_z,
-        pixel_selection=pixel_selection,
-        chunk_size=chunk_size,
-        threads=threads,
-        **kwargs,
-    )

--- a/rio_tiler/reader.py
+++ b/rio_tiler/reader.py
@@ -18,7 +18,6 @@ from rasterio.warp import transform_bounds
 from . import constants
 from .errors import (
     AlphaBandWarning,
-    DeprecationWarning,
     PointOutsideBounds,
     TileOutsideBounds,
 )

--- a/rio_tiler/reader.py
+++ b/rio_tiler/reader.py
@@ -247,13 +247,6 @@ def part(
             height=orig_vrt_height,
         )
 
-    if warp_vrt_option:
-        warnings.warn(
-            "warp_vrt_option will be removed in 2.0, use vrt_options",
-            DeprecationWarning,
-        )
-        vrt_options = vrt_options or warp_vrt_option
-
     vrt_options = vrt_options or {}
     vrt_options.update(
         {

--- a/rio_tiler/reader.py
+++ b/rio_tiler/reader.py
@@ -16,11 +16,7 @@ from rasterio.warp import transform as transform_coords
 from rasterio.warp import transform_bounds
 
 from . import constants
-from .errors import (
-    AlphaBandWarning,
-    PointOutsideBounds,
-    TileOutsideBounds,
-)
+from .errors import AlphaBandWarning, PointOutsideBounds, TileOutsideBounds
 from .utils import _requested_tile_aligned_with_internal_tile as is_aligned
 from .utils import _stats as raster_stats
 from .utils import (
@@ -140,7 +136,6 @@ def part(
     dst_crs: Optional[CRS] = None,
     bounds_crs: Optional[CRS] = None,
     minimum_overlap: Optional[float] = None,
-    warp_vrt_option: Optional[Dict] = None,
     vrt_options: Optional[Dict] = None,
     max_size: Optional[int] = None,
     **kwargs: Any,
@@ -169,8 +164,6 @@ def part(
     minimum_tile_cover: float, optional
         Minimum % overlap for which to raise an error with dataset not
         covering enought of the tile.
-    warp_vrt_option: dict, DEPRECATED
-        These will be passed to the rasterio.warp.WarpedVRT class.
     vrt_options: dict, optional
         These will be passed to the rasterio.warp.WarpedVRT class.
     max_size: int, optional

--- a/tests/test_cmap.py
+++ b/tests/test_cmap.py
@@ -5,18 +5,12 @@ import pytest
 
 from rio_tiler import colormap
 from rio_tiler.cmap_data import _default_cmaps
-from rio_tiler.errors import DeprecationWarning, InvalidColorMapName
+from rio_tiler.errors import InvalidColorMapName
 
 
 def test_get_cmaplist():
     """Should work as expected return all rio-tiler colormaps."""
     assert len(_default_cmaps) == 167
-
-
-def test_depreciation():
-    """Should warn when using get_colormap."""
-    with pytest.warns(DeprecationWarning):
-        colormap.get_colormap("viridis")
 
 
 def test_cmapObject():

--- a/tests/test_mosaic.py
+++ b/tests/test_mosaic.py
@@ -44,14 +44,6 @@ def _read_preview(
 
 def test_mosaic_tiler():
     """Test mosaic tiler."""
-    # test with mosaic_tiler for compatibility
-    (t, m), assets_used = mosaic.mosaic_tiler(assets, x, y, z, _read_tile)
-    assert len(assets_used) == 1
-    assert t.shape == (3, 256, 256)
-    assert m.shape == (256, 256)
-    assert m.all()
-    assert t[0][-1][-1] == 8682
-
     # test with default and full covered tile and default options
     (t, m), assets_used = mosaic.mosaic_reader(assets, _read_tile, x, y, z)
     assert t.shape == (3, 256, 256)

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -8,12 +8,7 @@ import pytest
 import rasterio
 
 from rio_tiler import constants, reader
-from rio_tiler.errors import (
-    AlphaBandWarning,
-    DeprecationWarning,
-    PointOutsideBounds,
-    TileOutsideBounds,
-)
+from rio_tiler.errors import AlphaBandWarning, PointOutsideBounds, TileOutsideBounds
 
 S3_KEY = "hro_sources/colorado/201404_13SED190110_201404_0x1500m_CL_1.tif"
 S3_KEY_ALPHA = "hro_sources/colorado/201404_13SED190110_201404_0x1500m_CL_1_alpha.tif"
@@ -468,18 +463,6 @@ def test_tile_read_vrt_option():
         12523442.714243278,
     ]
     tilesize = 16
-    with pytest.warns(DeprecationWarning):
-        with rasterio.open(COG) as src_dst:
-            arr, mask = reader.part(
-                src_dst,
-                bounds,
-                tilesize,
-                tilesize,
-                warp_vrt_option=dict(source_extra=10, num_threads=10),
-            )
-        assert arr.shape == (1, 16, 16)
-        assert mask.shape == (16, 16)
-
     with rasterio.open(COG) as src_dst:
         arr, mask = reader.part(
             src_dst,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,7 +9,7 @@ import rasterio
 from rasterio.features import bounds as featureBounds
 
 from rio_tiler import colormap, constants, utils
-from rio_tiler.errors import DeprecationWarning, RioTilerError
+from rio_tiler.errors import RioTilerError
 from rio_tiler.expression import parse_expression
 from rio_tiler.io import COGReader
 
@@ -162,12 +162,6 @@ def test_render_valid_colormap():
     mask = np.zeros((512, 512), dtype=np.uint8)
     cmap = colormap.cmap.get("cfastie")
     assert utils.render(arr, mask, colormap=cmap, img_format="jpeg")
-
-
-def test_cmap_depreciation():
-    """Make sure we warns for depreciation warning of get_colormap."""
-    with pytest.warns(DeprecationWarning):
-        colormap.get_colormap("cfastie")
 
 
 def test_render_valid_colormapDict():


### PR DESCRIPTION
Regarding removing `rio_tiler.mosaic.mosaic_tiler`: I feel that if you’re doing a major version bump anyways, there’s no reason to re-export a function with two names.

In any case, `mosaic_tiler` isn't currently backwards compatible because it returns the output of `mosaic_reader` directly, but `mosaic_reader` was updated to return the `asset_ids` of the assets that were used. If you decide to keep `mosaic_tiler` for backwards compatibility with `rio_tiler_mosaic`, it would be good to return only the `tile, mask`.