### PR TITLE
add post_process callback to _read and point

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+2.0b10 (TBD)
+------------------
+- add `post_process` callback to `rio_tiler.render._read` and `rio_tiler.render.point` to apply
+specific operation ouput arrays.
+
 2.0b9 (2020-09-09)
 ------------------
 - restore Mkdocs search bar (#255)

--- a/rio_tiler/io/cogeo.py
+++ b/rio_tiler/io/cogeo.py
@@ -2,7 +2,7 @@
 
 import warnings
 from concurrent import futures
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import attr
 import mercantile
@@ -95,8 +95,11 @@ class COGReader(BaseReader):
     # Define global options to be forwarded to functions reading the data (e.g rio_tiler.reader._read)
     nodata: Optional[Union[float, int, str]] = attr.ib(default=None)
     unscale: Optional[bool] = attr.ib(default=None)
-    vrt_options: Optional[Dict] = attr.ib(default=None)
     resampling_method: Optional[Resampling] = attr.ib(default=None)
+    vrt_options: Optional[Dict] = attr.ib(default=None)
+    post_process: Optional[
+        Callable[[numpy.ndarray, numpy.ndarray], Tuple[numpy.ndarray, numpy.ndarray]]
+    ] = attr.ib(default=None)
 
     # We use _kwargs to store values of nodata, unscale, vrt_options and resampling_method.
     # _kwargs is used avoid having to set those values on each method call.
@@ -108,10 +111,12 @@ class COGReader(BaseReader):
             self._kwargs["nodata"] = self.nodata
         if self.unscale is not None:
             self._kwargs["unscale"] = self.unscale
-        if self.vrt_options is not None:
-            self._kwargs["vrt_options"] = self.vrt_options
         if self.resampling_method is not None:
             self._kwargs["resampling_method"] = self.resampling_method
+        if self.vrt_options is not None:
+            self._kwargs["vrt_options"] = self.vrt_options
+        if self.post_process is not None:
+            self._kwargs["post_process"] = self.post_process
 
     def __enter__(self):
         """Support using with Context Managers."""

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ extra_reqs = {
 
 setup(
     name="rio-tiler",
-    version="2.0b9",
+    version="2.0b10",
     python_requires=">=3.5",
     description="Rasterio plugin to read mercator tiles from Cloud Optimized GeoTIFF.",
     long_description=readme,

--- a/tests/test_io_cogeo.py
+++ b/tests/test_io_cogeo.py
@@ -274,3 +274,23 @@ def test_COGReader_Options():
     with COGReader(COGEO, vrt_options={"cutline": cutline}) as cog:
         _, mask = cog.preview()
         assert not mask.all()
+
+    def callback(data, mask):
+        mask.fill(255)
+        data = data * 2
+        return data, mask
+
+    with COGReader(COGEO, nodata=1, post_process=callback) as cog:
+        data_init, _ = cog.tile(43, 25, 7, post_process=None)
+        data, mask = cog.tile(43, 25, 7)
+        assert mask.all()
+        assert data[0, 0, 0] == data_init[0, 0, 0] * 2
+
+    lon = -56.624124590533825
+    lat = 73.52687881825946
+    with COGReader(COG_NODATA, post_process=callback) as cog:
+        pts = cog.point(lon, lat)
+
+    with COGReader(COG_NODATA) as cog:
+        pts_init = cog.point(lon, lat)
+    assert pts[0] == pts_init[0] * 2


### PR DESCRIPTION
closes #181 

This PR does:
- add `post_process` callback to `reader._read` and `reader.point` to apply specific operation on output array. This is mostly to be able to apply ops on arrays for `metadata` and `stats`. 
- refactor `reader.point` to accept the post_process option.

@kylebarron I'm happy to change the name of the option if you have a better idea. 

I'll also try to add an example using Landsat8 rio-tiler-pds reader to show how this can be useful.