### PR TITLE
add input in baseclass definition

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+# 3.0.0a1 (TBD)
+
+**breaking changes**
+
+* add `input` in BaseReader class definition to avoid type mismatch (https://github.com/cogeotiff/rio-tiler/pull/450)
+
+    Note: `input` replaces `filepath` attribute in STACReader and COGReader.
+
+
 # 3.0.0a0 (2021-10-19)
 
 * add `crs` property in `rio_tiler.io.base.SpatialMixin` (https://github.com/cogeotiff/rio-tiler/pull/429)

--- a/docs/readers.md
+++ b/docs/readers.md
@@ -16,16 +16,20 @@ COGReader.__mro__
  object)
 ```
 
+#### Attributes
+
+- **input** (str): filepath
+- **dataset** (rasterio dataset, optional): rasterio openned dataset
+- **tms** (morecantile.TileMatrixSet, optional): morecantile TileMatrixSet used for tile reading (defaults to WebMercator)
+- **minzoom** (int, optional): dataset's minimum zoom level (for input tms)
+- **maxzoom** (int, optional): dataset's maximum zoom level (for input tms)
+- **colormap** (dict, optional): dataset's colormap
+
 #### Properties
 
-- **dataset**: rasterio openned dataset
-- **tms**: morecantile TileMatrixSet used for tile reading
-- **minzoom**: dataset's minimum zoom level (for input tms)
-- **maxzoom**: dataset's maximum zoom level (for input tms)
 - **bounds**: dataset's bounds (in dataset crs)
 - **crs**: dataset's crs
 - **geographic_bounds**: dataset's bounds in WGS84
-- **colormap**: dataset's internal colormap
 
 
 ```python
@@ -340,7 +344,7 @@ print(stats["1"].dict())
 
 #### Read Options
 
-`COGReader` accepts several options which will be forwarded to the `rio_tiler.reader.read` function (low level function accessing the data), those options can be set as reader's attribute or within each method calls:
+`COGReader` accepts several input options which will be forwarded to the `rio_tiler.reader.read` function (low level function accessing the data), those options can be set as reader's attribute or within each method calls:
 
 - **nodata**: Overwrite the nodata value (or set if not present)
 - **unscale**: Apply internal rescaling factors
@@ -374,14 +378,24 @@ STACReader.__mro__
  object)
 ```
 
+#### Attributes
+
+- **input** (str): STAC Item path, URL or S3 URL
+- **item**: PySTAC item
+- **tms** (morecantile.TileMatrixSet, optional): morecantile TileMatrixSet used for tile reading (defaults to WebMercator)
+- **minzoom** (int, optional): dataset's minimum zoom level (for input tms)
+- **maxzoom** (int, optional): dataset's maximum zoom level (for input tms)
+- **include_assets** (set, optional): Set of assets to include from the `available` asset list
+- **exclude_assets** (set, optional): Set of assets to exclude from the `available` asset list
+- **include_asset_types** (set, optional): asset types to consider as valid type for the reader
+- **exclude_asset_types** (set, optional): asset types to consider as invalid type for the reader
+- **reader** (BaseReader, optional): Reader to use to read assets (defaults to COGReader)
+- **reader_options** (dict, optional): Options to forward to the reader init
+- **fetch_options** (dict, optional): Options to pass to the `httpx.get` or `boto3` when fetching the STAC item
+
 #### Properties
 
-- **filepath**: STAC Item path, URL or S3 URL
-- **item**: PySTAC item
 - **assets**: Asset list.
-- **tms**: morecantile TileMatrixSet used for tile reading
-- **minzoom**: dataset's minimum zoom level (for input tms)
-- **maxzoom**: dataset's maximum zoom level (for input tms)
 - **bounds**: dataset's bounds (in dataset crs)
 - **crs**: dataset's crs
 - **geographic_bounds**: dataset's bounds in WGS84
@@ -393,7 +407,7 @@ with STACReader(
     "https://1tqdbvsut9.execute-api.us-west-2.amazonaws.com/v0/collections/sentinel-s2-l2a-cogs/items/S2A_34SGA_20200318_0_L2A",
     exclude_assets={"thumbnail"}
 ) as stac:
-    print(stac.filepath)
+    print(stac.input)
     print(stac.item)
     print(stac.assets)
     print(stac.tms.identifier)

--- a/rio_tiler/io/base.py
+++ b/rio_tiler/io/base.py
@@ -97,6 +97,15 @@ class SpatialMixin:
 class BaseReader(SpatialMixin, metaclass=abc.ABCMeta):
     """Rio-tiler.io BaseReader."""
 
+    input: Any = attr.ib()
+    tms: TileMatrixSet = attr.ib(default=WEB_MERCATOR_TMS)
+
+    minzoom: int = attr.ib(init=False)
+    maxzoom: int = attr.ib(init=False)
+
+    bounds: BBox = attr.ib(init=False)
+    crs: CRS = attr.ib(init=False)
+
     def __enter__(self):
         """Support using with Context Managers."""
         return self
@@ -194,6 +203,15 @@ class BaseReader(SpatialMixin, metaclass=abc.ABCMeta):
 @attr.s
 class AsyncBaseReader(SpatialMixin, metaclass=abc.ABCMeta):
     """Rio-tiler.io AsyncBaseReader."""
+
+    input: Any = attr.ib()
+    tms: TileMatrixSet = attr.ib(default=WEB_MERCATOR_TMS)
+
+    minzoom: int = attr.ib(init=False)
+    maxzoom: int = attr.ib(init=False)
+
+    bounds: BBox = attr.ib(init=False)
+    crs: CRS = attr.ib(init=False)
 
     async def __aenter__(self):
         """Support using with Context Managers."""
@@ -311,10 +329,17 @@ class MultiBaseReader(BaseReader, metaclass=abc.ABCMeta):
 
     """
 
+    input: Any = attr.ib()
     reader: Type[BaseReader] = attr.ib()
-    reader_options: Dict = attr.ib(factory=dict)
 
+    reader_options: Dict = attr.ib(factory=dict)
     tms: TileMatrixSet = attr.ib(default=WEB_MERCATOR_TMS)
+
+    minzoom: int = attr.ib(init=False)
+    maxzoom: int = attr.ib(init=False)
+
+    bounds: BBox = attr.ib(init=False)
+    crs: CRS = attr.ib(init=False)
 
     assets: Sequence[str] = attr.ib(init=False)
 
@@ -735,10 +760,17 @@ class MultiBandReader(BaseReader, metaclass=abc.ABCMeta):
 
     """
 
+    input: Any = attr.ib()
     reader: Type[BaseReader] = attr.ib()
-    reader_options: Dict = attr.ib(factory=dict)
 
+    reader_options: Dict = attr.ib(factory=dict)
     tms: TileMatrixSet = attr.ib(default=WEB_MERCATOR_TMS)
+
+    minzoom: int = attr.ib(init=False)
+    maxzoom: int = attr.ib(init=False)
+
+    bounds: BBox = attr.ib(init=False)
+    crs: CRS = attr.ib(init=False)
 
     bands: Sequence[str] = attr.ib(init=False)
 

--- a/rio_tiler/io/cogeo.py
+++ b/rio_tiler/io/cogeo.py
@@ -41,7 +41,7 @@ class COGReader(BaseReader):
     """Cloud Optimized GeoTIFF Reader.
 
     Attributes:
-        filepath (str): Cloud Optimized GeoTIFF path.
+        input (str): Cloud Optimized GeoTIFF path.
         dataset (rasterio.io.DatasetReader or rasterio.io.DatasetWriter or rasterio.vrt.WarpedVRT, optional): Rasterio dataset.
         bounds (tuple): Dataset bounds (left, bottom, right, top).
         crs (rasterio.crs.CRS): Dataset crs.
@@ -74,7 +74,7 @@ class COGReader(BaseReader):
 
     """
 
-    filepath: str = attr.ib()
+    input: str = attr.ib()
     dataset: Union[DatasetReader, DatasetWriter, MemoryFile, WarpedVRT] = attr.ib(
         default=None
     )
@@ -111,7 +111,7 @@ class COGReader(BaseReader):
         if self.post_process is not None:
             self._kwargs["post_process"] = self.post_process
 
-        self.dataset = self.dataset or rasterio.open(self.filepath)
+        self.dataset = self.dataset or rasterio.open(self.input)
         self.bounds = tuple(self.dataset.bounds)
         self.crs = self.dataset.crs
 
@@ -133,7 +133,7 @@ class COGReader(BaseReader):
 
     def close(self):
         """Close rasterio dataset."""
-        if self.filepath:
+        if self.input:
             self.dataset.close()
 
     def __exit__(self, exc_type, exc_value, traceback):
@@ -313,7 +313,7 @@ class COGReader(BaseReader):
         """
         if not self.tile_exists(tile_x, tile_y, tile_z):
             raise TileOutsideBounds(
-                f"Tile {tile_z}/{tile_x}/{tile_y} is outside {self.filepath} bounds"
+                f"Tile {tile_z}/{tile_x}/{tile_y} is outside {self.input} bounds"
             )
 
         tile_bounds = self.tms.xy_bounds(Tile(x=tile_x, y=tile_y, z=tile_z))
@@ -420,7 +420,7 @@ class COGReader(BaseReader):
             mask,
             bounds=bbox,
             crs=dst_crs,
-            assets=[self.filepath],
+            assets=[self.input],
             band_names=get_bands_names(
                 indexes=indexes, expression=expression, count=data.shape[0]
             ),
@@ -482,7 +482,7 @@ class COGReader(BaseReader):
             mask,
             bounds=self.bounds,
             crs=self.crs,
-            assets=[self.filepath],
+            assets=[self.input],
             band_names=get_bands_names(
                 indexes=indexes, expression=expression, count=data.shape[0]
             ),
@@ -631,7 +631,7 @@ class COGReader(BaseReader):
             mask,
             bounds=self.bounds,
             crs=self.crs,
-            assets=[self.filepath],
+            assets=[self.input],
             band_names=get_bands_names(
                 indexes=indexes, expression=expression, count=data.shape[0]
             ),
@@ -643,7 +643,7 @@ class GCPCOGReader(COGReader):
     """Custom COG Reader with GCPS support.
 
     Attributes:
-        filepath (str): Cloud Optimized GeoTIFF path.
+        input (str): Cloud Optimized GeoTIFF path.
         src_dataset (rasterio.io.DatasetReader or rasterio.io.DatasetWriter or rasterio.vrt.WarpedVRT, optional): Rasterio dataset.
         tms (morecantile.TileMatrixSet, optional): TileMatrixSet grid definition. Defaults to `WebMercatorQuad`.
         minzoom (int, optional): Overwrite Min Zoom level.
@@ -668,7 +668,7 @@ class GCPCOGReader(COGReader):
 
     """
 
-    filepath: str = attr.ib()
+    input: str = attr.ib()
     src_dataset: Union[DatasetReader, DatasetWriter, MemoryFile, WarpedVRT] = attr.ib(
         default=None
     )
@@ -695,7 +695,7 @@ class GCPCOGReader(COGReader):
 
     def __attrs_post_init__(self):
         """Define _kwargs, open dataset and get info."""
-        self.src_dataset = self.src_dataset or rasterio.open(self.filepath)
+        self.src_dataset = self.src_dataset or rasterio.open(self.input)
         self.dataset = WarpedVRT(
             self.src_dataset,
             src_crs=self.src_dataset.gcps[1],
@@ -706,5 +706,5 @@ class GCPCOGReader(COGReader):
     def close(self):
         """Close rasterio dataset."""
         self.dataset.close()
-        if self.filepath:
+        if self.input:
             self.src_dataset.close()

--- a/rio_tiler/io/stac.py
+++ b/rio_tiler/io/stac.py
@@ -122,7 +122,7 @@ class STACReader(MultiBaseReader):
     """STAC Reader.
 
     Attributes:
-        filepath (str): STAC Item path, URL or S3 URL.
+        input (str): STAC Item path, URL or S3 URL.
         item (dict or pystac.Item, STAC): Stac Item.
         minzoom (int, optional): Set minzoom for the tiles.
         maxzoom (int, optional): Set maxzoom for the tiles.
@@ -153,7 +153,7 @@ class STACReader(MultiBaseReader):
 
     """
 
-    filepath: str = attr.ib()
+    input: str = attr.ib()
     item: pystac.Item = attr.ib(default=None, converter=_to_pystac_item)
 
     tms: TileMatrixSet = attr.ib(default=WEB_MERCATOR_TMS)
@@ -174,7 +174,7 @@ class STACReader(MultiBaseReader):
     def __attrs_post_init__(self):
         """Fetch STAC Item and get list of valid assets."""
         self.item = self.item or pystac.Item.from_dict(
-            fetch(self.filepath, **self.fetch_options), self.filepath
+            fetch(self.input, **self.fetch_options), self.input
         )
 
         # TODO: get bounds/crs using PROJ extension if availble

--- a/tests/test_io_MultiBand.py
+++ b/tests/test_io_MultiBand.py
@@ -21,16 +21,19 @@ default_tms = morecantile.tms.get("WebMercatorQuad")
 class BandFileReader(MultiBandReader):
     """Test MultiBand"""
 
-    path: str = attr.ib()
+    input: str = attr.ib()
     reader: Type[BaseReader] = attr.ib(default=COGReader)
-    reader_options: Dict = attr.ib(factory=dict)
 
+    reader_options: Dict = attr.ib(factory=dict)
     tms: morecantile.TileMatrixSet = attr.ib(default=default_tms)
 
     def __attrs_post_init__(self):
         """Parse Sceneid and get grid bounds."""
         self.bands = sorted(
-            [p.stem.split("_")[1] for p in pathlib.Path(self.path).glob("*scene_*.tif")]
+            [
+                p.stem.split("_")[1]
+                for p in pathlib.Path(self.input).glob("*scene_*.tif")
+            ]
         )
         with self.reader(self._get_band_url(self.bands[0])) as cog:
             self.bounds = cog.bounds
@@ -40,7 +43,7 @@ class BandFileReader(MultiBandReader):
 
     def _get_band_url(self, band: str) -> str:
         """Validate band's name and return band's url."""
-        return os.path.join(self.path, f"scene_{band}.tif")
+        return os.path.join(self.input, f"scene_{band}.tif")
 
 
 def test_MultiBandReader():

--- a/tests/test_io_async.py
+++ b/tests/test_io_async.py
@@ -48,53 +48,53 @@ async def run_in_threadpool(
 @attr.s
 class AsyncCOGReader(AsyncBaseReader):
 
-    dataset: Type[COGReader] = attr.ib()
+    input: Type[COGReader] = attr.ib()
     tms: morecantile.TileMatrixSet = attr.ib(default=WEB_MERCATOR_TMS)
 
     def __attrs_post_init__(self):
         """Update dataset info."""
-        self.bounds = self.dataset.bounds
-        self.crs = self.dataset.crs
-        self.minzoom = self.dataset.minzoom
-        self.maxzoom = self.dataset.maxzoom
+        self.bounds = self.input.bounds
+        self.crs = self.input.crs
+        self.minzoom = self.input.minzoom
+        self.maxzoom = self.input.maxzoom
 
     async def info(self) -> Coroutine[Any, Any, Info]:
         """Return Dataset's info."""
-        return await run_in_threadpool(self.dataset.info)  # type: ignore
+        return await run_in_threadpool(self.input.info)  # type: ignore
 
     async def statistics(
         self, **kwargs: Any
     ) -> Coroutine[Any, Any, Dict[str, BandStatistics]]:
         """Return Dataset's statistics."""
-        return await run_in_threadpool(self.dataset.statistics, **kwargs)  # type: ignore
+        return await run_in_threadpool(self.input.statistics, **kwargs)  # type: ignore
 
     async def tile(
         self, tile_x: int, tile_y: int, tile_z: int, **kwargs: Any
     ) -> Coroutine[Any, Any, ImageData]:
         """Read a Map tile from the Dataset."""
         return await run_in_threadpool(
-            self.dataset.tile, tile_x, tile_y, tile_z, **kwargs  # type: ignore
+            self.input.tile, tile_x, tile_y, tile_z, **kwargs  # type: ignore
         )
 
     async def part(self, bbox: BBox, **kwargs: Any) -> Coroutine[Any, Any, ImageData]:
         """Read a Part of a Dataset."""
-        return await run_in_threadpool(self.dataset.part, bbox, **kwargs)  # type: ignore
+        return await run_in_threadpool(self.input.part, bbox, **kwargs)  # type: ignore
 
     async def preview(self, **kwargs: Any) -> Coroutine[Any, Any, ImageData]:
         """Return a preview of a Dataset."""
-        return await run_in_threadpool(self.dataset.preview, **kwargs)  # type: ignore
+        return await run_in_threadpool(self.input.preview, **kwargs)  # type: ignore
 
     async def point(
         self, lon: float, lat: float, **kwargs: Any
     ) -> Coroutine[Any, Any, List]:
         """Read a value from a Dataset."""
-        return await run_in_threadpool(self.dataset.point, lon, lat, **kwargs)  # type: ignore
+        return await run_in_threadpool(self.input.point, lon, lat, **kwargs)  # type: ignore
 
     async def feature(
         self, shape: Dict, **kwargs: Any
     ) -> Coroutine[Any, Any, ImageData]:
         """Read a Dataset for a GeoJSON feature"""
-        return await run_in_threadpool(self.dataset.feature, shape, **kwargs)  # type: ignore
+        return await run_in_threadpool(self.input.feature, shape, **kwargs)  # type: ignore
 
 
 @pytest.mark.asyncio

--- a/tests/test_io_stac.py
+++ b/tests/test_io_stac.py
@@ -39,7 +39,7 @@ def test_fetch_stac(httpx, s3_get):
         assert stac.minzoom == 0
         assert stac.maxzoom == 24
         assert stac.bounds
-        assert stac.filepath == STAC_PATH
+        assert stac.input == STAC_PATH
         assert stac.assets == ["red", "green", "blue"]
     httpx.assert_not_called()
     s3_get.assert_not_called()
@@ -48,7 +48,7 @@ def test_fetch_stac(httpx, s3_get):
     with STACReader(None, item=item) as stac:
         assert stac.minzoom == 0
         assert stac.maxzoom == 24
-        assert not stac.filepath
+        assert not stac.input
         assert stac.assets == ["red", "green", "blue"]
     httpx.assert_not_called()
     s3_get.assert_not_called()


### PR DESCRIPTION
This PR adds `input` attribute in the BaseReader abstract class. This is to avoid type mismatch for tools using BaseReader type as input. I think most of Reader will need an `input` anyway so it's safe to add it in the baseclass. 