### PR TITLE
loosen mosaic assets type information to allow other type than str

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 2.1.2 (TBD)
+
+* update type information for mosaics functions (https://github.com/cogeotiff/rio-tiler/pull/409)
+
 ## 2.1.1 (2021-07-29)
 
 * add support for setting the S3 endpoint url via the `AWS_S3_ENDPOINT` environment variables in `aws_get_object` function using boto3 (https://github.com/cogeotiff/rio-tiler/pull/394)

--- a/rio_tiler/models.py
+++ b/rio_tiler/models.py
@@ -110,7 +110,7 @@ class ImageData:
 
     data: numpy.ndarray = attr.ib()
     mask: numpy.ndarray = attr.ib()
-    assets: Optional[List[str]] = attr.ib(default=None)
+    assets: Optional[List] = attr.ib(default=None)
     bounds: Optional[BoundingBox] = attr.ib(default=None, converter=to_coordsbbox)
     crs: Optional[CRS] = attr.ib(default=None)
     metadata: Optional[Dict] = attr.ib(factory=dict)

--- a/rio_tiler/mosaic/reader.py
+++ b/rio_tiler/mosaic/reader.py
@@ -15,7 +15,7 @@ from .methods.defaults import FirstMethod
 
 
 def mosaic_reader(
-    mosaic_assets: Sequence[str],
+    mosaic_assets: Sequence,
     reader: Callable[..., ImageData],
     *args: Any,
     pixel_selection: Union[Type[MosaicMethodBase], MosaicMethodBase] = FirstMethod,
@@ -23,7 +23,7 @@ def mosaic_reader(
     threads: int = MAX_THREADS,
     allowed_exceptions: Tuple = (TileOutsideBounds,),
     **kwargs,
-) -> Tuple[ImageData, List[str]]:
+) -> Tuple[ImageData, List]:
     """Merge multiple assets.
 
     Args:
@@ -71,7 +71,7 @@ def mosaic_reader(
     if not chunk_size:
         chunk_size = threads if threads > 1 else len(mosaic_assets)
 
-    assets_used: List[str] = []
+    assets_used: List = []
     crs: Optional[CRS] = None
     bounds: Optional[BBox] = None
 

--- a/rio_tiler/tasks.py
+++ b/rio_tiler/tasks.py
@@ -8,7 +8,7 @@ from .constants import MAX_THREADS
 from .logger import logger
 from .models import ImageData
 
-TaskType = Sequence[Tuple[Union[futures.Future, Callable], str]]
+TaskType = Sequence[Tuple[Union[futures.Future, Callable], Any]]
 
 
 def filter_tasks(
@@ -38,7 +38,9 @@ def filter_tasks(
             pass
 
 
-def create_tasks(reader: Callable, asset_list, threads, *args, **kwargs) -> TaskType:
+def create_tasks(
+    reader: Callable, asset_list: Sequence, threads: int, *args, **kwargs
+) -> TaskType:
     """Create Future Tasks."""
     if threads and threads > 1:
         logger.debug(f"Running tasks in ThreadPool with max_workers={threads}")
@@ -55,7 +57,7 @@ def create_tasks(reader: Callable, asset_list, threads, *args, **kwargs) -> Task
 
 
 def multi_arrays(
-    asset_list: Sequence[str],
+    asset_list: Sequence,
     reader: Callable[..., ImageData],
     *args: Any,
     threads: int = MAX_THREADS,
@@ -70,7 +72,7 @@ def multi_arrays(
 
 
 def multi_values(
-    asset_list: Sequence[str],
+    asset_list: Sequence,
     reader: Callable,
     *args: Any,
     threads: int = MAX_THREADS,


### PR DESCRIPTION
This PR does:
- change `assets` type from `Sequence[str]` to `Sequence` 

This is related to https://github.com/stac-utils/titiler-pgstac/blob/bebfe504d242b19798f68feaceebd5bda6284515/src/titiler/pgstac/titiler/pgstac/mosaic.py#L131-L132 where I wanted to build a simple MultiBaseReader which takes dict as input. 

The type of asset should not be enforced, it all comes down to what the `reader` expects. 