### PR TITLE
GeoMedianMethod and MaxIndexMethod for pixel selection

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ mercantile
 rasterio>=1.1.3
 
 requests
+
+hdmedians

--- a/rio_tiler/mosaic/methods/__init__.py
+++ b/rio_tiler/mosaic/methods/__init__.py
@@ -7,4 +7,6 @@ from .defaults import (  # noqa
     MeanMethod,
     MedianMethod,
     StdevMethod,
+    GeoMedianMethod,
+    MaxIndexMethod
 )

--- a/tests/test_mosaic.py
+++ b/tests/test_mosaic.py
@@ -156,6 +156,24 @@ def test_mosaic_tiler():
     assert m.all()
     assert t[0][-1][-1] == 8682
 
+    # Test max index pixel selection
+    (t, m), assets_used = mosaic.mosaic_reader(
+        assets, _read_tile, x, y, z, pixel_selection=defaults.MaxIndexMethod
+    )
+    assert t.shape == (3, 256, 256)
+    assert m.shape == (256, 256)
+    assert m.all()
+    assert t[0][-1][-1] == 8057
+
+    # Test geomedian index selection
+    (t, m), assets_used = mosaic.mosaic_reader(
+        assets, _read_tile, x, y, z, pixel_selection=defaults.GeoMedianMethod
+    )
+    assert t.shape == (3, 256, 256)
+    assert m.shape == (256, 256)
+    assert m.all()
+    assert t[0][-1][-1] == 8369
+
     # Test invalid Pixel Selection class
     with pytest.raises(InvalidMosaicMethod):
 
@@ -163,6 +181,12 @@ def test_mosaic_tiler():
             pass
 
         mosaic.mosaic_reader(assets, _read_tile, x, y, z, pixel_selection=aClass())
+
+    # Test invalid Pixel Selection class
+    with pytest.raises(NameError):
+
+        mosaic.mosaic_reader(assets, _read_tile, x, y, z,
+                             pixel_selection=defaults.MaxIndexMethod(formula='(t2-t1)/(t2+t1)'))
 
     # test with preview
     # NOTE: We need to fix the output width and height because each preview could have different size


### PR DESCRIPTION
I added `GeoMedianMethod` and `MaxIndexMethod` as pixel selection methods.
The former is based on Dale Roberts' `hdmedians` package, a geometric median implementation in cython.

For `GeoMedianMethod`, I didn't want to add cython dependencies to rio-tiler, so currently it's just a naive numpy array assignment which is rather slow, but left it like this to spark the discussion on how to best go forward on this one, as I think pixel selection using the geomedian is rather useful. I contacted the Geoscience Australia project, who seem to internally use an `hdstats` package that offers an interface to n-dimensional array geomedian compositing: [https://github.com/GeoscienceAustralia/digitalearthau/issues/260](https://github.com/GeoscienceAustralia/digitalearthau/issues/260 ), but it's currently not on PyPI.

For the `MaxIndexMethod`, the idea is to expand the behavior of a max NDVI composite (which is itself missing) to any possible band combination.