### PR TITLE
call .read() only once when dataset do not have nodata

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 2.0.3 (2021-02-19)
+
+* Reduce the number of `.read()` calls for dataset without nodata value (https://github.com/cogeotiff/rio-tiler/pull/355)
+* replace deprecated `numpy.float` by `numpy.float64`
 
 ## 2.0.2 (2021-02-17)
 

--- a/rio_tiler/reader.py
+++ b/rio_tiler/reader.py
@@ -81,19 +81,26 @@ def read(
         vrt_params.update(vrt_options)
 
     with WarpedVRT(src_dst, **vrt_params) as vrt:
-        data = vrt.read(
-            indexes=indexes, window=window, out_shape=out_shape, resampling=resampling,
-        )
         if ColorInterp.alpha in vrt.colorinterp:
             idx = vrt.colorinterp.index(ColorInterp.alpha) + 1
-            mask = vrt.read(
-                indexes=idx,
+            indexes = tuple(indexes) + (idx,)
+            if out_shape:
+                out_shape = (len(indexes), height, width)
+
+            data = vrt.read(
+                indexes=indexes,
                 window=window,
-                out_shape=mask_out_shape,
+                out_shape=out_shape,
                 resampling=resampling,
-                out_dtype="uint8",
             )
+            data, mask = data[0:-1], data[-1].astype("uint8")
         else:
+            data = vrt.read(
+                indexes=indexes,
+                window=window,
+                out_shape=out_shape,
+                resampling=resampling,
+            )
             mask = vrt.dataset_mask(
                 window=window, out_shape=mask_out_shape, resampling=resampling,
             )

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -262,7 +262,7 @@ def linear_rescale(
     imin, imax = in_range
     omin, omax = out_range
     image = numpy.clip(image, imin, imax) - imin
-    image = image / numpy.float(imax - imin)
+    image = image / numpy.float64(imax - imin)
     return image * (omax - omin) + omin
 
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ inst_reqs = [
 ]
 
 extra_reqs = {
-    "test": ["pytest", "pytest-benchmark", "pytest-cov", "rio-cogeo"],
+    "test": ["pytest", "pytest-asyncio", "pytest-benchmark", "pytest-cov", "rio-cogeo"],
     "dev": [
         "pytest",
         "pytest-benchmark",


### PR DESCRIPTION
For a dataset that has a mask or and alpha band (by default every data that don't have Nodata set will have an alpha/mask band within the WarpedVRT instance) we were doing two `read()`, one for the data, another one for the mask. This PR changes the behavior and performs only one read() and then split the data and the mask to two arrays.

```
### Before 
$ python tiprofile.py https://rio-tiler-dev.s3.amazonaws.com/data/m_3209542_se_15_060_20181115_20190222.tif --tile 13-1916-3319 --config GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR
         193901 function calls (193178 primitive calls) in 0.978 seconds

   Ordered by: internal time, cumulative time
   List reduced from 635 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.571    0.571    0.571    0.571 __init__.py:56(open)
        2    0.118    0.059    0.118    0.059 {method 'read' of 'rasterio._warp.WarpedVRTReaderBase' objects}
 
### Now
$ python tiprofile.py https://rio-tiler-dev.s3.amazonaws.com/data/m_3209542_se_15_060_20181115_20190222.tif --tile 13-1916-3319 --config GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR       
         193801 function calls (193078 primitive calls) in 0.885 seconds

   Ordered by: internal time, cumulative time
   List reduced from 636 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.382    0.382    0.383    0.383 __init__.py:56(open)
        1    0.048    0.048    0.048    0.048 {method 'read' of 'rasterio._warp.WarpedVRTReaderBase' objects}
```

☝️ this is a profiling results that show that the `method 'read' of 'rasterio._warp.WarpedVRTReaderBase' objects` was called twice and only once in the new version.
