### PR TITLE
Add py.typed to package data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include rio_tiler/cmap_data/*.npy
+include rio_tiler/py.typed

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     license="BSD",
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
-    package_data={"rio_tiler": ["cmap_data/*.npy"]},
+    package_data={"rio_tiler": ["py.typed", "cmap_data/*.npy"]},
     zip_safe=False,
     install_requires=inst_reqs,
     extras_require=extra_reqs,


### PR DESCRIPTION
I'm trying to understand the mypy ecosystem better. In the original [PEP 561](https://www.python.org/dev/peps/pep-0561/), it references a [simple script](https://github.com/ethanhs/check_typedpkg/blob/master/typed_check/__main__.py) to check if your package correctly exposes types, and that alleges that `rio-tiler` isn't exporting types because `py.typed` isn't included in the distributed output. In the [Mypy documentation](https://mypy.readthedocs.io/en/stable/installed_packages.html#making-pep-561-compatible-packages), it instructs you to include `py.typed` manually in your package data output.

That said, in an example script that just imports `rio_tiler`, running `mypy test.py` doesn't complain about being unable to follow the `rio-tiler` import, so I can't tell if this is necessary.