### PR TITLE
remove ContextManager requirement

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## Next (TBD) - Master
+
+* remove ContextManager requirement for `rio_tiler.io.base.BaseReader` and `rio_tiler.io.base.MultiBaseReader` base classes.
+* move ContextManager properties definition to `__attrs_post_init__` method in `rio_tiler.io.STACReader` and `rio_tiler.io.COGReader` (ref: https://github.com/cogeotiff/rio-tiler-pds/issues/21)
+
 ## 2.0b12 (2020-09-28)
 
 * Make sure Alpha band isn't considered as an internal mask by `utils.has_mask_band`

--- a/rio_tiler/io/base.py
+++ b/rio_tiler/io/base.py
@@ -21,16 +21,6 @@ class BaseReader(metaclass=abc.ABCMeta):
     minzoom: int = attr.ib(init=False)
     maxzoom: int = attr.ib(init=False)
 
-    @abc.abstractmethod
-    def __enter__(self):
-        """Support using with Context Managers."""
-        ...
-
-    @abc.abstractmethod
-    def __exit__(self, exc_type, exc_value, traceback):
-        """Support using with Context Managers."""
-        ...
-
     @property
     def center(self) -> Tuple[float, float, int]:
         """Dataset center + minzoom."""
@@ -100,15 +90,6 @@ class MultiBaseReader(BaseReader, metaclass=abc.ABCMeta):
     reader_options: Dict = attr.ib(factory=dict)
     bounds: Tuple[float, float, float, float] = attr.ib(init=False)
     assets: Sequence[str] = attr.ib(init=False)
-
-    @abc.abstractmethod
-    def __enter__(self):
-        """Support using with Context Managers."""
-        ...
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        """Support using with Context Managers."""
-        pass
 
     @abc.abstractmethod
     def _get_asset_url(self, asset: str) -> str:

--- a/rio_tiler/io/cogeo.py
+++ b/rio_tiler/io/cogeo.py
@@ -106,7 +106,7 @@ class COGReader(BaseReader):
     _kwargs: Dict[str, Any] = attr.ib(init=False, factory=dict)
 
     def __attrs_post_init__(self):
-        """Define _kwargs."""
+        """Define _kwargs, open dataset and get info."""
         if self.nodata is not None:
             self._kwargs["nodata"] = self.nodata
         if self.unscale is not None:
@@ -118,8 +118,6 @@ class COGReader(BaseReader):
         if self.post_process is not None:
             self._kwargs["post_process"] = self.post_process
 
-    def __enter__(self):
-        """Support using with Context Managers."""
         self.dataset = self.dataset or rasterio.open(self.filepath)
 
         self.bounds = transform_bounds(
@@ -131,6 +129,13 @@ class COGReader(BaseReader):
         if self.colormap is None:
             self._get_colormap()
 
+    def close(self):
+        """Close rasterio dataset."""
+        if self.filepath:
+            self.dataset.close()
+
+    def __enter__(self):
+        """Support using with Context Managers."""
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):

--- a/rio_tiler/io/cogeo.py
+++ b/rio_tiler/io/cogeo.py
@@ -140,8 +140,7 @@ class COGReader(BaseReader):
 
     def __exit__(self, exc_type, exc_value, traceback):
         """Support using with Context Managers."""
-        if self.filepath:
-            self.dataset.close()
+        self.close()
 
     def _get_zooms(self):
         """Calculate raster min/max zoom level."""

--- a/rio_tiler/io/stac.py
+++ b/rio_tiler/io/stac.py
@@ -153,16 +153,14 @@ class STACReader(MultiBaseReader):
     exclude_assets: Optional[Set[str]] = attr.ib(default=None)
     include_asset_types: Set[str] = attr.ib(default=DEFAULT_VALID_TYPE)
     exclude_asset_types: Optional[Set[str]] = attr.ib(default=None)
+
     reader: Type[BaseReader] = attr.ib(default=COGReader)
     reader_options: Dict = attr.ib(factory=dict)
 
-    def __enter__(self):
-        """Support using with Context Managers."""
+    def __attrs_post_init__(self):
+        """Define _kwargs, open dataset and get info."""
         self.item = self.item or fetch(self.filepath)
-
-        # Get Zooms from proj: ?
         self.bounds = self.item["bbox"]
-
         self.assets = list(
             _get_assets(
                 self.item,
@@ -175,7 +173,13 @@ class STACReader(MultiBaseReader):
         if not self.assets:
             raise MissingAssets("No valid asset found")
 
+    def __enter__(self):
+        """Support using with Context Managers."""
         return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """Support using with Context Managers."""
+        pass
 
     def _get_asset_url(self, asset: str) -> str:
         """Validate asset names and return asset's url."""

--- a/tests/test_io_cogeo.py
+++ b/tests/test_io_cogeo.py
@@ -27,11 +27,18 @@ COG_SCALE = os.path.join(PREFIX, "cog_scale.tif")
 def test_spatial_info_valid():
     """Should work as expected (get spatial info)"""
     with COGReader(COG_NODATA) as cog:
+        assert not cog.dataset.closed
         meta = cog.spatial_info
         assert meta.get("minzoom") == 5
         assert meta.get("maxzoom") == 8
         assert meta.get("center")
         assert len(meta.get("bounds")) == 4
+    assert cog.dataset.closed
+
+    cog = COGReader(COG_NODATA)
+    assert not cog.dataset.closed
+    cog.close()
+    assert cog.dataset.closed
 
     with COGReader(COG_NODATA, minzoom=3) as cog:
         meta = cog.spatial_info


### PR DESCRIPTION
Started in #265, this PR removes the ContextManager requirement in the base classes. 

We also move all properties definiton from `__enter__` to `__attrs_post_init__`.

ref: https://github.com/cogeotiff/rio-tiler-pds/issues/21