### PR TITLE
Pin black version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-    -   
+    -
         repo: https://github.com/pre-commit/mirrors-isort
         rev: v4.3.21
         hooks:
@@ -7,14 +7,14 @@ repos:
               language_version: python3.7
     -
         repo: 'https://github.com/psf/black'
-        rev: stable
+        rev: 19.10b0
         hooks:
             - id: black
               args: ['--safe']
               language_version: python3.7
     -
         repo: 'https://github.com/pre-commit/pre-commit-hooks'
-        rev: v2.4.0 
+        rev: v2.4.0
         hooks:
             - id: flake8
               language_version: python3.7
@@ -36,7 +36,7 @@ repos:
                  # Don't require docstrings for tests
                  '--match=(?!test).*\.py']
 
-    -   
+    -
         repo: https://github.com/pre-commit/mirrors-mypy
         rev: 'v0.770'
         hooks:


### PR DESCRIPTION
CI on master is currently failing with
```
black....................................................................Failed
- hook id: black
- exit code: 123
- files were modified by this hook

reformatted /home/runner/work/rio-tiler/rio-tiler/rio_tiler/expression.py
reformatted /home/runner/work/rio-tiler/rio-tiler/docs/scripts/colormap_thumb.py
reformatted /home/runner/work/rio-tiler/rio-tiler/rio_tiler/io/base.py
error: cannot format /home/runner/work/rio-tiler/rio-tiler/rio_tiler/io/cogeo.py: INTERNAL ERROR: Black produced code that is not equivalent to the source.  Please report a bug on https://github.com/psf/black/issues.  This diff might be helpful: /tmp/blk_lzqera7f.log
error: cannot format /home/runner/work/rio-tiler/rio-tiler/rio_tiler/io/stac.py: INTERNAL ERROR: Black produced code that is not equivalent to the source.  Please report a bug on https://github.com/psf/black/issues.  This diff might be helpful: /tmp/blk_5b3wznne.log
reformatted /home/runner/work/rio-tiler/rio-tiler/rio_tiler/tasks.py
reformatted /home/runner/work/rio-tiler/rio-tiler/rio_tiler/reader.py
reformatted /home/runner/work/rio-tiler/rio-tiler/tests/test_io_cogeo.py
Oh no! 💥 💔 💥
6 files reformatted, 27 files left unchanged, 2 files failed to reformat.
```

This may be related to https://github.com/psf/black/issues/1629.

In any case, good to pin the black version.