### PR TITLE
Restore mkdocs search

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ nav:
   - Colormaps: 'colormap.md'
 
 plugins:
+  - search
   - mkdocs-jupyter:
       include_source: True
 


### PR DESCRIPTION
By default mkdocs includes the `search` plugin, but when you define an array of custom plugins, it overrides this default. Therefore we need to manually specify including `search`

![image](https://user-images.githubusercontent.com/15164633/91645340-87a7a800-ea01-11ea-8e0b-c8e978ea852d.png)
