### PR TITLE
make colormap holder more immutable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,6 +68,21 @@ with COGReader("/Users/vincentsarago/S-2_20200422_COG.tif") as cog:
 {"percentiles": [19.0, 168.0], "min": 0.0, "max": 255.0, ...}
 ```
 
+* make `rio_tiler.colormap.ColorMap` object immutable. Registering a new colormap will new returns a now instance of ColorMap(https://github.com/cogeotiff/rio-tiler/issues/289).
+* changed the `rio_tiler.colormap.ColorMap.register()` method to take a dictionary as input (instead of name + dict).
+
+```python
+from rio_tiler.colormap import cmap # default cmap
+
+# previous
+cmap.register("acmap", {0: [0, 0, 0, 0], ...})
+
+# Now
+cmap = cmap.register({"acmap": {0: [0, 0, 0, 0], ...}})
+```
+
+* added the possibility to automatically register colormaps stored as `.npy` file in a directory, if `COLORMAP_DIRECTORY` environment variable is set with the name of the directory.
+
 * Update to morecantile 2.0.0
 
 ## 2.0.0b19 (2020-10-26)

--- a/docs/examples/Using-rio-tiler.ipynb
+++ b/docs/examples/Using-rio-tiler.ipynb
@@ -41,7 +41,7 @@
     "# Requirements\n",
     "\n",
     "To be able to run this notebook you'll need the following requirements:\n",
-    "- rio-tiler~= 2.0b"
+    "- rio-tiler~= 2.0"
    ]
   },
   {


### PR DESCRIPTION
closes #289 

This PR does 
- make `ColorMaps` object more immutable (using `deepcopy` to initiate the default colormaps and by returning a new instance when registering a new cmap)
- update the register method to take a dict in input instead of name + colormap (useful if you have multiple cmap to register) **breaking change**
- add `COLORMAP_DIRECTORY` environment variable check to automatically register cmap stored as `.npy` files