### PR TITLE
add new statistics methods and band names in ImageData object

### DIFF
--- a/rio_tiler/io/cogeo.py
+++ b/rio_tiler/io/cogeo.py
@@ -20,8 +20,14 @@ from .. import reader
 from ..constants import WEB_MERCATOR_TMS, WGS84_CRS, BBox, Indexes, NoData
 from ..errors import ExpressionMixingWarning, NoOverviewWarning, TileOutsideBounds
 from ..expression import apply_expression, parse_expression
-from ..models import ImageData, ImageStatistics, Info
-from ..utils import create_cutline, has_alpha_band, has_mask_band
+from ..models import BandStatistics, ImageData, ImageStatistics, Info
+from ..utils import (
+    create_cutline,
+    get_array_statistics,
+    get_bands_names,
+    has_alpha_band,
+    has_mask_band,
+)
 from .base import BaseReader
 
 
@@ -236,6 +242,11 @@ class COGReader(BaseReader):
             rio_tiler.models.ImageStatistics: bands statistics.
 
         """
+        warnings.warn(
+            "`stats` method will be removed and replaced by `statistics` in rio-tiler v3.0.0",
+            DeprecationWarning,
+        )
+
         kwargs = {**self._kwargs, **kwargs}
 
         hist_options = hist_options or {}
@@ -249,6 +260,46 @@ class COGReader(BaseReader):
             self.dataset, percentiles=(pmin, pmax), hist_options=hist_options, **kwargs,
         )
         return {b: ImageStatistics(**s) for b, s in stats.items()}
+
+    def statistics(
+        self,
+        categorical: bool = False,
+        categories: Optional[List[float]] = None,
+        percentiles: List[int] = [2, 98],
+        hist_options: Optional[Dict] = None,
+        max_size: int = 1024,
+        **kwargs: Any,
+    ) -> Dict[str, BandStatistics]:
+        """Return bands statistics from a COG.
+
+        Args:
+
+
+            hist_options (dict, optional): Options to forward to numpy.histogram function.
+            kwargs (optional): Options to forward to `self.preview`.
+
+        Returns:
+            Dict[str, rio_tiler.models.BandStatistics]: bands statistics.
+
+        """
+        kwargs = {**self._kwargs, **kwargs}
+
+        data = self.preview(max_size=max_size, **kwargs)
+
+        hist_options = hist_options or {}
+
+        stats = get_array_statistics(
+            data.as_masked(),
+            categorical=categorical,
+            categories=categories,
+            percentiles=percentiles,
+            **hist_options,
+        )
+
+        return {
+            f"{data.band_names[ix]}": BandStatistics(**stats[ix])
+            for ix in range(len(stats))
+        }
 
     def tile(
         self,
@@ -371,7 +422,16 @@ class COGReader(BaseReader):
         if bounds_crs and bounds_crs != dst_crs:
             bbox = transform_bounds(bounds_crs, dst_crs, *bbox, densify_pts=21)
 
-        return ImageData(data, mask, bounds=bbox, crs=dst_crs, assets=[self.filepath],)
+        return ImageData(
+            data,
+            mask,
+            bounds=bbox,
+            crs=dst_crs,
+            assets=[self.filepath],
+            band_names=get_bands_names(
+                indexes=indexes, expression=expression, count=data.shape[0]
+            ),
+        )
 
     def preview(
         self,
@@ -430,6 +490,9 @@ class COGReader(BaseReader):
             bounds=self.dataset.bounds,
             crs=self.dataset.crs,
             assets=[self.filepath],
+            band_names=get_bands_names(
+                indexes=indexes, expression=expression, count=data.shape[0]
+            ),
         )
 
     def point(
@@ -572,6 +635,9 @@ class COGReader(BaseReader):
             bounds=self.dataset.bounds,
             crs=self.dataset.crs,
             assets=[self.filepath],
+            band_names=get_bands_names(
+                indexes=indexes, expression=expression, count=data.shape[0]
+            ),
         )
 
 

--- a/rio_tiler/models.py
+++ b/rio_tiler/models.py
@@ -83,6 +83,30 @@ class ImageStatistics(RioTilerBaseModel):
     valid_percent: float
 
 
+class BandStatistics(RioTilerBaseModel):
+    """Image statistics"""
+
+    min: float
+    max: float
+    mean: float
+    count: float
+    sum: float
+    std: float
+    median: float
+    majority: float
+    minority: float
+    unique: float
+    histogram: List[List[NumType]]
+    valid_percent: float
+    masked_pixels: float
+    valid_pixels: float
+
+    class Config:
+        """Config for model."""
+
+        extra = "allow"
+
+
 class Metadata(Info):
     """Dataset metadata and statistics."""
 
@@ -114,6 +138,7 @@ class ImageData:
     bounds: Optional[BoundingBox] = attr.ib(default=None, converter=to_coordsbbox)
     crs: Optional[CRS] = attr.ib(default=None)
     metadata: Optional[Dict] = attr.ib(factory=dict)
+    band_names: Optional[List[str]] = attr.ib()
 
     @data.validator
     def _validate_data(self, attribute, value):
@@ -122,6 +147,10 @@ class ImageData:
             raise ValueError(
                 "ImageData data has to be an array in form of (count, height, width)"
             )
+
+    @band_names.default
+    def _default_names(self):
+        return [f"{ix + 1}" for ix in range(self.count)]
 
     @mask.default
     def _default_mask(self):


### PR DESCRIPTION
This PR will bring some important change to the `statistics` method in rio-tiler

- replaces `stats` by `statistics` method (in baseclass)
- add new `BandStatistics` model (replace `ImageStatistics`)
- add `band_names` in ImageData class (statistics can be get for expression or indexes so we need a way to forward the band information from the ImageData object to the statistics method)
- `statistics` method is only able to return stats for the full dataset (no bounds nor feature)


## To Do

- [ ] validate ☝️ changes
- [ ] update base classes (deprecate `stats` and add `statistics`)
- [ ] update tests
- [ ] update documentation
- [ ] start docs for v2 to v3 