### PR TITLE
use .files() methods from importlib.resources to find the package directory

### DIFF
--- a/rio_tiler/colormap.py
+++ b/rio_tiler/colormap.py
@@ -25,8 +25,7 @@ except ImportError:
 EMPTY_COLORMAP: Dict = {i: [0, 0, 0, 0] for i in range(256)}
 
 DEFAULT_CMAPS_FILES = {
-    f.stem: str(f)
-    for f in (resources_files(__package__) / "cmap_data").glob("*.npy")
+    f.stem: str(f) for f in (resources_files(__package__) / "cmap_data").glob("*.npy")
 }
 
 USER_CMAPS_DIR = os.environ.get("COLORMAP_DIRECTORY", None)

--- a/rio_tiler/colormap.py
+++ b/rio_tiler/colormap.py
@@ -26,7 +26,7 @@ EMPTY_COLORMAP: Dict = {i: [0, 0, 0, 0] for i in range(256)}
 
 DEFAULT_CMAPS_FILES = {
     f.stem: str(f)
-    for f in resources_files(__package__).joinpath("cmap_data").glob("*.npy")
+    for f in (resources_files(__package__) / "cmap_data").glob("*.npy")
 }
 
 USER_CMAPS_DIR = os.environ.get("COLORMAP_DIRECTORY", None)

--- a/rio_tiler/colormap.py
+++ b/rio_tiler/colormap.py
@@ -16,16 +16,18 @@ from .errors import (
 )
 
 try:
-    import importlib.resources as pkg_resources
+    from importlib.resources import files as resources_files  # type: ignore
 except ImportError:
-    # Try backported to PY<37 `importlib_resources`.
-    import importlib_resources as pkg_resources  # type: ignore
+    # Try backported to PY<39 `importlib_resources`.
+    from importlib_resources import files as resources_files  # type: ignore
 
 
 EMPTY_COLORMAP: Dict = {i: [0, 0, 0, 0] for i in range(256)}
 
-with pkg_resources.path(__package__, "cmap_data") as p:
-    DEFAULT_CMAPS_FILES = {f.stem: str(f) for f in p.glob("*.npy")}
+DEFAULT_CMAPS_FILES = {
+    f.stem: str(f)
+    for f in resources_files(__package__).joinpath("cmap_data").glob("*.npy")
+}
 
 USER_CMAPS_DIR = os.environ.get("COLORMAP_DIRECTORY", None)
 if USER_CMAPS_DIR:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ inst_reqs = [
     "rasterio>=1.1.7",
     "requests",
     "rio-color",
-    "importlib_resources;python_version<'3.7'",
+    "importlib_resources>=1.1.0;python_version<'3.9'",
 ]
 
 extra_reqs = {


### PR DESCRIPTION
closes #376 

let's embrace the future @kylebarron and depends on features that were added in python 3.9 😄 


### summary 
- in #370 we switched to `importlib.resources.path()` to find the path for `rio_tiler/cmap_data`. 
- ☝️ worked in python 3.7 and 3.8 ... but failed in 3.9. The docs did mention that the second argument of `path()` had to be a file ... but it worked with a directory... it's not the case anymore with 3.9
- A new methods (`.files()`) was added to 3.9, and it gives the result we were hopping for.

> importlib.resources.files(package)
Returns an importlib.resources.abc.Traversable object representing the resource container for the package (think directory) and its resources (think files). A Traversable may contain other containers (think subdirectories).
package is either a name or a module object which conforms to the Package requirements.
New in version 3.9.