### PR TITLE
Using pystac for reading STAC items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ ENV/
 .benchmarks/
 tests/benchmarks/data/*
 tests/fixtures/mask* 
+.vscode/settings.json

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 ## Next (TBD)
 
 * add `NPZ` output format (ref: https://github.com/cogeotiff/rio-tiler/issues/308)
+* using pystac for STAC item reader (https://github.com/cogeotiff/rio-tiler/issues/212)
 
 ## 2.0.0rc3 (2020-11-24)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ rasterio>=1.1.7
 rio-color
 
 requests
+
+pystac>=0.5.3

--- a/rio_tiler/io/stac.py
+++ b/rio_tiler/io/stac.py
@@ -77,6 +77,7 @@ def _get_assets(
 
 
 def to_stac_item(item: Union[Dict, pystac.Item]) -> pystac.Item:
+    """Convert to STAC item."""
     if isinstance(item, Dict):
         return pystac.Item.from_dict(item)
     return item

--- a/rio_tiler/io/stac.py
+++ b/rio_tiler/io/stac.py
@@ -2,11 +2,11 @@
 
 import functools
 import json
-import pystac
 from typing import Dict, Iterator, Optional, Set, Type
 from urllib.parse import urlparse
 
 import attr
+import pystac
 import requests
 from morecantile import TileMatrixSet
 
@@ -133,9 +133,9 @@ class STACReader(MultiBaseReader):
 
     Methods
     -------
-    tile(0, 0, 0, assets="B01", expression="B01/B02")
+    tile(0, 0, 0, assets="B01", expression="B01/B02")
         Read a map tile from the COG.
-    part((0,10,0,10), assets="B01", expression="B1/B20", max_size=1024)
+    part((0,10,0,10), assets="B01", expression="B1/B20", max_size=1024)
         Read part of the COG.
     preview(assets="B01", max_size=1024)
         Read preview of the COG.
@@ -166,7 +166,9 @@ class STACReader(MultiBaseReader):
     def __attrs_post_init__(self):
         """Define _kwargs, open dataset and get info."""
         self.item = self.item or fetch(self.filepath)
-        self.stac_item = self.stac_item or pystac.Item.from_dict(self.item, self.filepath)
+        self.stac_item = self.stac_item or pystac.Item.from_dict(
+            self.item, self.filepath
+        )
         self.bounds = self.stac_item.bbox
         self.assets = list(
             _get_assets(

--- a/rio_tiler/io/stac.py
+++ b/rio_tiler/io/stac.py
@@ -108,10 +108,8 @@ class STACReader(MultiBaseReader):
     ----------
     filepath: str
         STAC Item path, URL or S3 URL.
-    item: Dict, optional
-        STAC Item as dictionary.
     item: pystac.Item, optional
-        STAC Item.
+         STAC Item.
     minzoom: int, optional
         Set minzoom for the tiles.
     minzoom: int, optional

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ inst_reqs = [
     "rasterio>=1.1.7",
     "requests",
     "rio-color",
+    "pystac>=0.5.3"
 ]
 
 extra_reqs = {

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ inst_reqs = [
     "rasterio>=1.1.7",
     "requests",
     "rio-color",
-    "pystac>=0.5.3"
+    "pystac>=0.5.3",
 ]
 
 extra_reqs = {

--- a/tests/fixtures/stac_relative.json
+++ b/tests/fixtures/stac_relative.json
@@ -1,0 +1,247 @@
+{
+    "stac_extensions": [
+        "disaster",
+        "eo",
+        "sat",
+        "proj",
+        "view"
+    ],
+    "stac_version": "1.0.0-beta.2",
+    "links": [
+        {
+            "type": "application/json; profile=stac-item",
+            "rel": "derived_from",
+            "href": "786-KARI-KOMPSAT3-urn_ogc_def_EOP_KARI_KOMPSAT3_K3_20201112193439_45302_18521139_L1G_Aux_xml.json"
+        }
+    ],
+    "assets": {
+        "metadata": {
+            "type": "text/xml",
+            "roles": [
+                "metadata"
+            ],
+            "href": "urn_ogc_def_EOP_KARI_KOMPSAT3_K3_20201112193439_45302_18521139_L1G_Aux_xml-product/K3_20201112193439_45302_18521139_L1G_Aux.xml"
+        },
+        "MS1": {
+            "type": "image/tiff; application=geotiff",
+            "roles": [
+                "data"
+            ],
+            "href": "urn_ogc_def_EOP_KARI_KOMPSAT3_K3_20201112193439_45302_18521139_L1G_Aux_xml-product/K3_20201112193439_45302_18521139_L1G_B.tif",
+            "gsd": 2.8,
+            "eo:bands": [
+                {
+                    "name": "MS1",
+                    "common_name": "blue",
+                    "center_wavelength": 0.07,
+                    "scale": 36.36363636363637,
+                    "offset": -28.4989,
+                    "eai": 2001.0
+                }
+            ]
+        },
+        "overview": {
+            "type": "image/jpeg",
+            "roles": [
+                "overview"
+            ],
+            "href": "urn_ogc_def_EOP_KARI_KOMPSAT3_K3_20201112193439_45302_18521139_L1G_Aux_xml-product/K3_20201112193439_45302_18521139_L1G_br.jpg"
+        },
+        "MS2": {
+            "type": "image/tiff; application=geotiff",
+            "roles": [
+                "data"
+            ],
+            "href": "urn_ogc_def_EOP_KARI_KOMPSAT3_K3_20201112193439_45302_18521139_L1G_Aux_xml-product/K3_20201112193439_45302_18521139_L1G_G.tif",
+            "gsd": 2.8,
+            "eo:bands": [
+                {
+                    "name": "MS2",
+                    "common_name": "green",
+                    "center_wavelength": 0.08,
+                    "scale": 26.17801047120419,
+                    "offset": -27.3846,
+                    "eai": 1875.0
+                }
+            ]
+        },
+        "MS4": {
+            "type": "image/tiff; application=geotiff",
+            "roles": [
+                "data"
+            ],
+            "href": "urn_ogc_def_EOP_KARI_KOMPSAT3_K3_20201112193439_45302_18521139_L1G_Aux_xml-product/K3_20201112193439_45302_18521139_L1G_N.tif",
+            "gsd": 2.8,
+            "eo:bands": [
+                {
+                    "name": "MS4",
+                    "common_name": "nir",
+                    "center_wavelength": 0.14,
+                    "scale": 52.083333333333336,
+                    "offset": -13.591,
+                    "eai": 1027.0
+                }
+            ]
+        },
+        "PAN": {
+            "type": "image/tiff; application=geotiff",
+            "roles": [
+                "data"
+            ],
+            "href": "urn_ogc_def_EOP_KARI_KOMPSAT3_K3_20201112193439_45302_18521139_L1G_Aux_xml-product/K3_20201112193439_45302_18521139_L1G_P.tif",
+            "gsd": 0.7,
+            "eo:bands": [
+                {
+                    "name": "PAN",
+                    "common_name": "pan",
+                    "center_wavelength": 0.45
+                }
+            ]
+        },
+        "MS3": {
+            "type": "image/tiff; application=geotiff",
+            "roles": [
+                "data"
+            ],
+            "href": "urn_ogc_def_EOP_KARI_KOMPSAT3_K3_20201112193439_45302_18521139_L1G_Aux_xml-product/K3_20201112193439_45302_18521139_L1G_R.tif",
+            "gsd": 2.8,
+            "eo:bands": [
+                {
+                    "name": "MS3",
+                    "common_name": "red",
+                    "center_wavelength": 0.06,
+                    "scale": 34.013605442176875,
+                    "offset": -21.6854,
+                    "eai": 1525.0
+                }
+            ]
+        },
+        "thumbnail": {
+            "type": "image/jpeg",
+            "roles": [
+                "thumbnail"
+            ],
+            "href": "urn_ogc_def_EOP_KARI_KOMPSAT3_K3_20201112193439_45302_18521139_L1G_Aux_xml-product/K3_20201112193439_45302_18521139_L1G_th.jpg"
+        }
+    },
+    "type": "Feature",
+    "id": "K3_20201112193439_45302_18521139_L1G",
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -92.64663661,
+                    18.576395368
+                ],
+                [
+                    -92.529930348,
+                    18.57614059
+                ],
+                [
+                    -92.413226243,
+                    18.575813599
+                ],
+                [
+                    -92.412722213,
+                    18.722456862
+                ],
+                [
+                    -92.529526555,
+                    18.722786621
+                ],
+                [
+                    -92.646333063,
+                    18.723043555
+                ],
+                [
+                    -92.64663661,
+                    18.576395368
+                ]
+            ]
+        ]
+    },
+    "properties": {
+        "datetime": "2020-11-12T19:34:47.8741569+00:00",
+        "start_datetime": "2020-11-12T19:34:47.8741569+00:00",
+        "end_datetime": "2020-11-12T19:34:50.2062721+00:00",
+        "updated": "2020-12-10T21:58:38.3728271Z",
+        "platform": "kompsat-3",
+        "constellation": "kompsat-3",
+        "mission": "kompsat-3",
+        "instruments": [
+            "aeiss"
+        ],
+        "gsd": 0.7,
+        "title": "dummy",
+        "description": "<div style=\"float: left; width: 64px;\"><img width=\"64px\" src=\"https://d1nhio0ox7pgb.cloudfront.net/_img/g_collection_png/standard/128x128/satellite.png\" /></div>\n\n### dummy\n\n* Platform **kompsat-3**\n* Instruments **aeiss**\n* Sensing Time **[11/12/2020 19:34:47]**\n* Created **1/1/0001 12:00:00 AM**\n* Updated **12/10/2020 9:58:38 PM**\n",
+        "eo:cloud_cover": 0.0,
+        "sat:absolute_orbit": 45302,
+        "sat:relative_orbit": 45302,
+        "sat:orbit_state": "ascending",
+        "proj:epsg": 32615,
+        "proj:wkt2": "PROJCS[\"WGS 84 / UTM zone 15N\", GEOGCS[\"WGS 84\", DATUM[\"World Geodetic System 1984\", SPHEROID[\"WGS 84\", 6378137, 298.257223563, AUTHORITY[\"EPSG\", \"7030\"]], AUTHORITY[\"EPSG\", \"6326\"]], PRIMEM[\"Greenwich\", 0, AUTHORITY[\"EPSG\", \"8901\"]], UNIT[\"degree\", 0.017453292519943295, AUTHORITY[\"EPSG\", \"9102\"]], AUTHORITY[\"EPSG\", \"4326\"]], UNIT[\"metre\", 1, AUTHORITY[\"EPSG\", \"9001\"]], PROJECTION[\"UTM15N\", AUTHORITY[\"EPSG\", \"32615\"]], PARAMETER[\"latitude_of_origin\", 0], PARAMETER[\"central_meridian\", -93], PARAMETER[\"scale_factor\", 0.9996], PARAMETER[\"false_easting\", 500000], PARAMETER[\"false_northing\", 0], AUTHORITY[\"EPSG\", \"32615\"], AXIS[\"East\", EAST], AXIS[\"North\", NORTH]]",
+        "view:off_nadir": 30.864219939,
+        "view:incidence_angle": 34.605545581,
+        "view:azimuth": 318.194222473,
+        "view:sun_azimuth": 212.9437888826261,
+        "view:sun_elevation": 46.962222523232704,
+        "proc:level": "Level1G",
+        "product_type": "PAN_MS_L1G",
+        "eo:bands": [
+            {
+                "name": "MS1",
+                "common_name": "blue",
+                "center_wavelength": 0.07,
+                "scale": 36.36363636363637,
+                "offset": -28.4989,
+                "eai": 2001.0
+            },
+            {
+                "name": "MS2",
+                "common_name": "green",
+                "center_wavelength": 0.08,
+                "scale": 26.17801047120419,
+                "offset": -27.3846,
+                "eai": 1875.0
+            },
+            {
+                "name": "MS4",
+                "common_name": "nir",
+                "center_wavelength": 0.14,
+                "scale": 52.083333333333336,
+                "offset": -13.591,
+                "eai": 1027.0
+            },
+            {
+                "name": "PAN",
+                "common_name": "pan",
+                "center_wavelength": 0.45
+            },
+            {
+                "name": "MS3",
+                "common_name": "red",
+                "center_wavelength": 0.06,
+                "scale": 34.013605442176875,
+                "offset": -21.6854,
+                "eai": 1525.0
+            }
+        ],
+        "disaster:class": "Acquisition",
+        "status": {
+            "stage": "dataset",
+            "message": null
+        },
+        "disaster:call_ids": [
+            786
+        ],
+        "cos2:xml": null,
+        "cos2:id": "786-KARI-KOMPSAT3-urn_ogc_def_EOP_KARI_KOMPSAT3_K3_20201112193439_45302_18521139_L1G_Aux_xml"
+    },
+    "bbox": [
+        -92.64663661,
+        18.575813599,
+        -92.412722213,
+        18.723043555
+    ]
+}

--- a/tests/test_io_cogeo.py
+++ b/tests/test_io_cogeo.py
@@ -183,15 +183,7 @@ def test_tile_valid_default():
         data, mask = cog.tile(43, 24, 7, indexes=1)
         assert data.shape == (1, 256, 256)
 
-        data, mask = cog.tile(
-            43,
-            24,
-            7,
-            indexes=(
-                1,
-                1,
-            ),
-        )
+        data, mask = cog.tile(43, 24, 7, indexes=(1, 1,))
         assert data.shape == (2, 256, 256)
 
 
@@ -220,14 +212,7 @@ def test_point_valid():
         pts = cog.point(lon, lat, indexes=1)
         assert len(pts) == 1
 
-        pts = cog.point(
-            lon,
-            lat,
-            indexes=(
-                1,
-                1,
-            ),
-        )
+        pts = cog.point(lon, lat, indexes=(1, 1,))
         assert len(pts) == 2
 
 
@@ -259,13 +244,7 @@ def test_area_valid():
         data, mask = cog.part(bbox, indexes=1)
         assert data.shape == (1, 11, 41)
 
-        data, mask = cog.part(
-            bbox,
-            indexes=(
-                1,
-                1,
-            ),
-        )
+        data, mask = cog.part(bbox, indexes=(1, 1,))
         assert data.shape == (2, 11, 41)
 
 
@@ -288,13 +267,7 @@ def test_preview_valid():
         data, mask = cog.preview(max_size=128, indexes=1)
         assert data.shape == (1, 128, 128)
 
-        data, mask = cog.preview(
-            max_size=128,
-            indexes=(
-                1,
-                1,
-            ),
-        )
+        data, mask = cog.preview(max_size=128, indexes=(1, 1,))
         assert data.shape == (2, 128, 128)
 
 
@@ -507,13 +480,7 @@ def test_feature_valid():
         img = cog.feature(feature, indexes=1)
         assert img.data.shape == (1, 349, 1024)
 
-        img = cog.feature(
-            feature,
-            indexes=(
-                1,
-                1,
-            ),
-        )
+        img = cog.feature(feature, indexes=(1, 1,))
         assert img.data.shape == (2, 349, 1024)
 
         # feature overlaping on mask area

--- a/tests/test_io_cogeo.py
+++ b/tests/test_io_cogeo.py
@@ -183,7 +183,15 @@ def test_tile_valid_default():
         data, mask = cog.tile(43, 24, 7, indexes=1)
         assert data.shape == (1, 256, 256)
 
-        data, mask = cog.tile(43, 24, 7, indexes=(1, 1,))
+        data, mask = cog.tile(
+            43,
+            24,
+            7,
+            indexes=(
+                1,
+                1,
+            ),
+        )
         assert data.shape == (2, 256, 256)
 
 
@@ -212,7 +220,14 @@ def test_point_valid():
         pts = cog.point(lon, lat, indexes=1)
         assert len(pts) == 1
 
-        pts = cog.point(lon, lat, indexes=(1, 1,))
+        pts = cog.point(
+            lon,
+            lat,
+            indexes=(
+                1,
+                1,
+            ),
+        )
         assert len(pts) == 2
 
 
@@ -244,7 +259,13 @@ def test_area_valid():
         data, mask = cog.part(bbox, indexes=1)
         assert data.shape == (1, 11, 41)
 
-        data, mask = cog.part(bbox, indexes=(1, 1,))
+        data, mask = cog.part(
+            bbox,
+            indexes=(
+                1,
+                1,
+            ),
+        )
         assert data.shape == (2, 11, 41)
 
 
@@ -267,7 +288,13 @@ def test_preview_valid():
         data, mask = cog.preview(max_size=128, indexes=1)
         assert data.shape == (1, 128, 128)
 
-        data, mask = cog.preview(max_size=128, indexes=(1, 1,))
+        data, mask = cog.preview(
+            max_size=128,
+            indexes=(
+                1,
+                1,
+            ),
+        )
         assert data.shape == (2, 128, 128)
 
 
@@ -480,7 +507,13 @@ def test_feature_valid():
         img = cog.feature(feature, indexes=1)
         assert img.data.shape == (1, 349, 1024)
 
-        img = cog.feature(feature, indexes=(1, 1,))
+        img = cog.feature(
+            feature,
+            indexes=(
+                1,
+                1,
+            ),
+        )
         assert img.data.shape == (2, 349, 1024)
 
         # feature overlaping on mask area

--- a/tests/test_io_stac.py
+++ b/tests/test_io_stac.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import pytest
 import rasterio
+import pystac
 
 from rio_tiler.errors import (
     ExpressionMixingWarning,
@@ -19,7 +20,7 @@ PREFIX = os.path.join(os.path.dirname(__file__), "fixtures")
 STAC_PATH = os.path.join(PREFIX, "stac.json")
 
 with open(STAC_PATH) as f:
-    stac_item = json.loads(f.read())
+    stac_item = pystac.Item.from_dict(json.loads(f.read()))
 
 
 def mock_rasterio_open(asset):

--- a/tests/test_io_stac.py
+++ b/tests/test_io_stac.py
@@ -6,7 +6,6 @@ from unittest.mock import patch
 
 import pytest
 import rasterio
-import pystac
 
 from rio_tiler.errors import (
     ExpressionMixingWarning,
@@ -20,7 +19,7 @@ PREFIX = os.path.join(os.path.dirname(__file__), "fixtures")
 STAC_PATH = os.path.join(PREFIX, "stac.json")
 
 with open(STAC_PATH) as f:
-    stac_item = pystac.Item.from_dict(json.loads(f.read()))
+    item = json.loads(f.read())
 
 
 def mock_rasterio_open(asset):
@@ -46,7 +45,7 @@ def test_fetch_stac(requests, s3_get):
     s3_get.assert_not_called()
 
     # Load from dict
-    with STACReader(None, item=stac_item) as stac:
+    with STACReader(None, item=item) as stac:
         assert stac.minzoom == 0
         assert stac.maxzoom == 30
         assert not stac.filepath

--- a/tests/test_io_stac.py
+++ b/tests/test_io_stac.py
@@ -3,7 +3,6 @@
 import json
 import os
 from unittest.mock import patch
-from urllib.parse import urlparse
 
 import pytest
 import rasterio

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ ignore_missing_imports = True
 [tool:isort]
 profile=black
 known_first_party = rio_tiler
-known_third_party = rasterio,mercantile,supermercado,affine
+known_third_party = rasterio,mercantile,supermercado,affine,pystac
 default_section = THIRDPARTY
 
 # Release tooling


### PR DESCRIPTION
**Proposed Changes:**

***Using pystac***
using [pystac](https://github.com/stac-utils/pystac) to manipulate stac items.
Among other features, it allows to resolve absolute url from relative links in assets. It should fix https://github.com/cogeotiff/rio-tiler/issues/212

**PR Checklist:**

- [X] This PR has **no** breaking changes.
- [X] I have added my changes to the [CHANGELOG](https://github.com/cogeotiff/rio-tiler/blob/master/CHANGES.md)