### PR TITLE
second but now tested Tasks generator with/without threads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: "3.x"
+          python-version: "3.8"
 
       - name: Install dependencies
         run: |

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## 2.0.0b18 (2020-10-22)
+
+* surface dataset.nodata in COGReader.nodata property (https://github.com/cogeotiff/rio-tiler/pull/292)
+* fix non-threaded tasks scheduler/filter (https://github.com/cogeotiff/rio-tiler/pull/291)
+
 ## 2.0.0b17 (2020-10-13)
 
 * switch to morecantile for TMS definition (ref: https://github.com/cogeotiff/rio-tiler/issues/283)

--- a/rio_tiler/mosaic/reader.py
+++ b/rio_tiler/mosaic/reader.py
@@ -73,7 +73,7 @@ def mosaic_reader(
         )
 
     if not chunk_size:
-        chunk_size = threads or len(assets)
+        chunk_size = threads if threads > 1 else len(assets)
 
     assets_used: List[str] = []
 

--- a/rio_tiler/tasks.py
+++ b/rio_tiler/tasks.py
@@ -1,26 +1,29 @@
 """rio_tiler.tasks: tools for handling rio-tiler's future tasks."""
 
 from concurrent import futures
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Generator,
-    Iterator,
-    Optional,
-    Sequence,
-    Tuple,
-    Union,
-)
+from typing import Any, Callable, Dict, Generator, Optional, Sequence, Tuple, Union
 
 import numpy
 
 from .constants import MAX_THREADS
 from .logger import logger
 
-TaskType = Union[
-    Generator[Tuple[Callable, str], None, None], Iterator[Tuple[futures.Future, str]],
-]
+
+class LikeFuture:
+    """Wrap Functions in a future like object."""
+
+    def __init__(self, f: Callable, *args: Any, **kwargs: Any):
+        """Init Object."""
+        self.func = f
+        self.args = args
+        self.kwargs = kwargs
+
+    def result(self):
+        """Run function with args and kwargs."""
+        return self.func(*self.args, **self.kwargs)
+
+
+TaskType = Sequence[Tuple[Union[futures.Future, LikeFuture], str]]
 
 
 def filter_tasks(
@@ -31,8 +34,8 @@ def filter_tasks(
 
     Attributes
     ----------
-    tasks: list or generator
-        Sequence of 'concurrent.futures._base.Future' or 'callable'
+    tasks: list
+        Sequence of 'concurrent.futures._base.Future' or 'LikeFuture'
     allowed_exceptions: Tuple, optional
         List of exceptions which won't be raised.
 
@@ -44,15 +47,9 @@ def filter_tasks(
     if not allowed_exceptions:
         allowed_exceptions = ()
 
-    while True:
+    for (future, asset) in tasks:
         try:
-            future, asset = next(tasks)  # type: ignore
-            if isinstance(future, futures.Future):
-                yield future.result(), asset
-            else:
-                yield future, asset
-        except StopIteration:
-            break
+            yield future.result(), asset
         except allowed_exceptions as err:
             logger.info(err)
             pass
@@ -61,15 +58,15 @@ def filter_tasks(
 def create_tasks(reader: Callable, assets, threads, *args, **kwargs) -> TaskType:
     """Create Future Tasks."""
     if threads and threads > 1:
+        logger.debug(f"Running tasks in ThreadPool with max_workers={threads}")
         with futures.ThreadPoolExecutor(max_workers=threads) as executor:
-            return iter(
-                [
-                    (executor.submit(reader, asset, *args, **kwargs), asset)
-                    for asset in assets
-                ]
-            )
+            return [
+                (executor.submit(reader, asset, *args, **kwargs), asset)
+                for asset in assets
+            ]
     else:
-        return ((reader(asset, *args, **kwargs), asset) for asset in assets)
+        logger.debug(f"Running tasks outside ThreadsPool (max_workers={threads})")
+        return [(LikeFuture(reader, asset, *args, **kwargs), asset) for asset in assets]
 
 
 def multi_arrays(


### PR DESCRIPTION
re-do of https://github.com/cogeotiff/rio-tiler/pull/281

1. tests were poorly written
2. everything was fine when running with `1 thread` because of a `bug`
3. Generator lose its state at the first exception, meaning that we can't really go through all the stack of tasks, it's was just luck that we someone had a first COG returning (yield) before a task raise an exception.

cc @kylebarron @geospatial-jeff 