### PR TITLE
surface dataset.nodata as cog.nodata

### DIFF
--- a/rio_tiler/io/cogeo.py
+++ b/rio_tiler/io/cogeo.py
@@ -122,6 +122,8 @@ class COGReader(BaseReader):
 
         self.dataset = self.dataset or rasterio.open(self.filepath)
 
+        self.nodata = self.nodata if self.nodata is not None else self.dataset.nodata
+
         self.bounds = transform_bounds(
             self.dataset.crs, constants.WGS84_CRS, *self.dataset.bounds, densify_pts=21
         )
@@ -192,7 +194,7 @@ class COGReader(BaseReader):
             nodata_type = "Alpha"
         elif has_mask_band(self.dataset):
             nodata_type = "Mask"
-        elif self.dataset.nodata is not None:
+        elif self.nodata is not None:
             nodata_type = "Nodata"
         else:
             nodata_type = "None"
@@ -661,6 +663,8 @@ class GCPCOGReader(COGReader):
             src_crs=self.src_dataset.gcps[1],
             src_transform=transform.from_gcps(self.src_dataset.gcps[0]),
         )
+
+        self.nodata = self.nodata if self.nodata is not None else self.dataset.nodata
 
         self.bounds = transform_bounds(
             self.dataset.crs, constants.WGS84_CRS, *self.dataset.bounds, densify_pts=21

--- a/tests/test_io_cogeo.py
+++ b/tests/test_io_cogeo.py
@@ -36,6 +36,7 @@ def test_spatial_info_valid():
         assert meta.get("maxzoom") == 8
         assert meta.get("center")
         assert len(meta.get("bounds")) == 4
+        assert cog.nodata == cog.dataset.nodata
     assert cog.dataset.closed
 
     cog = COGReader(COG_NODATA)
@@ -261,8 +262,14 @@ def test_preview_valid():
 def test_COGReader_Options():
     """Set options in reader."""
     with COGReader(COGEO, nodata=1) as cog:
+        assert cog.nodata == 1
         meta = cog.metadata()
         assert meta["statistics"][1]["pc"] == [2720, 6896]
+        assert cog.info()["nodata_type"] == "Nodata"
+
+    with COGReader(COGEO) as cog:
+        assert not cog.nodata
+        assert cog.info()["nodata_type"] == "None"
 
     with COGReader(COGEO, nodata=1) as cog:
         _, mask = cog.tile(43, 25, 7)
@@ -310,6 +317,7 @@ def test_cog_with_internal_gcps():
     """Make sure file gets re-projected using gcps."""
     with GCPCOGReader(COG_GCPS, nodata=0) as cog:
         assert cog.bounds
+        assert cog.nodata == 0
         assert isinstance(cog.src_dataset, DatasetReader)
         assert isinstance(cog.dataset, WarpedVRT)
 


### PR DESCRIPTION
closes #290 

This pr does:
- surface the dataset nodata value in `COGReader.nodata` property
- surface `COGReader.nodata` in `COGReader.info()` result