### PR TITLE
re-use class methods to reduce code duplication

### DIFF
--- a/rio_tiler/expression.py
+++ b/rio_tiler/expression.py
@@ -44,10 +44,11 @@ def apply_expression(
         numpy.array: output data.
 
     """
-    data = dict(zip(bands, data))
     return numpy.array(
         [
-            numpy.nan_to_num(numexpr.evaluate(bloc.strip(), local_dict=data))
+            numpy.nan_to_num(
+                numexpr.evaluate(bloc.strip(), local_dict=dict(zip(bands, data)))
+            )
             for bloc in blocks
         ]
     )

--- a/rio_tiler/io/cogeo.py
+++ b/rio_tiler/io/cogeo.py
@@ -270,30 +270,16 @@ class COGReader(BaseReader):
             tilesize (int, optional): Output image size. Defaults to `256`.
             indexes (int or sequence of int, optional): Band indexes.
             expression (str, optional): rio-tiler expression (e.g. b1/b2+b3).
-            kwargs (optional): Options to forward to the `rio_tiler.reader.part` function.
+            kwargs (optional): Options to forward to the `COGReader.part` method.
 
         Returns:
             rio_tiler.models.ImageData: ImageData instance with data, mask and tile spatial info.
 
         """
-        kwargs = {**self._kwargs, **kwargs}
-
         if not self.tile_exists(tile_z, tile_x, tile_y):
             raise TileOutsideBounds(
                 f"Tile {tile_z}/{tile_x}/{tile_y} is outside {self.filepath} bounds"
             )
-
-        if isinstance(indexes, int):
-            indexes = (indexes,)
-
-        if indexes and expression:
-            warnings.warn(
-                "Both expression and indexes passed; expression will overwrite indexes parameter.",
-                ExpressionMixingWarning,
-            )
-
-        if expression:
-            indexes = parse_expression(expression)
 
         tile_bounds = self.tms.xy_bounds(*Tile(x=tile_x, y=tile_y, z=tile_z))
         if tile_buffer:
@@ -307,22 +293,16 @@ class COGReader(BaseReader):
             )
             tilesize += tile_buffer * 2
 
-        tile, mask = reader.part(
-            self.dataset,
+        return self.part(
             tile_bounds,
-            tilesize,
-            tilesize,
-            indexes=indexes,
             dst_crs=self.tms.crs,
+            bounds_crs=None,
+            height=tilesize,
+            width=tilesize,
+            max_size=None,
+            indexes=indexes,
+            expression=expression,
             **kwargs,
-        )
-        if expression:
-            blocks = expression.lower().split(",")
-            bands = [f"b{bidx}" for bidx in indexes]
-            tile = apply_expression(blocks, bands, tile)
-
-        return ImageData(
-            tile, mask, bounds=tile_bounds, crs=self.tms.crs, assets=[self.filepath]
         )
 
     def part(
@@ -382,14 +362,10 @@ class COGReader(BaseReader):
             bands = [f"b{bidx}" for bidx in indexes]
             data = apply_expression(blocks, bands, data)
 
-        if dst_crs == bounds_crs:
-            bounds = bbox
-        else:
-            bounds = transform_bounds(bounds_crs, dst_crs, *bbox, densify_pts=21)
+        if bounds_crs and bounds_crs != dst_crs:
+            bbox = transform_bounds(bounds_crs, dst_crs, *bbox, densify_pts=21)
 
-        return ImageData(
-            data, mask, bounds=bounds, crs=dst_crs, assets=[self.filepath],
-        )
+        return ImageData(data, mask, bounds=bbox, crs=dst_crs, assets=[self.filepath],)
 
     def preview(
         self,
@@ -477,7 +453,7 @@ class COGReader(BaseReader):
         if expression:
             blocks = expression.lower().split(",")
             bands = [f"b{bidx}" for bidx in indexes]
-            point = apply_expression(blocks, bands, point).tolist()
+            point = apply_expression(blocks, bands, numpy.array(point)).tolist()
 
         return point
 
@@ -500,26 +476,12 @@ class COGReader(BaseReader):
             max_size (int, optional): Limit the size of the longest dimension of the dataset read, respecting bounds X/Y aspect ratio. Defaults to `1024`.
             indexes (sequence of int or int, optional): Band indexes.
             expression (str, optional): rio-tiler expression (e.g. b1/b2+b3).
-            kwargs (optional): Options to forward to the `rio_tiler.reader.part` function.
+            kwargs (optional): Options to forward to the `COGReader.part` method.
 
         Returns:
             rio_tiler.models.ImageData: ImageData instance with data, mask and input spatial info.
 
         """
-        kwargs = {**self._kwargs, **kwargs}
-
-        if isinstance(indexes, int):
-            indexes = (indexes,)
-
-        if indexes and expression:
-            warnings.warn(
-                "Both expression and indexes passed; expression will overwrite indexes parameter.",
-                ExpressionMixingWarning,
-            )
-
-        if expression:
-            indexes = parse_expression(expression)
-
         if not dst_crs:
             dst_crs = shape_crs
 
@@ -530,29 +492,15 @@ class COGReader(BaseReader):
         vrt_options = kwargs.pop("vrt_options", {})
         vrt_options.update({"cutline": cutline})
 
-        data, mask = reader.part(
-            self.dataset,
+        return self.part(
             bbox,
-            max_size=max_size,
-            bounds_crs=shape_crs,
             dst_crs=dst_crs,
+            bounds_crs=shape_crs,
             indexes=indexes,
+            expression=expression,
+            max_size=max_size,
             vrt_options=vrt_options,
             **kwargs,
-        )
-
-        if expression:
-            blocks = expression.lower().split(",")
-            bands = [f"b{bidx}" for bidx in indexes]
-            data = apply_expression(blocks, bands, data)
-
-        if dst_crs == shape_crs:
-            bounds = bbox
-        else:
-            bounds = transform_bounds(shape_crs, dst_crs, *bbox, densify_pts=21)
-
-        return ImageData(
-            data, mask, bounds=bounds, crs=dst_crs, assets=[self.filepath],
         )
 
     def read(


### PR DESCRIPTION
This PR does:
- simplify `COGReader.tile` and `COGReader.feature` to use `COGReader.part` method.