### PR TITLE
Bring mypy out of pre-commit to type check against imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       # Run mypy using the version of Python in `PATH`
       - name: Run mypy
         run: |
-            python -m pip install '.[test]'
+            python -m pip install '.[test]' 'numpy>=1.21,<1.22'
             python -m mypy --config-file setup.cfg -p rio_tiler
 
       # Run pre-commit (only for python-3.8)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,12 @@ jobs:
       - name: Run Tox
         run: tox -e py
 
+      # Run mypy using the version of Python in `PATH`
+      - name: Run mypy
+        run: |
+            python -m pip install '.[test]'
+            python -m mypy --config-file setup.cfg -p rio_tiler
+
       # Run pre-commit (only for python-3.8)
       - name: run pre-commit
         if: matrix.python-version == 3.8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
       # Run mypy using the version of Python in `PATH`
       - name: Run mypy
         run: |
+            python -m pip install --upgrade pip
             python -m pip install '.[test]' 'numpy>=1.21,<1.22'
             python -m mypy --config-file setup.cfg -p rio_tiler
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,7 @@ jobs:
       # Run mypy using the version of Python in `PATH`
       - name: Run mypy
         run: |
-            python -m pip install --upgrade pip
-            python -m pip install '.[test]' 'numpy>=1.21,<1.22'
+            python -m pip install '.[test]'
             python -m mypy --config-file setup.cfg -p rio_tiler
 
       # Run pre-commit (only for python-3.8)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,9 +22,3 @@ repos:
     hooks:
       - id: pydocstyle
         language_version: python
-
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.812
-    hooks:
-      - id: mypy
-        language_version: python

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ inst_reqs = [
 
 test_reqs = [
     "mypy",
-    "numpy>=1.21,<1.22",
     "pytest-asyncio",
     "pytest-benchmark",
     "pytest-cov",

--- a/setup.py
+++ b/setup.py
@@ -20,16 +20,18 @@ inst_reqs = [
     "importlib_resources>=1.1.0;python_version<'3.9'",
 ]
 
+test_reqs = [
+    "pytest",
+    "pytest-asyncio",
+    "pytest-benchmark",
+    "pytest-cov",
+    "rio-cogeo",
+    "mypy",
+]
+
 extra_reqs = {
-    "test": ["pytest", "pytest-asyncio", "pytest-benchmark", "pytest-cov", "rio-cogeo"],
-    "dev": [
-        "pytest",
-        "pytest-benchmark",
-        "pytest-cov",
-        "pytest-asyncio",
-        "rio-cogeo",
-        "pre-commit",
-    ],
+    "test": test_reqs,
+    "dev": [*test_reqs, "pre-commit"],
     "docs": ["nbconvert", "mkdocs", "mkdocs-material", "pygments", "mkdocs-jupyter"],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ test_reqs = [
     "pytest-cov",
     "rio-cogeo",
     "mypy",
+    "types-requests",
 ]
 
 extra_reqs = {

--- a/setup.py
+++ b/setup.py
@@ -21,12 +21,13 @@ inst_reqs = [
 ]
 
 test_reqs = [
-    "pytest",
+    "mypy",
+    "numpy>=1.21,<1.22",
     "pytest-asyncio",
     "pytest-benchmark",
     "pytest-cov",
+    "pytest",
     "rio-cogeo",
-    "mypy",
     "types-requests",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ inst_reqs = [
 
 test_reqs = [
     "mypy",
+    "numpy>=1.21,<1.22;python_version>='3.7'",
     "pytest-asyncio",
     "pytest-benchmark",
     "pytest-cov",

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ inst_reqs = [
 
 test_reqs = [
     "mypy",
-    "numpy>=1.21,<1.22;python_version>='3.7'",
     "pytest-asyncio",
     "pytest-benchmark",
     "pytest-cov",

--- a/tox.ini
+++ b/tox.ini
@@ -5,15 +5,11 @@ envlist = py36,py37,py38,p39
 extras = test
 commands=
     python -m pytest --cov rio_tiler --cov-report xml --cov-report term-missing --benchmark-skip --ignore=venv
-deps=
-    numpy
 
 [testenv:benchmark]
 extras = test
 commands=
     python -m pytest --benchmark-only --benchmark-autosave --benchmark-columns 'min, max, mean, median' --benchmark-sort 'min'
-deps=
-    numpy
 
 # Release tooling
 [testenv:build]


### PR DESCRIPTION
Testing on CI; I can't figure out how to add a section to `tox.ini`. I added (locally, didn't commit)
```
[testenv:typing]
extras = test
commands=
    python -m mypy --config-file setup.cfg -p rio_tiler
deps=
    numpy
```
but it didn't seem to get run.