### PR TITLE
update morecantile

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 * add [pystac](https://pystac.readthedocs.io/en/latest/) for STAC item reader (author @emmanuelmathot, https://github.com/cogeotiff/rio-tiler/issues/212)
 * delete deprecated function: `rio_tiler.reader.tile`, `rio_tiler.utils.tile_exits` and `rio_tiler.utils.geotiff_options`
 * deprecated `rio_tiler.mercator` submodule (https://github.com/cogeotiff/rio-tiler/issues/315)
+* update morecantile version to 2.1, which has better `tms.zoom_for_res` definition.
 
 ## 2.0.0rc3 (2020-11-24)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ numexpr
 numpy
 
 mercantile
-morecantile>=2.0,<2.1
+morecantile>=2.1,<2.2
 
 rasterio>=1.1.7
 rio-color

--- a/rio_tiler/io/cogeo.py
+++ b/rio_tiler/io/cogeo.py
@@ -145,13 +145,19 @@ class COGReader(BaseReader):
 
     def get_zooms(self, tilesize: int = 256) -> Tuple[int, int]:
         """Calculate raster min/max zoom level."""
-        dst_affine, w, h = calculate_default_transform(
-            self.dataset.crs,
-            self.tms.crs,
-            self.dataset.width,
-            self.dataset.height,
-            *self.dataset.bounds,
-        )
+        if self.dataset.crs != self.tms.crs:
+            dst_affine, w, h = calculate_default_transform(
+                self.dataset.crs,
+                self.tms.crs,
+                self.dataset.width,
+                self.dataset.height,
+                *self.dataset.bounds,
+            )
+        else:
+            dst_affine = list(self.dataset.transform)
+            w = self.dataset.width
+            h = self.dataset.height
+
         resolution = max(abs(dst_affine[0]), abs(dst_affine[4]))
         maxzoom = self.tms.zoom_for_res(resolution)
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ inst_reqs = [
     "numexpr",
     "numpy",
     "mercantile",
-    "morecantile>=2.0,<2.1",
+    "morecantile>=2.1,<2.2",
     "rasterio>=1.1.7",
     "requests",
     "rio-color",

--- a/tests/test_io_async.py
+++ b/tests/test_io_async.py
@@ -107,8 +107,8 @@ async def test_async():
         assert info == dataset.info()
 
         meta = cog.spatial_info
-        assert meta.minzoom == 4
-        assert meta.maxzoom == 8
+        assert meta.minzoom == 5
+        assert meta.maxzoom == 9
 
         assert await cog.stats(5, 95)
         assert await cog.metadata(2, 98)

--- a/tests/test_io_cogeo.py
+++ b/tests/test_io_cogeo.py
@@ -46,9 +46,9 @@ def test_spatial_info_valid():
     with COGReader(COG_NODATA) as cog:
         assert not cog.dataset.closed
         meta = cog.spatial_info
-        assert meta["minzoom"] == 4
-        assert meta.minzoom == 4
-        assert meta.maxzoom == 8
+        assert meta["minzoom"] == 5
+        assert meta.minzoom == 5
+        assert meta.maxzoom == 9
         assert cog.nodata == cog.dataset.nodata
     assert cog.dataset.closed
 
@@ -60,11 +60,11 @@ def test_spatial_info_valid():
     with COGReader(COG_NODATA, minzoom=3) as cog:
         meta = cog.spatial_info
         assert meta.minzoom == 3
-        assert meta.maxzoom == 8
+        assert meta.maxzoom == 9
 
     with COGReader(COG_NODATA, maxzoom=12) as cog:
         meta = cog.spatial_info
-        assert meta.minzoom == 4
+        assert meta.minzoom == 5
         assert meta.maxzoom == 12
 
     with COGReader(COG_NODATA, minzoom=3, maxzoom=12) as cog:
@@ -344,8 +344,8 @@ def test_cog_with_internal_gcps():
         assert isinstance(cog.src_dataset, DatasetReader)
         assert isinstance(cog.dataset, WarpedVRT)
 
-        assert cog.minzoom == 6
-        assert cog.maxzoom == 9
+        assert cog.minzoom == 7
+        assert cog.maxzoom == 10
 
         metadata = cog.info()
         assert len(metadata.band_metadata) == 1


### PR DESCRIPTION
The new morecantile version `2.1` brings a better definition for the zoom levels (`tms.zoom_for_res`) 