### PR TITLE
drop python 3.5

### DIFF
--- a/docs/v2_migration.md
+++ b/docs/v2_migration.md
@@ -7,7 +7,7 @@ document aims to help with migrating your code to use `rio-tiler` 2.0.
 First and foremost is the drop of Python 2 support. We are in 2020 and Python 2
 is [officially dead](https://pythonclock.org). For ease of maintenance we
 decided to remove Python 2 support and to continue with only Python 3. **Python
-3.5 or later is required.**
+3.6 or later is required.**
 
 If you need help moving from Python 2 to 3 check out the official transition
 [documentation](https://docs.python.org/3/howto/pyporting.html).

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ extra_reqs = {
 setup(
     name="rio-tiler",
     version="2.0.0rc4",
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     description="Rasterio plugin to read mercator tiles from Cloud Optimized GeoTIFF.",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
We never really tested rio-tiler support in python 3.5 and I think in 2021 it's safe require python>=3.6.

and rasterio also require python>=3.6 https://github.com/mapbox/rasterio/blob/master/setup.py#L422