### PR TITLE
update ImageData model and raise error on empty mosaic data

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,30 @@
 
+## 2.0.0rc2 (TBD)
+
+* add `data` validation in `rio_tiler.models.ImageData` model. Data MUST be a 3 dimensions array in form of (count, height, width).
+* `mask` is now optional for `rio_tiler.models.ImageData` model, but will be initialized to a default full valid (`255`) array.
+
+```python
+import numpy
+from rio_tiler.models import ImageData
+
+data = numpy.random.rand(3, 10, 10)
+
+img = ImageData(data)
+assert img.mask.all()
+```
+
+* add `metadata` property to `rio_tiler.models.ImageData` model
+
+```python
+img.metadata
+>>> {}
+```
+
+**breaking change**
+
+* `rio_tiler.mosaic.reader.mosaic_reader` now raises `EmptyMosaicError` instead of returning an empty `ImageData`
+
 ## 2.0.0rc1.post1 (2020-11-12)
 
 * Remove `Uint8` data casting before applying `color_formula` in ImageData.render (https://github.com/cogeotiff/rio-tiler/issues/302)

--- a/rio_tiler/errors.py
+++ b/rio_tiler/errors.py
@@ -59,3 +59,7 @@ class InvalidMosaicMethod(RioTilerError):
 
 class ColorMapAlreadyRegistered(Exception):
     """ColorMap is already registered."""
+
+
+class EmptyMosaicError(RioTilerError):
+    """Mosaic method returned empty array."""

--- a/rio_tiler/models.py
+++ b/rio_tiler/models.py
@@ -99,6 +99,19 @@ class ImageData:
     assets: Optional[List[str]] = attr.ib(default=None)
     bounds: Optional[BoundingBox] = attr.ib(default=None, converter=to_coordsbbox)
     crs: Optional[CRS] = attr.ib(default=None)
+    metadata: Optional[Dict] = attr.ib(factory=dict)
+
+    @data.validator
+    def _validate_data(self, attribute, value):
+        """ImageData data has to be a 3d array in form of (count, height, width)"""
+        if not len(value.shape) == 3:
+            raise ValueError(
+                "ImageData data has to be an array in form of (count, height, width)"
+            )
+
+    @mask.default
+    def _default_mask(self):
+        return numpy.zeros((self.height, self.width), dtype="uint8") + 255
 
     def __iter__(self):
         """Allow for variable expansion (``arr, mask = ImageData``)"""


### PR DESCRIPTION
This PR does:
- add `metadata` property in ImageData model
- make `mask` optional on ImageData creation but define a full valid default
- add `data` validation in ImageData creation, Has to be a 3d array

**breaking change**
- raises error on mosaic_reader empty result.