### PR TITLE
Correct bounds to be aligned with internal block

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 ## 2.0.2 (2021-02-17)
 
 * fix bad mask datatype returned by mosaic methods (https://github.com/cogeotiff/rio-tiler/pull/353)
+* align WarpedVRT with internal blocks when needed. This is to reduce the number of GET requests need for VSI files (https://github.com/cogeotiff/rio-tiler/pull/345)
 
 ## 2.0.1 (2021-02-04)
 

--- a/rio_tiler/reader.py
+++ b/rio_tiler/reader.py
@@ -18,7 +18,13 @@ from . import constants
 from .errors import AlphaBandWarning, PointOutsideBounds, TileOutsideBounds
 from .utils import _requested_tile_aligned_with_internal_tile as is_aligned
 from .utils import _stats as raster_stats
-from .utils import get_vrt_transform, has_alpha_band, has_mask_band, non_alpha_indexes
+from .utils import (
+    get_aligned_bounds,
+    get_vrt_transform,
+    has_alpha_band,
+    has_mask_band,
+    non_alpha_indexes,
+)
 
 
 def read(
@@ -174,6 +180,8 @@ def part(
             raise TileOutsideBounds(
                 "Dataset covers less than {:.0f}% of tile".format(cover_ratio * 100)
             )
+
+    bounds = get_aligned_bounds(src_dst, bounds, height, width, bounds_crs=dst_crs)
 
     vrt_transform, vrt_width, vrt_height = get_vrt_transform(
         src_dst, bounds, height, width, dst_crs=dst_crs

--- a/rio_tiler/reader.py
+++ b/rio_tiler/reader.py
@@ -18,13 +18,7 @@ from . import constants
 from .errors import AlphaBandWarning, PointOutsideBounds, TileOutsideBounds
 from .utils import _requested_tile_aligned_with_internal_tile as is_aligned
 from .utils import _stats as raster_stats
-from .utils import (
-    get_aligned_bounds,
-    get_vrt_transform,
-    has_alpha_band,
-    has_mask_band,
-    non_alpha_indexes,
-)
+from .utils import get_vrt_transform, has_alpha_band, has_mask_band, non_alpha_indexes
 
 
 def read(
@@ -181,8 +175,6 @@ def part(
                 "Dataset covers less than {:.0f}% of tile".format(cover_ratio * 100)
             )
 
-    bounds = get_aligned_bounds(src_dst, bounds, height, width, bounds_crs=dst_crs)
-
     vrt_transform, vrt_width, vrt_height = get_vrt_transform(
         src_dst, bounds, height, width, dst_crs=dst_crs
     )
@@ -201,7 +193,7 @@ def part(
 
     out_height = height or vrt_height
     out_width = width or vrt_width
-    if padding > 0 and not is_aligned(src_dst, bounds, out_height, out_width):
+    if padding > 0 and not is_aligned(src_dst, bounds, out_height, out_width, dst_crs):
         vrt_transform = vrt_transform * Affine.translation(-padding, -padding)
         orig_vrt_height = vrt_height
         orig_vrt_width = vrt_width

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -245,6 +245,46 @@ def linear_rescale(
     return image * (omax - omin) + omin
 
 
+def get_aligned_bounds(
+    src_dst: Union[DatasetReader, DatasetWriter, WarpedVRT],
+    bounds: Tuple[float, float, float, float],
+    height: Optional[int] = None,
+    width: Optional[int] = None,
+    bounds_crs: CRS = WEB_MERCATOR_CRS,
+    threshold: float = 0.0001,
+):
+    """Correct bounds to align with internal block bounds."""
+    if not src_dst.is_tiled:
+        return bounds
+
+    if src_dst.crs != bounds_crs:
+        return bounds
+
+    col_off, row_off, w, h = windows.from_bounds(
+        *bounds, transform=src_dst.transform, width=width, height=height,
+    ).flatten()
+
+    if round(w) % 64 and round(h) % 64:
+        return bounds
+
+    if (src_dst.width - round(col_off)) % 64:
+        return bounds
+
+    if (src_dst.height - round(row_off)) % 64:
+        return bounds
+
+    w = windows.Window(
+        col_off=round(col_off), row_off=round(row_off), width=round(w), height=round(h),
+    )
+
+    new_bounds = src_dst.window_bounds(w)
+    for ii in range(4):
+        if abs(new_bounds[ii] - bounds[ii]) > threshold:
+            return bounds
+
+    return new_bounds
+
+
 def _requested_tile_aligned_with_internal_tile(
     src_dst: Union[DatasetReader, DatasetWriter, WarpedVRT],
     bounds: Tuple[float, float, float, float],

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -1,6 +1,5 @@
 """rio_tiler.utils: utility functions."""
 
-import math
 from io import BytesIO
 from typing import Any, Dict, Optional, Sequence, Tuple, Union
 
@@ -178,16 +177,19 @@ def get_vrt_transform(
             round(w, window_precision),
             round(h, window_precision),
         )
+        print(w)
         bounds = src_dst.window_bounds(w)
 
     w, s, e, n = bounds
 
+    # TODO: Explain
     if not height or not width:
-        vrt_width = math.ceil((e - w) / dst_transform.a)
-        vrt_height = math.ceil((s - n) / dst_transform.e)
+        vrt_width = max(1, round((e - w) / dst_transform.a))
+        vrt_height = max(1, round((s - n) / dst_transform.e))
         vrt_transform = from_bounds(w, s, e, n, vrt_width, vrt_height)
         return vrt_transform, vrt_width, vrt_height
 
+    # TODO: Explain
     tile_transform = from_bounds(w, s, e, n, width, height)
     w_res = (
         tile_transform.a
@@ -200,10 +202,12 @@ def get_vrt_transform(
         else dst_transform.e
     )
 
-    vrt_width = math.ceil((e - w) / w_res)
-    vrt_height = math.ceil((s - n) / h_res)
+    # TODO: Explain
+    vrt_width = max(1, round((e - w) / w_res))
+    vrt_height = max(1, round((s - n) / h_res))
     vrt_transform = from_bounds(w, s, e, n, vrt_width, vrt_height)
 
+    print(vrt_width, vrt_height)
     return vrt_transform, vrt_width, vrt_height
 
 

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -177,7 +177,6 @@ def get_vrt_transform(
             round(w, window_precision),
             round(h, window_precision),
         )
-        print(w)
         bounds = src_dst.window_bounds(w)
 
     w, s, e, n = bounds
@@ -207,7 +206,6 @@ def get_vrt_transform(
     vrt_height = max(1, round((s - n) / h_res))
     vrt_transform = from_bounds(w, s, e, n, vrt_width, vrt_height)
 
-    print(vrt_width, vrt_height)
     return vrt_transform, vrt_width, vrt_height
 
 

--- a/tests/test_io_async.py
+++ b/tests/test_io_async.py
@@ -129,7 +129,7 @@ async def test_async():
             73.50183615350426,
         )
         data, mask = await cog.part(bbox)
-        assert data.shape == (1, 11, 41)
+        assert data.shape == (1, 11, 40)
 
         data, mask = await cog.preview(max_size=128)
         assert data.shape == (1, 128, 128)
@@ -159,4 +159,4 @@ async def test_async():
         }
 
         img = await cog.feature(feature)
-        assert img.data.shape == (1, 349, 1024)
+        assert img.data.shape == (1, 348, 1024)

--- a/tests/test_io_cogeo.py
+++ b/tests/test_io_cogeo.py
@@ -240,26 +240,26 @@ def test_area_valid():
     )
     with COGReader(COG_NODATA) as cog:
         data, mask = cog.part(bbox)
-        assert data.shape == (1, 11, 41)
+        assert data.shape == (1, 11, 40)
 
         data, mask = cog.part(bbox, dst_crs=cog.dataset.crs)
-        assert data.shape == (1, 29, 30)
+        assert data.shape == (1, 28, 30)
 
         data, mask = cog.part(bbox, max_size=30)
         assert data.shape == (1, 9, 30)
 
         data, mask = cog.part(bbox, expression="b1*2,b1-100")
-        assert data.shape == (2, 11, 41)
+        assert data.shape == (2, 11, 40)
 
         with pytest.warns(ExpressionMixingWarning):
             data, _ = cog.part(bbox, indexes=(1, 2, 3), expression="b1*2")
-            assert data.shape == (1, 11, 41)
+            assert data.shape == (1, 11, 40)
 
         data, mask = cog.part(bbox, indexes=1)
-        assert data.shape == (1, 11, 41)
+        assert data.shape == (1, 11, 40)
 
         data, mask = cog.part(bbox, indexes=(1, 1,))
-        assert data.shape == (2, 11, 41)
+        assert data.shape == (2, 11, 40)
 
 
 def test_preview_valid():
@@ -461,13 +461,13 @@ def test_imageData_output():
             73.50183615350426,
         )
         img = cog.part(bbox)
-        assert img.data.shape == (1, 11, 41)
+        assert img.data.shape == (1, 11, 40)
         meta = parse_img(img.render(img_format="GTiff"))
         assert meta["crs"] == WGS84_CRS
         assert img.bounds == bbox
 
         img = cog.part(bbox, dst_crs=cog.dataset.crs)
-        assert img.data.shape == (1, 29, 30)
+        assert img.data.shape == (1, 28, 30)
         meta = parse_img(img.render(img_format="GTiff"))
         assert meta["crs"] == cog.dataset.crs
         assert not img.bounds == bbox
@@ -507,7 +507,7 @@ def test_feature_valid():
 
     with COGReader(COG_NODATA) as cog:
         img = cog.feature(feature)
-        assert img.data.shape == (1, 349, 1024)
+        assert img.data.shape == (1, 348, 1024)
 
         img = cog.feature(feature, dst_crs=cog.dataset.crs)
         assert img.data.shape == (1, 1024, 869)
@@ -516,17 +516,17 @@ def test_feature_valid():
         assert img.data.shape == (1, 11, 30)
 
         img = cog.feature(feature, expression="b1*2,b1-100")
-        assert img.data.shape == (2, 349, 1024)
+        assert img.data.shape == (2, 348, 1024)
 
         with pytest.warns(ExpressionMixingWarning):
             img = cog.feature(feature, indexes=(1, 2, 3), expression="b1*2")
-            assert img.data.shape == (1, 349, 1024)
+            assert img.data.shape == (1, 348, 1024)
 
         img = cog.feature(feature, indexes=1)
-        assert img.data.shape == (1, 349, 1024)
+        assert img.data.shape == (1, 348, 1024)
 
         img = cog.feature(feature, indexes=(1, 1,))
-        assert img.data.shape == (2, 349, 1024)
+        assert img.data.shape == (2, 348, 1024)
 
         # feature overlaping on mask area
         mask_feat = {

--- a/tests/test_io_stac.py
+++ b/tests/test_io_stac.py
@@ -174,16 +174,16 @@ def test_part_valid(rio):
             stac.part(bbox)
 
         data, mask = stac.part(bbox, assets="green")
-        assert data.shape == (1, 73, 84)
-        assert mask.shape == (73, 84)
+        assert data.shape == (1, 73, 83)
+        assert mask.shape == (73, 83)
 
         data, mask = stac.part(bbox, assets=("green",))
-        assert data.shape == (1, 73, 84)
-        assert mask.shape == (73, 84)
+        assert data.shape == (1, 73, 83)
+        assert mask.shape == (73, 83)
 
         data, mask = stac.part(bbox, expression="green/red")
-        assert data.shape == (1, 73, 84)
-        assert mask.shape == (73, 84)
+        assert data.shape == (1, 73, 83)
+        assert mask.shape == (73, 83)
 
         data, mask = stac.part(bbox, assets="green", max_size=30)
         assert data.shape == (1, 27, 30)
@@ -191,7 +191,7 @@ def test_part_valid(rio):
 
         with pytest.warns(ExpressionMixingWarning):
             data, _ = stac.part(bbox, assets=("green", "red"), expression="green/red")
-            assert data.shape == (1, 73, 84)
+            assert data.shape == (1, 73, 83)
 
 
 @patch("rio_tiler.io.cogeo.rasterio")
@@ -352,16 +352,16 @@ def test_feature_valid(rio):
             stac.feature(feat)
 
         data, mask = stac.feature(feat, assets="green")
-        assert data.shape == (1, 119, 97)
-        assert mask.shape == (119, 97)
+        assert data.shape == (1, 118, 96)
+        assert mask.shape == (118, 96)
 
         data, mask = stac.feature(feat, assets=("green",))
-        assert data.shape == (1, 119, 97)
-        assert mask.shape == (119, 97)
+        assert data.shape == (1, 118, 96)
+        assert mask.shape == (118, 96)
 
         data, mask = stac.feature(feat, expression="green/red")
-        assert data.shape == (1, 119, 97)
-        assert mask.shape == (119, 97)
+        assert data.shape == (1, 118, 96)
+        assert mask.shape == (118, 96)
 
         data, mask = stac.feature(feat, assets="green", max_size=30)
         assert data.shape == (1, 30, 25)
@@ -371,7 +371,7 @@ def test_feature_valid(rio):
             data, _ = stac.feature(
                 feat, assets=("green", "red"), expression="green/red"
             )
-            assert data.shape == (1, 119, 97)
+            assert data.shape == (1, 118, 96)
 
 
 def test_relative_assets():

--- a/tests/test_mosaic.py
+++ b/tests/test_mosaic.py
@@ -386,8 +386,8 @@ def test_mosaic_tiler_with_imageDataClass():
     img, assets_used = mosaic.mosaic_reader(
         assets, _read_part, bbox=bbox, dst_crs=crs1, bounds_crs=WGS84_CRS, max_size=1024
     )
-    assert img.data.shape == (3, 690, 1024)
-    assert img.mask.shape == (690, 1024)
+    assert img.data.shape == (3, 689, 1024)
+    assert img.mask.shape == (689, 1024)
     assert img.mask.any()
     assert assets_used == img.assets == assets
     assert img.crs == crs1 == crs2

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -77,8 +77,8 @@ def test_get_vrt_transform_valid():
         )
         assert vrt_transform[2] == -11663507.036777973
         assert vrt_transform[5] == 4715037.199028169
-        assert vrt_width == 100
-        assert vrt_height == 100
+        assert vrt_width == 99
+        assert vrt_height == 99
 
         vrt_transform, vrt_width, vrt_height = utils.get_vrt_transform(
             src, bounds, 256, 256
@@ -105,7 +105,7 @@ def test_get_vrt_transform_valid4326():
     assert vrt_transform[2] == -104.77523803710938
     assert vrt_transform[5] == 38.954069293441066
     assert vrt_width == 420
-    assert vrt_height == 327
+    assert vrt_height == 326
 
 
 def test_statsFunction_valid():


### PR DESCRIPTION
closes #338 

To be discussed

This PR adds a check to see if the requested bounds are almost aligned with the internal block. If yes then we use the bounds the block. 

```python
import rasterio
from rasterio import windows
import morecantile

tms = morecantile.tms.get("WebMercatorQuad")
morecantile_bounds = list(tms.xy_bounds(10, 9, 5))
print("morecantile boumds: ", morecantile_bounds)


src_path = "https://rio-tiler-dev.s3.amazonaws.com/data/eu_webAligned_256pxWEBP.tif"

with rasterio.open(src_path) as src:
    col_off, row_off, w, h = windows.from_bounds(
        *morecantile_bounds, transform=src.transform, width=256, height=256,
    ).flatten()
    print("Window: ", col_off, row_off, w, h)
    
    w = windows.Window(
        col_off=round(col_off),
        row_off=round(row_off),
        width=round(w),
        height=round(h),
    )
    new_bounds = src.window_bounds(w)
    print("Corrected Window: ", *w.flatten())
    print("Corrected bounds: ", new_bounds)
    print("diff: ", [abs(new_bounds[ii] - morecantile_bounds[ii]) for ii in range(4)])

morecantile boumds:  [-7514065.6285459455, 7514065.6285459455, -6261721.35712162, 8766409.89997027]
Window:  1024.000000000005 4607.9999999999945 511.9999999999991 512.0
Corrected Window:  1024 4608 512 512
Corrected bounds:  (-7514065.628545957, 7514065.628545931, -6261721.357121631, 8766409.899970258)
diff:  [1.1175870895385742e-08, 1.4901161193847656e-08, 1.0244548320770264e-08, 1.30385160446167e-08]
```

### Discussion
- Is the implementation OK ? 
- Do we want this to be a default ?
- is the. `0.0001` threshold ok or should it be based on the dataset resolution ? 
- Should the threshold be applied on the window instead of bounds ? 

cc @geospatial-jeff @kylebarron 

