### PR TITLE
add resampling_method in COGReader global options

### DIFF
--- a/rio_tiler/io/base.py
+++ b/rio_tiler/io/base.py
@@ -56,13 +56,7 @@ class BaseReader(metaclass=abc.ABCMeta):
         }
 
     @abc.abstractmethod
-    def stats(
-        self,
-        pmin: float = 2.0,
-        pmax: float = 98.0,
-        hist_options: Optional[Dict] = None,
-        **kwargs: Any,
-    ) -> Dict:
+    def stats(self, pmin: float = 2.0, pmax: float = 98.0, **kwargs: Any) -> Dict:
         """Return Dataset's statistics."""
         ...
 
@@ -148,7 +142,6 @@ class MultiBaseReader(BaseReader, metaclass=abc.ABCMeta):
         self,
         pmin: float = 2.0,
         pmax: float = 98.0,
-        hist_options: Optional[Dict] = None,
         assets: Union[Sequence[str], str] = None,
         **kwargs: Any,
     ) -> Dict:
@@ -164,9 +157,7 @@ class MultiBaseReader(BaseReader, metaclass=abc.ABCMeta):
             with self.reader(url, **self.reader_options) as cog:  # type: ignore
                 return cog.stats(*args, **kwargs)
 
-        return multi_values(
-            assets, _reader, pmin, pmax, hist_options=hist_options, **kwargs
-        )
+        return multi_values(assets, _reader, pmin, pmax, **kwargs)
 
     def metadata(
         self,

--- a/rio_tiler/io/cogeo.py
+++ b/rio_tiler/io/cogeo.py
@@ -9,6 +9,7 @@ import mercantile
 import numpy
 import rasterio
 from rasterio.crs import CRS
+from rasterio.enums import Resampling
 from rasterio.io import DatasetReader, DatasetWriter, MemoryFile
 from rasterio.vrt import WarpedVRT
 from rasterio.warp import transform_bounds
@@ -95,8 +96,9 @@ class COGReader(BaseReader):
     nodata: Optional[Union[float, int, str]] = attr.ib(default=None)
     unscale: Optional[bool] = attr.ib(default=None)
     vrt_options: Optional[Dict] = attr.ib(default=None)
+    resampling_method: Optional[Resampling] = attr.ib(default=None)
 
-    # We use _kwargs to store values of nodata, unscale and vrt_options.
+    # We use _kwargs to store values of nodata, unscale, vrt_options and resampling_method.
     # _kwargs is used avoid having to set those values on each method call.
     _kwargs: Dict[str, Any] = attr.ib(init=False, factory=dict)
 
@@ -108,6 +110,8 @@ class COGReader(BaseReader):
             self._kwargs["unscale"] = self.unscale
         if self.vrt_options is not None:
             self._kwargs["vrt_options"] = self.vrt_options
+        if self.resampling_method is not None:
+            self._kwargs["resampling_method"] = self.resampling_method
 
     def __enter__(self):
         """Support using with Context Managers."""

--- a/rio_tiler/reader.py
+++ b/rio_tiler/reader.py
@@ -34,10 +34,10 @@ def _read(
     width: Optional[int] = None,
     indexes: Optional[Union[Sequence[int], int]] = None,
     window: Optional[windows.Window] = None,
-    nodata: Optional[Union[float, int, str]] = None,
-    resampling_method: Resampling = "nearest",
     force_binary_mask: bool = True,
+    nodata: Optional[Union[float, int, str]] = None,
     unscale: bool = False,
+    resampling_method: Resampling = "nearest",
     vrt_options: Optional[Dict] = None,
 ) -> Tuple[numpy.ndarray, numpy.ndarray]:
     """
@@ -310,9 +310,10 @@ def point(
     coordinates: Tuple[float, float],
     indexes: Optional[Union[Sequence[int], int]] = None,
     coord_crs: CRS = constants.WGS84_CRS,
+    masked: bool = True,
     nodata: Optional[Union[float, int, str]] = None,
     unscale: bool = False,
-    masked: bool = True,
+    resampling_method: Resampling = "nearest",
     vrt_options: Optional[Dict] = None,
 ) -> List:
     """
@@ -358,7 +359,10 @@ def point(
 
     indexes = indexes if indexes is not None else src_dst.indexes
 
-    vrt_params: Dict[str, Any] = {"add_alpha": True}
+    vrt_params: Dict[str, Any] = {
+        "add_alpha": True,
+        "resampling": Resampling[resampling_method],
+    }
     nodata = nodata if nodata is not None else src_dst.nodata
     if nodata is not None:
         vrt_params.update({"nodata": nodata, "add_alpha": False, "src_nodata": nodata})

--- a/tests/test_io_cogeo.py
+++ b/tests/test_io_cogeo.py
@@ -258,6 +258,10 @@ def test_COGReader_Options():
         _, mask = cog.tile(43, 25, 7)
         assert not mask.all()
 
+    with COGReader(COGEO, nodata=1, resampling_method="bilinear") as cog:
+        data, _ = cog.tile(43, 25, 7)
+        assert data[0, 100, 100] == 3774  # 3776 with nearest
+
     with COGReader(COG_SCALE, unscale=True) as cog:
         p = cog.point(310000, 4100000, coord_crs=cog.dataset.crs)
         assert round(p[0], 3) == 1000.892


### PR DESCRIPTION
This PR does:

- remove useless `hist_options` in `BaseReader.stats` method
- add `resampling_method` in COGReader global options
- add `resampling_method` in COGReader.point for compatibility with `_read`
- re-order keyword argument in `reader._read` and `reader.point`