### PR TITLE
added cog type from pystac

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 2.0.4 (?)
+
+* Added [pystac.MediaType.COG](https://github.com/stac-utils/pystac/blob/master/pystac/media_type.py#L4) in supported types by STAC reader
+
 ## 2.0.3 (2021-02-19)
 
 * Reduce the number of `.read()` calls for dataset without nodata value (https://github.com/cogeotiff/rio-tiler/pull/355)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,6 @@
 * fix bad type definition in `rio_tiler.colormap.ColorMaps` data (https://github.com/cogeotiff/rio-tiler/issues/359)
 * add `rio_tiler.colormap.parse_color` function to parse HEX color (https://github.com/cogeotiff/rio-tiler/issues/361)
 
-
 ## 2.0.3 (2021-02-19)
 
 * Reduce the number of `.read()` calls for dataset without nodata value (https://github.com/cogeotiff/rio-tiler/pull/355)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-## 2.0.4 (?)
+## 2.0.4 (2021-03-09)
 
 * Added [pystac.MediaType.COG](https://github.com/stac-utils/pystac/blob/master/pystac/media_type.py#L4) in supported types by STAC reader
 * fix bad type definition in `rio_tiler.colormap.ColorMaps` data (https://github.com/cogeotiff/rio-tiler/issues/359)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ numexpr
 numpy
 morecantile>=2.1,<2.2
 pydantic
-pystac>=0.5.3
+pystac>=0.5.4
 rasterio>=1.1.7
 requests
 rio-color

--- a/rio_tiler/io/stac.py
+++ b/rio_tiler/io/stac.py
@@ -19,6 +19,7 @@ from .cogeo import COGReader
 DEFAULT_VALID_TYPE = {
     "image/tiff; application=geotiff",
     "image/tiff; application=geotiff; profile=cloud-optimized",
+    "image/tiff; profile=cloud-optimized; application=geotiff",
     pystac.MediaType.COG,
     "image/vnd.stac.geotiff; cloud-optimized=true",
     "image/tiff",

--- a/rio_tiler/io/stac.py
+++ b/rio_tiler/io/stac.py
@@ -19,6 +19,7 @@ from .cogeo import COGReader
 DEFAULT_VALID_TYPE = {
     "image/tiff; application=geotiff",
     "image/tiff; application=geotiff; profile=cloud-optimized",
+    pystac.MediaType.COG,
     "image/vnd.stac.geotiff; cloud-optimized=true",
     "image/tiff",
     "image/x.geotiff",


### PR DESCRIPTION
**Proposed Changes:**

***Adding pystac COG type***
in [pystac](https://github.com/stac-utils/pystac/blob/develop/pystac/media_type.py#L10) COG is defined as `image/tiff; profile=cloud-optimized; application=geotiff` and thus not recognized in rio-tiler STAC reader. the COG type defined in pystac 0.5.4 is then added for compatibility.

**PR Checklist:**

- [X] This PR has **no** breaking changes.
- [X] I have added my changes to the [CHANGELOG](https://github.com/cogeotiff/rio-tiler/blob/master/CHANGES.md)