### PR TITLE
support for setting the S3 endpoint url

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
+## Unreleased
 
+* add support for setting the S3 endpoint url via the `AWS_S3_ENDPOINT` environment variables in `aws_get_object` function using boto3 (https://github.com/cogeotiff/rio-tiler/pull/394)
 ## 2.1.0 (2021-05-17)
 
 * add auto-rescaling in `ImageData.render` method to avoid error when datatype is not supported by the output driver (https://github.com/cogeotiff/rio-tiler/pull/391)

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -1,6 +1,7 @@
 """rio_tiler.utils: utility functions."""
 
 from io import BytesIO
+import os
 from typing import Any, Dict, Generator, Optional, Sequence, Tuple, Union
 
 import numpy
@@ -36,7 +37,8 @@ def aws_get_object(
     """AWS s3 get object content."""
     if not client:
         session = boto3_session()
-        client = session.client("s3")
+        endpoint_url = os.environ.get('AWS_S3_ENDPOINT', None)
+        client = session.client("s3", endpoint_url=endpoint_url)
 
     params = {"Bucket": bucket, "Key": key}
     if request_pays:

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -1,7 +1,7 @@
 """rio_tiler.utils: utility functions."""
 
-from io import BytesIO
 import os
+from io import BytesIO
 from typing import Any, Dict, Generator, Optional, Sequence, Tuple, Union
 
 import numpy
@@ -37,7 +37,7 @@ def aws_get_object(
     """AWS s3 get object content."""
     if not client:
         session = boto3_session()
-        endpoint_url = os.environ.get('AWS_S3_ENDPOINT', None)
+        endpoint_url = os.environ.get("AWS_S3_ENDPOINT", None)
         client = session.client("s3", endpoint_url=endpoint_url)
 
     params = {"Bucket": bucket, "Key": key}


### PR DESCRIPTION
**Proposed Changes:**

This PR add support for setting the S3 endpoint url via the `AWS_S3_ENDPOINT` environment variables in `aws_get_object` function using boto3. `AWS_S3_ENDPOINT` name has been chosen to work also with gdal vsis3 (https://gdal.org/user/virtual_file_systems.html#vsis3-aws-s3-files)

**PR Checklist:**

- [X] This PR has **no** breaking changes.
- [X] Tests pass (run `tox`)
- [X] I have added my changes to the [CHANGELOG](https://github.com/cogeotiff/rio-tiler/blob/master/CHANGES.md)