### PR TITLE
Cast output data to uint8 by default

### DIFF
--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -254,7 +254,7 @@ def non_alpha_indexes(src_dst: Union[DatasetReader, DatasetWriter, WarpedVRT]) -
 def linear_rescale(
     image: numpy.ndarray,
     in_range: Tuple[NumType, NumType],
-    out_range: Optional[Tuple[NumType, NumType]] = None,
+    out_range: Tuple[NumType, NumType] = (0, 255),
 ) -> numpy.ndarray:
     """
     Linear rescaling.
@@ -274,12 +274,6 @@ def linear_rescale(
         returns rescaled image array.
 
     """
-    if out_range is None:
-        warnings.warn(
-            "No output range set, using image (0, 255)", UserWarning,
-        )
-        out_range = (0, 255)
-
     imin, imax = in_range
     omin, omax = out_range
     image = numpy.clip(image, imin, imax) - imin

--- a/tests/test_io_cogeo.py
+++ b/tests/test_io_cogeo.py
@@ -387,7 +387,7 @@ def test_imageData_output():
 
         imgr = img.post_process(in_range=(img.data.min(), img.data.max()))
         assert not numpy.array_equal(img.data, imgr.data)
-        assert imgr.data.dtype == "uint16"
+        assert imgr.data.dtype == "uint8"
         assert imgr.data.min() == 0
         assert imgr.data.max() == 255
         assert imgr.bounds == img.bounds


### PR DESCRIPTION
this PR does:
- revert default out_range to (0, 255) in `utils.linear_rescale`
- add default output_dtype to `ImageData.post_process` method when applying linear rescaling.
