### PR TITLE
add autorescaling to avoid image creation errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,8 @@
 
+## 2.1.0 (TBD)
+
+* add auto-rescaling in `ImageData.render` method to avoid error when datatype is not supported by the output driver (https://github.com/cogeotiff/rio-tiler/pull/391)
+
 ## 2.0.8 (2021-04-26)
 
 * add warning when dataset doesn't have overviews (https://github.com/cogeotiff/rio-tiler/pull/386)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,5 @@
 
-## 2.1.0 (TBD)
+## 2.1.0 (2021-05-17)
 
 * add auto-rescaling in `ImageData.render` method to avoid error when datatype is not supported by the output driver (https://github.com/cogeotiff/rio-tiler/pull/391)
 
@@ -20,11 +20,13 @@ with open("img.png", "wb") as f:
 * change type of `in_range` option in `ImageData.render` to `Sequence[Tuple[NumType, NumType]]` (https://github.com/cogeotiff/rio-tiler/pull/391)
 
 ```python
+img = ImageData(numpy.zeros((3, 256, 256), dtype="uint16"))
+
 # before - Tuple[NumType, NumType]
-buff = ImageData(numpy.zeros((3, 256, 256), dtype="uint16")).render(in_range=(0, 1000, 0, 1000, 0, 1000))
+buff = img.render(in_range=(0, 1000, 0, 1000, 0, 1000))
 
 # now - Sequence[Tuple[NumType, NumType]]
-buff = ImageData(numpy.zeros((1, 256, 256), dtype="uint16")).render(in_range=((0, 1000), (0, 1000), (0, 1000)))
+buff = img.render(in_range=((0, 1000), (0, 1000), (0, 1000)))
 ```
 
 ## 2.0.8 (2021-04-26)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,30 @@
 
 * add auto-rescaling in `ImageData.render` method to avoid error when datatype is not supported by the output driver (https://github.com/cogeotiff/rio-tiler/pull/391)
 
+```python
+# before - exit with error
+with open("img.png", "wb") as f:
+    f.write(ImageData(numpy.zeros((3, 256, 256), dtype="float32")).render())
+>>> (ERROR) CPLE_NotSupportedError: "PNG driver doesn't support data type Float32. Only eight bit (Byte) and sixteen bit (UInt16) bands supported".
+
+# now - print a warning
+with open("img.png", "wb") as f:
+    f.write(ImageData(numpy.zeros((3, 256, 256), dtype="float32")).render())
+>>> (WARNING) InvalidDatatypeWarning: "Invalid type: `float32` for the `PNG` driver. Data will be rescaled using min/max type bounds".
+```
+
+**breaking changes**
+
+* change type of `in_range` option in `ImageData.render` to `Sequence[Tuple[NumType, NumType]]` (https://github.com/cogeotiff/rio-tiler/pull/391)
+
+```python
+# before - Tuple[NumType, NumType]
+buff = ImageData(numpy.zeros((3, 256, 256), dtype="uint16")).render(in_range=(0, 1000, 0, 1000, 0, 1000))
+
+# now - Sequence[Tuple[NumType, NumType]]
+buff = ImageData(numpy.zeros((1, 256, 256), dtype="uint16")).render(in_range=((0, 1000), (0, 1000), (0, 1000)))
+```
+
 ## 2.0.8 (2021-04-26)
 
 * add warning when dataset doesn't have overviews (https://github.com/cogeotiff/rio-tiler/pull/386)

--- a/docs/colormap.md
+++ b/docs/colormap.md
@@ -21,7 +21,10 @@ with COGReader(
     img = cog.tile(150, 187, 9)
 
     # Rescale the data linearly from 0-10000 to 0-255
-    image_rescale = img.post_process(in_range=(0, 10000), out_range=(0, 255))
+    image_rescale = img.post_process(
+        in_range=((0, 10000),),
+        out_range=((0, 255),)
+    )
 
     # Apply colormap and create a PNG buffer
     buff = image_rescale.render(colormap=cm) # this returns a buffer (PNG by default)

--- a/docs/examples/Using-rio-tiler-STACReader.ipynb
+++ b/docs/examples/Using-rio-tiler-STACReader.ipynb
@@ -390,7 +390,7 @@
     "# The sentinel data is stored as UInt16, we need to do some data rescaling to display data from 0 to 255\n",
     "print(img.data.min(), img.data.max())\n",
     "\n",
-    "image = img.post_process(in_range=(0,10000))\n",
+    "image = img.post_process(in_range=((0,10000),))\n",
     "image = image.data_as_image()\n",
     "print(image.min(), image.max())\n",
     "imshow(image)"
@@ -447,7 +447,7 @@
     "    assert isinstance(img, ImageData)\n",
     "\n",
     "# NDVI data range should be between -1 and 1\n",
-    "image = img.post_process(in_range=(-1,1))\n",
+    "image = img.post_process(in_range=((-1,1),))\n",
     "image = image.data_as_image()\n",
     "imshow(image)"
    ]
@@ -461,22 +461,16 @@
   }
  ],
  "metadata": {
+  "interpreter": {
+   "hash": "e5a596c8625da0593f23bdd5ea51ce5c4572779fa5edc69fb6a18fc94feb7fb6"
+  },
   "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
+   "display_name": "Python 3.8.2 64-bit",
    "name": "python3"
   },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": ""
   }
  },
  "nbformat": 4,

--- a/docs/examples/Using-rio-tiler.ipynb
+++ b/docs/examples/Using-rio-tiler.ipynb
@@ -486,7 +486,7 @@
     "    print(ndvi.data.dtype)\n",
     "    print(\"NDVI range: \", ndvi.data.min(), ndvi.data.max())\n",
     "\n",
-    "image = ndvi.post_process(in_range=(-1,1))\n",
+    "image = ndvi.post_process(in_range=((-1,1),))\n",
     "imshow(image.data[0])"
    ]
   },
