### PR TITLE
Allow overwriting colormap with force=True

### DIFF
--- a/rio_tiler/colormap.py
+++ b/rio_tiler/colormap.py
@@ -184,7 +184,7 @@ class ColorMaps(object):
         """List registered Colormaps."""
         return list(self._data.keys())
 
-    def register(self, name: str, custom_cmap: Union[Dict, str]):
+    def register(self, name: str, custom_cmap: Union[Dict, str], force: bool = False):
         """
         Register a custom colormap.
 
@@ -194,10 +194,14 @@ class ColorMaps(object):
             Name of the colormap.
         custom_cmap: dict or str
             A dict or a path to a numpy file
+        force: bool
+            Overwrite existing colormap with same key (default: False)
 
         """
-        if name in self._data.keys():
-            raise Exception(f"{name} is already registered")
+        if not force and name in self._data.keys():
+            raise Exception(
+                f"{name} is already registered. Use force=True to overwrite."
+            )
 
         self._data[name] = custom_cmap
 


### PR DESCRIPTION
I think there's a valid use case for overwriting a built-in colormap, so I think it makes sense to optionally turn off the exception when registering a colormap with an existing name.