### PR TITLE
remove pkg_resources and refactor ColorMap lookup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## 2.0.0b16 (2020-10-07)
+
+* remove `pkg_resources` (https://github.com/pypa/setuptools/issues/510)
+* refactor default colormap lookup to use pathlib instead of pkg_resources.
+
+Note: We changed the versioning scheme to `{major}.{minor}.{path}{pre}{prenum}`
+
 ## 2.0b15 (2020-10-05)
 
 * Fix missing Exception catching when running task outside threads (ref: https://github.com/developmentseed/titiler/issues/130).

--- a/rio_tiler/__init__.py
+++ b/rio_tiler/__init__.py
@@ -1,7 +1,5 @@
 """rio-tiler."""
 
-import pkg_resources
-
 from . import (  # noqa
     colormap,
     constants,
@@ -16,4 +14,4 @@ from . import (  # noqa
     utils,
 )
 
-version = pkg_resources.get_distribution(__package__).version
+__version__ = "2.0.0-beta.15"

--- a/rio_tiler/cmap_data/__init__.py
+++ b/rio_tiler/cmap_data/__init__.py
@@ -19,29 +19,3 @@ Additional colormaps:
 
 Code inspired from our friends https://github.com/DHI-GRAS/terracotta/blob/master/terracotta/cmaps/__init__.py
 """
-
-import os
-
-from pkg_resources import (
-    DistributionNotFound,
-    Requirement,
-    resource_filename,
-    resource_listdir,
-)
-
-SUFFIX = ".npy"
-
-
-try:
-    PACKAGE = Requirement.parse("rio_tiler")
-    _colormap_dir = resource_filename("rio_tiler", "cmap_data")
-    _file_list = [
-        os.path.join(_colormap_dir, f)
-        for f in resource_listdir(PACKAGE, "rio_tiler/cmap_data")
-    ]
-except DistributionNotFound:  # rio_tiler was not installed, fall back to file system
-    _colormap_dir = os.path.dirname(__file__)
-    _file_list = os.listdir(_colormap_dir)
-
-
-_default_cmaps = [f for f in _file_list if f.endswith(SUFFIX)]

--- a/rio_tiler/colormap.py
+++ b/rio_tiler/colormap.py
@@ -1,14 +1,16 @@
 """rio-tiler colormap functions."""
 
-import os
+import pathlib
 from typing import Dict, List, Sequence, Tuple, Union
 
 import numpy
 
-from .cmap_data import _default_cmaps
 from .errors import ColorMapAlreadyRegistered, InvalidColorMapName, InvalidFormat
 
 EMPTY_COLORMAP: Dict = {i: [0, 0, 0, 0] for i in range(256)}
+
+
+_default_cmaps = list(pathlib.Path(__file__).parent.joinpath("cmap_data").glob("*.npy"))
 
 
 def _update_alpha(cmap: Dict, idx: Sequence[int], alpha: int = 0) -> None:
@@ -132,9 +134,7 @@ class ColorMaps(object):
 
     def __init__(self):
         """Load default CMAP names in a dict."""
-        self._data = {
-            os.path.splitext(os.path.basename(f))[0]: f for f in _default_cmaps
-        }
+        self._data = {f.stem: str(f) for f in _default_cmaps}
 
     def get(self, name: str) -> Dict:
         """Fetch a colormap."""

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,20 @@
+[bumpversion]
+current_version = 2.0.0-beta.15
+commit = True
+tag = True
+tag_name = {new_version}
+parse =
+	(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
+	(?:\-(?P<pre>(?:alpha|beta|rc))(\.(?P<prenum>\d+))?)?
+serialize =
+	{major}.{minor}.{patch}-{pre}.{prenum}
+	{major}.{minor}.{patch}-{pre}
+	{major}.{minor}.{patch}
+
+[bumpversion:rio_tiler:setup.py]
+search = version="{current_version}"
+replace = version="{new_version}"
+
+[bumpversion:file:rio_tiler/__init__.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ extra_reqs = {
 
 setup(
     name="rio-tiler",
-    version="2.0b15",
+    version="2.0.0-beta.15",
     python_requires=">=3.5",
     description="Rasterio plugin to read mercator tiles from Cloud Optimized GeoTIFF.",
     long_description=readme,

--- a/tests/test_cmap.py
+++ b/tests/test_cmap.py
@@ -4,7 +4,7 @@ import numpy
 import pytest
 
 from rio_tiler import colormap
-from rio_tiler.cmap_data import _default_cmaps
+from rio_tiler.colormap import _default_cmaps
 from rio_tiler.errors import (
     ColorMapAlreadyRegistered,
     InvalidColorMapName,


### PR DESCRIPTION
This PR removes any `pkg_resources` import to speed up rio-tiler imports.

## before
![before](https://user-images.githubusercontent.com/10407788/95382723-15f03300-08b8-11eb-8d5f-bca6f9a68434.png)


## after
![after](https://user-images.githubusercontent.com/10407788/95382674-0375f980-08b8-11eb-950c-1ac9696ecbe4.png)
