### PR TITLE
surface allowed_exceptions in mosaic_reader

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 ## NEXT (TBD)
 
 * surface `allowed_exceptions` options in `rio_tiler.mosaic.reader.mosaic_reader` (https://github.com/cogeotiff/rio-tiler/issues/293)
+* add SpatialInfoMixin base class to reduce code duplication (co-author with @geospatial-jeff, https://github.com/cogeotiff/rio-tiler/pull/295)
 
 ## 2.0.0b18 (2020-10-22)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+
+## NEXT (TBD)
+
+* surface `allowed_exceptions` options in `rio_tiler.mosaic.reader.mosaic_reader` (https://github.com/cogeotiff/rio-tiler/issues/293)
+
 ## 2.0.0b18 (2020-10-22)
 
 * surface dataset.nodata in COGReader.nodata property (https://github.com/cogeotiff/rio-tiler/pull/292)

--- a/rio_tiler/mosaic/reader.py
+++ b/rio_tiler/mosaic/reader.py
@@ -53,7 +53,8 @@ def mosaic_reader(
         loop. By default reads from the MAX_THREADS environment variable, and if
         not found defaults to multiprocessing.cpu_count() * 5.
     allowed_exceptions: Tuple, optional
-        List of exceptions which will be ignored.
+        List of exceptions which will be ignored. Default is set to `(TileOutsideBounds,)`.
+        Note: `TileOutsideBounds` is likely to be raised and should be included in the allowed_exceptions.
     kwargs: dict, optional
         tiler specific options.
 

--- a/rio_tiler/mosaic/reader.py
+++ b/rio_tiler/mosaic/reader.py
@@ -20,6 +20,7 @@ def mosaic_reader(
     pixel_selection: Union[Type[MosaicMethodBase], MosaicMethodBase] = FirstMethod,
     chunk_size: Optional[int] = None,
     threads: int = MAX_THREADS,
+    allowed_exceptions: Tuple = (TileOutsideBounds,),
     **kwargs,
 ) -> Tuple[Tuple[numpy.ndarray, numpy.ndarray], Sequence[str]]:
     """
@@ -51,6 +52,8 @@ def mosaic_reader(
         Number of threads to use. If <= 1, runs single threaded without an event
         loop. By default reads from the MAX_THREADS environment variable, and if
         not found defaults to multiprocessing.cpu_count() * 5.
+    allowed_exceptions: Tuple, optional
+        List of exceptions which will be ignored.
     kwargs: dict, optional
         tiler specific options.
 
@@ -80,7 +83,7 @@ def mosaic_reader(
     for chunks in _chunks(assets, chunk_size):
         tasks = create_tasks(reader, chunks, threads, *args, **kwargs)
         for (t, m), asset in filter_tasks(
-            tasks, allowed_exceptions=(TileOutsideBounds,)
+            tasks, allowed_exceptions=allowed_exceptions,
         ):
             assets_used.append(asset)
             t = numpy.ma.array(t)

--- a/rio_tiler/tasks.py
+++ b/rio_tiler/tasks.py
@@ -30,7 +30,7 @@ def filter_tasks(
     Successful task's result
 
     """
-    if not allowed_exceptions:
+    if allowed_exceptions is None:
         allowed_exceptions = ()
 
     for (future, asset) in tasks:
@@ -63,11 +63,14 @@ def multi_arrays(
     reader: Callable,
     *args: Any,
     threads: int = MAX_THREADS,
+    allowed_exceptions: Optional[Tuple] = None,
     **kwargs: Any,
 ) -> Tuple[numpy.ndarray, numpy.ndarray]:
     """Multi array."""
     tasks = create_tasks(reader, assets, threads, *args, **kwargs)
-    data, masks = zip(*[r for r, _ in filter_tasks(tasks)])
+    data, masks = zip(
+        *[r for r, _ in filter_tasks(tasks, allowed_exceptions=allowed_exceptions)]
+    )
     data = numpy.concatenate(data)
     mask = numpy.all(masks, axis=0).astype(numpy.uint8) * 255
     return data, mask
@@ -78,8 +81,12 @@ def multi_values(
     reader: Callable,
     *args: Any,
     threads: int = MAX_THREADS,
+    allowed_exceptions: Optional[Tuple] = None,
     **kwargs: Any,
 ) -> Dict:
     """Multi Values."""
     tasks = create_tasks(reader, assets, threads, *args, **kwargs)
-    return {asset: val for val, asset in filter_tasks(tasks)}
+    return {
+        asset: val
+        for val, asset in filter_tasks(tasks, allowed_exceptions=allowed_exceptions)
+    }

--- a/tests/test_mosaic.py
+++ b/tests/test_mosaic.py
@@ -7,7 +7,7 @@ import numpy
 import pytest
 
 from rio_tiler import mosaic
-from rio_tiler.errors import InvalidMosaicMethod
+from rio_tiler.errors import InvalidMosaicMethod, TileOutsideBounds
 from rio_tiler.io import COGReader
 from rio_tiler.mosaic.methods import defaults
 
@@ -235,6 +235,17 @@ def test_threads():
     xpp = 147
     ypp = 180
     zpp = 9
+
+    with pytest.raises(TileOutsideBounds):
+        mosaic.mosaic_reader(
+            assets,
+            _read_tile,
+            xpp,
+            ypp,
+            zpp,
+            pixel_selection=defaults.MedianMethod,
+            allowed_exceptions=None,
+        )
 
     # Partial tile, some assets should Error with TileOutside bounds
     (tnothread, _), a = mosaic.mosaic_reader(


### PR DESCRIPTION
closes #293 

FYI, we needed this because some items in the sentinel-2 stac API are not present, so we need to add `botocore.errorfactory.NoSuchKey` to the allowed exceptions.