@@ -677,7 +677,7 @@
     "    ndvi = cog.tile(*tile_cover[0], expression=\"(b4-b1)/(b4+b1)\")\n",
     "    print(ndvi.data.shape)\n",
     "\n",
-    "image = ndvi.post_process(in_range=(-1,1))\n",
+    "image = ndvi.post_process(in_range=((-1,1),))\n",
     "imshow(image.data[0])"
    ]
   },
@@ -861,22 +861,16 @@
   }
  ],
  "metadata": {
+  "interpreter": {
+   "hash": "e5a596c8625da0593f23bdd5ea51ce5c4572779fa5edc69fb6a18fc94feb7fb6"
+  },
   "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
+   "display_name": "Python 3.8.2 64-bit",
    "name": "python3"
   },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": ""
   }
  },
  "nbformat": 4,

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -74,7 +74,10 @@ with COGReader(
     img = cog.tile(150, 187, 9)
 
     # Rescale the data from 0-10000 to 0-255
-    image_rescale = img.post_process(in_range=(0, 10000), out_range=(0, 255))
+    image_rescale = img.post_process(
+        in_range=((0, 10000),),
+        out_range=((0, 255),),
+    )
 
     # Get Colormap
     cm = cmap.get("viridis")
@@ -100,6 +103,9 @@ with COGReader(
 
     buff = img.render(img_format="webp", **options)
 ```
+
+Note: Starting with `rio-tiler==2.1`, when the output datatype is not valid for a driver (e.g `float` for `PNG`),
+`rio-tiler` will automatically rescale the data using the `min/max` value for the datatype (ref: https://github.com/cogeotiff/rio-tiler/pull/391).
 
 ## Write image to file
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -90,7 +90,12 @@ print(img.data.max())
 >>> 2999
 
 # rescale the data from 0 -> 3000 to 0 -> 255
-image = img.post_process(in_range=(0, 3000))
+# by default rio-tiler will apply the same `in_range` for all the bands
+image = img.post_process(in_range=((0, 3000),))
+
+# or provide range for each bands
+image = img.post_process(in_range=((0, 3000), (0, 1000), (0, 2000)))
+
 assert isinstance(image, ImageData)
 
 print(image.data.dtype)
@@ -100,7 +105,10 @@ print(image.data.max())
 >>> 254
 
 # rescale and apply rio-color formula
-image = img.post_process(in_range=(0, 3000), color_formula="Gamma RGB 3.1")
+image = img.post_process(
+    in_range=((0, 3000),),
+    color_formula="Gamma RGB 3.1",
+)
 assert isinstance(image, ImageData)
 ```
 
@@ -149,6 +157,9 @@ print(get_meta(buf))
     'transform': Affine(1.0, 0.0, 0.0, 0.0, 1.0, 0.0)
 }
 ```
+
+Note: Starting with `rio-tiler==2.1`, when the output datatype is not valid for a driver (e.g `float` for `PNG`),
+`rio-tiler` will automatically rescale the data using the `min/max` value for the datatype (ref: https://github.com/cogeotiff/rio-tiler/pull/391).
 
 ## Others
 
@@ -275,7 +286,7 @@ print(info.dict(exclude_none=True))
 }
 ```
 
-Note: starting with `rio-tiler>=2.0.8`, additional metadat can be set (e.g. driver, count, width, height, overviews in `COGReader.info()`)
+Note: starting with `rio-tiler>=2.0.8`, additional metadata can be set (e.g. driver, count, width, height, overviews in `COGReader.info()`)
 
 ### Metadata
 

--- a/rio_tiler/errors.py
+++ b/rio_tiler/errors.py
@@ -63,3 +63,7 @@ class EmptyMosaicError(RioTilerError):
 
 class InvalidColorFormat(RioTilerError):
     """Invalid color format."""
+
+
+class InvalidDatatypeWarning(UserWarning):
+    """Invalid Output Datatype."""

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -1,7 +1,7 @@
 """rio_tiler.utils: utility functions."""
 
 from io import BytesIO
-from typing import Any, Dict, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Generator, Optional, Sequence, Tuple, Union
 
 import numpy
 from affine import Affine
@@ -21,7 +21,7 @@ from .constants import WEB_MERCATOR_CRS, BBox, NumType
 from .errors import RioTilerError
 
 
-def _chunks(my_list: Sequence, chuck_size: int):
+def _chunks(my_list: Sequence, chuck_size: int) -> Generator[Sequence, None, None]:
     """Yield successive n-sized chunks from l."""
     for i in range(0, len(my_list), chuck_size):
         yield my_list[i : i + chuck_size]

--- a/tests/test_io_cogeo.py
+++ b/tests/test_io_cogeo.py
@@ -455,7 +455,7 @@ def test_imageData_output():
         imgc = img.post_process(color_formula="Gamma R 3.1")
         assert imgc.data.dtype == "uint8"
 
-        imgr = img.post_process(in_range=(img.data.min(), img.data.max()))
+        imgr = img.post_process(in_range=((img.data.min(), img.data.max()),))
         assert not numpy.array_equal(img.data, imgr.data)
         assert imgr.data.dtype == "uint8"
         assert imgr.data.min() == 0
@@ -472,7 +472,7 @@ def test_imageData_output():
         assert imgc.assets == img.assets
 
         imgrc = img.post_process(
-            in_range=(img.data.min(), img.data.max()), color_formula="Gamma R 3.1"
+            in_range=((img.data.min(), img.data.max()),), color_formula="Gamma R 3.1"
         )
         assert numpy.array_equal(imgc.data, imgrc.data)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,56 @@
+"""Test rio_tiler.models."""
+
+import numpy
+import pytest
+
+from rio_tiler.errors import InvalidDatatypeWarning
+from rio_tiler.models import ImageData
+
+
+def test_imageData_AutoRescaling():
+    """Test ImageData auto rescaling."""
+
+    with pytest.warns(InvalidDatatypeWarning) as w:
+        ImageData(numpy.zeros((1, 256, 256), dtype="float32")).render(img_format="PNG")
+        assert len(w.list) == 2  # NotGeoreferencedWarning and InvalidDatatypeWarning
+
+    with pytest.warns(None) as w:
+        ImageData(numpy.zeros((1, 256, 256), dtype="uint8")).render(img_format="PNG")
+        assert len(w.list) == 1  # only NotGeoreferencedWarning
+
+    with pytest.warns(InvalidDatatypeWarning) as w:
+        ImageData(numpy.zeros((1, 256, 256), dtype="int8")).render(img_format="PNG")
+
+    with pytest.warns(None) as w:
+        ImageData(numpy.zeros((1, 256, 256), dtype="uint16")).render(img_format="PNG")
+        assert len(w.list) == 1
+
+    with pytest.warns(None) as w:
+        ImageData(numpy.zeros((1, 256, 256), dtype="uint16")).render(img_format="GTiff")
+        assert len(w.list) == 0
+
+    with pytest.warns(InvalidDatatypeWarning) as w:
+        ImageData(numpy.zeros((1, 256, 256), dtype="uint16")).render(img_format="jpeg")
+
+    with pytest.warns(InvalidDatatypeWarning) as w:
+        ImageData(numpy.zeros((3, 256, 256), dtype="uint16")).render(img_format="WEBP")
+
+    with pytest.warns(InvalidDatatypeWarning) as w:
+        ImageData(numpy.zeros((3, 256, 256), dtype="int8")).render(
+            img_format="JP2OpenJPEG"
+        )
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    ["uint8", "int8", "uint16", "int16", "uint32", "int32", "float32", "float64"],
+)
+def test_imageData_AutoRescalingAllTypes(dtype):
+    """Test ImageData auto rescaling."""
+    with pytest.warns(None):
+        ImageData(numpy.zeros((1, 256, 256), dtype=dtype)).render(img_format="PNG")
+        ImageData(numpy.zeros((1, 256, 256), dtype=dtype)).render(img_format="JPEG")
+        ImageData(numpy.zeros((3, 256, 256), dtype=dtype)).render(img_format="WEBP")
+        ImageData(numpy.zeros((3, 256, 256), dtype=dtype)).render(
+            img_format="JP2OPENJPEG"
+        )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,7 +9,6 @@ from rio_tiler.models import ImageData
 
 def test_imageData_AutoRescaling():
     """Test ImageData auto rescaling."""
-
     with pytest.warns(InvalidDatatypeWarning) as w:
         ImageData(numpy.zeros((1, 256, 256), dtype="float32")).render(img_format="PNG")
         assert len(w.list) == 2  # NotGeoreferencedWarning and InvalidDatatypeWarning


### PR DESCRIPTION
closes #390 

This PR does:
- [x] add data type rescaling when we know the output driver will raise an error (e.g float -> uint8 for PNG)


**Why the `auto-rescaling` is only in `ImageData.render` and not in `rio_tiler.utils.render`?**

The rescale method (`rio_tiler.utils.linear_rescale`) requires a `mask` in argument but in `rio_tiler.utils.render` the mask is either optional or deleted. In the ImageData object, the mask will always be defined.
