### PR TITLE
add read method in COGReader

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+
+## Next (TBD)
+
+* add `read()` method in COGReader (https://github.com/cogeotiff/rio-tiler/pull/366)
+
 ## 2.0.5 (2021-03-17)
 
 * make sure `py.typed` is included in the package (https://github.com/cogeotiff/rio-tiler/pull/363)

--- a/README.md
+++ b/README.md
@@ -86,21 +86,27 @@ from rio_tiler.io import COGReader
 from rio_tiler.models import ImageData, Info, Metadata, ImageStatistics
 
 with COGReader("my-tif.tif") as cog:
-    # get info
+    # Get dataset basic info
     info: Info = cog.info()
     assert info.nodata_type
     assert info.band_descriptions
 
-    # get image statistics
+    # Get image statistics
     stats: ImageStatistics = cog.stats()
     assert stats.min
     assert stats.max
 
-    # get metadata (info + image statistics)
+    # Get metadata (info + image statistics)
     meta: Metadata = cog.metadata()
     assert meta.statistics
     assert meta.nodata_type
     assert meta.band_descriptions
+
+    # Read the full dataset
+    img: ImageData = cog.read()
+    assert img.width == cog.dataset.width
+    assert img.height == cog.dataset.height
+    assert img.count == cog.dataset.count
 
     # Read data for a mercator tile
     img: ImageData = cog.tile(tile_x, tile_y, tile_zoom, tilesize=256)

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,12 +1,12 @@
 
-The main goal of `rio-tiler` is to create [slippy map
+`rio-tiler` was initialy designed to create [slippy map
 tiles](https://en.wikipedia.org/wiki/Tiled_web_map) from large raster data
-sources and render these tiles dynamically on a web map. `rio-tiler` can read
+sources and render these tiles dynamically on a web map. With `rio-tiler` v2.0 we added many more methods to read
 data and metadata from any raster source supported by Rasterio/GDAL wherever
 they may be, including local files and via HTTP, AWS S3, Google Cloud Storage,
 etc.
 
-## Read a tile from a file
+## Read data
 
 ```python
 from rio_tiler.io import COGReader
@@ -19,6 +19,7 @@ tile_zoom = 21
 with COGReader(
   "http://oin-hotosm.s3.amazonaws.com/5a95f32c2553e6000ce5ad2e/0/10edab38-1bdd-4c06-b83d-6e10ac532b7d.tif"
 ) as cog:
+    # Read data for a slippy map tile
     img = cog.tile(tile_x, tile_y, tile_zoom, tilesize=256)
     assert isinstance(img, ImageData)
 
@@ -26,6 +27,29 @@ with COGReader(
     >>> (3, 256, 256)
     print(img.mask.shape)
     >>> (256, 256)
+
+    # Read the entire data
+    img = cog.read()
+    print(img.data.shape)
+    >>> (3, 11666, 19836)
+
+    # Read part of a data for a given bbox (size is maxed out to 1024)
+    img = cog.part([-61.281, 15.539, -61.279, 15.541])
+    print(img.data.shape)
+    >>> (3, 1024, 1024)
+
+    # Read data for a given geojson polygon (size is maxed out to 1024)
+    img = cog.feature(geojson_feature)
+
+    # Get a preview (size is maxed out to 1024)
+    img = cog.preview()
+    print(img.data.shape)
+    >>> (3, 603, 1024)
+
+    # Get pixel values for a given lon/lat coordinate
+    values = cog.point(-61.281, 15.539)
+    print(values)
+    >>> [47, 62, 43]
 
     # You can also use the `old style` notation
     data, mask = cog.tile(691559, 956905, 21, tilesize=256)

--- a/docs/readers.md
+++ b/docs/readers.md
@@ -13,12 +13,38 @@
 
 #### Methods
 
+- **read()**: Read the entire dataset
+
+```python
+from rio_tiler.io import COGReader
+from rio_tiler.models import ImageData
+
+with COGReader("myfile.tif") as cog:
+    img = cog.read()
+    assert isinstance(img, ImageData)
+    assert img.crs == cog.dataset.crs
+    assert img.assets == ["myfile.tif"]
+    assert img.width == cog.dataset.width
+    assert img.height == cog.dataset.height
+    assert img.count == cog.dataset.count
+
+# With indexes
+with COGReader("myfile.tif") as cog:
+    img = cog.read(indexes=1)  # or cog.read(indexes=(1,))
+    assert img.data.count == 1
+
+# With expression
+with COGReader("myfile.tif"s) as cog:
+    img = cog.read(expression="B1/B2")
+    assert img.data.count == 1
+```
+
 - **tile()**: Read map tile from a raster
 
 ```python
 from rio_tiler.contants import WEB_MERCATOR_CRS
 from rio_tiler.io import COGReader
-from rio_tiler.models import ImageData, Info, Metadata, SpatialInfo
+from rio_tiler.models import ImageData
 
 with COGReader("myfile.tif") as cog:
     # cog.tile(tile_x, tile_y, tile_z, **kwargs)
@@ -41,6 +67,9 @@ with COGReader("myfile.tif"s) as cog:
 - **part()**: Read a raster for a given bounding box (`bbox`). By default the bbox is considered to be in WGS84.
 
 ```python
+from rio_tiler.io import COGReader
+from rio_tiler.models import ImageData
+
 with COGReader("myfile.tif") as cog:
     # cog.part((minx, miny, maxx, maxy), **kwargs)
     img = cog.part((10, 10, 20, 20))
@@ -74,6 +103,9 @@ with COGReader("myfile.tif") as cog:
 - **feature()**: Read a raster for a geojson feature. By default the feature is considered to be in WGS84.
 
 ```python
+from rio_tiler.constants import WGS84_CRS
+from rio_tiler.io import COGReader
+from rio_tiler.models import ImageData
 
 feat = {
     "type": "Feature",
@@ -125,6 +157,9 @@ with COGReader("myfile.tif") as cog:
 - **preview()**: Read a preview of a raster
 
 ```python
+from rio_tiler.io import COGReader
+from rio_tiler.models import ImageData
+
 with COGReader("myfile.tif") as cog:
     img = cog.preview()
     assert isinstance(img, ImageData)
@@ -141,6 +176,8 @@ with COGReader("myfile.tif") as cog:
 - **point()**: Read the pixel values of a raster for a given `lon, lat` coordinates. By default the coordinates are considered to be in WGS84.
 
 ```python
+from rio_tiler.io import COGReader
+
 with COGReader("myfile.tif") as cog:
     # cog.point(lon, lat)
     print(cog.point(-100, 25))
@@ -159,6 +196,9 @@ with COGReader("myfile.tif") as cog:
 - **info()**: Return simple metadata about the dataset
 
 ```python
+from rio_tiler.io import COGReader
+from rio_tiler.models import Info
+
 with COGReader("myfile.tif") as cog:
     info = cog.info()
     assert isinstance(info, Info)
@@ -185,6 +225,8 @@ print(info.dict(exclude_none=True))
 - **stats()**: Return image statistics (Min/Max/Stdev)
 
 ```python
+from rio_tiler.io import COGReader
+
 with COGReader("myfile.tif") as cog:
     # cog.stats(min_percentile, max_percentile, **kwargs)
     stats = cog.stats()
@@ -213,6 +255,9 @@ print(stats["1"].dict())
 - **metadata()**: Return COG info + statistics
 
 ```python
+from rio_tiler.io import COGReader
+from rio_tiler.models import Metadata
+
 with COGReader("myfile.tif") as cog:
     # cog.metadata(min_percentile, max_percentile, **kwargs)
     metadata = cog.metadata()
@@ -249,16 +294,15 @@ print(metadata.dict(exclude_none=True))
 }
 ```
 
-#### Global Options
+#### Read Options
 
-`COGReader` accepts several options which will be forwarded to the `rio_tiler.reader.read` function (low level function accessing the data):
+`COGReader` accepts several options which will be forwarded to the `rio_tiler.reader.read` function (low level function accessing the data), those options can be set as reader's attribute or within each method calls:
 
 - **nodata**: Overwrite the nodata value (or set if not present)
 - **unscale**: Apply internal rescaling factors
 - **vrt_options**: Pass WarpedVRT Option (see: https://gdal.org/api/gdalwarp_cpp.html?highlight=vrt#_CPPv415GDALWarpOptions)
 - **resampling_method**: Set default `resampling_method`
-
-Note: Those options could already be passed on each `method` call.
+- **post_process**: Function to apply after the read operations
 
 ```python
 with COGReader("my_cog.tif", nodata=0) as cog:

--- a/tests/test_io_cogeo.py
+++ b/tests/test_io_cogeo.py
@@ -643,3 +643,23 @@ def test_fullEarth():
 
         img = cog.tile(127, 42, 7, tilesize=64)
         assert img.data.shape == (1, 64, 64)
+
+
+def test_read():
+    """Should read the entire dataset."""
+    with COGReader(COGEO) as cog:
+        img = cog.read()
+        assert numpy.array_equal(img.data, cog.dataset.read(indexes=(1,)))
+        assert img.width == cog.dataset.width
+        assert img.height == cog.dataset.height
+        assert img.count == cog.dataset.count
+
+        with pytest.warns(ExpressionMixingWarning):
+            img = cog.read(indexes=(1, 2, 3), expression="b1*2")
+            assert img.data.shape == (1, 2667, 2658)
+
+        img = cog.read(indexes=1)
+        assert img.data.shape == (1, 2667, 2658)
+
+        img = cog.read(indexes=(1, 1,))
+        assert img.data.shape == (2, 2667, 2658)


### PR DESCRIPTION
This PR does:

- add a `read()` method in COGReader to read the entire dataset
   This could be seen as a wrapper around rasterio read() method but it allows more options like expression, cutline, nodata overwriting...
- update the docs

I let the `read()` outside the BaseClass for now because it might not be suitable for other readers