### PR TITLE
Multi*Reader `info` and `statistics` methods to default to available `bands` or `assets`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+
+# 3.0.0a3 (2021-11-03)
+
+* Reader's `info` and `statistics` methods to default to available `bands` or `assets` if not provided (https://github.com/cogeotiff/rio-tiler/pull/451)
+
 # 3.0.0a2 (2021-10-21)
 
 * Allow `rio_tiler.utils.get_array_statistics` to return `0` for unfound category, instead of raising an error (https://github.com/cogeotiff/rio-tiler/pull/443)

--- a/rio_tiler/io/base.py
+++ b/rio_tiler/io/base.py
@@ -366,8 +366,7 @@ class MultiBaseReader(BaseReader, metaclass=abc.ABCMeta):
             dict: Multiple assets info in form of {"asset1": rio_tile.models.Info}.
 
         """
-        if not assets:
-            raise MissingAssets("Missing 'assets' option")
+        assets = assets or self.assets
 
         if isinstance(assets, str):
             assets = (assets,)
@@ -398,8 +397,7 @@ class MultiBaseReader(BaseReader, metaclass=abc.ABCMeta):
             dict: Multiple assets statistics in form of {"asset1": {"1": rio_tiler.models.BandStatistics, ...}}.
 
         """
-        if not assets:
-            raise MissingAssets("Missing 'assets' option")
+        assets = assets or self.assets
 
         if isinstance(assets, str):
             assets = (assets,)
@@ -797,8 +795,7 @@ class MultiBandReader(BaseReader, metaclass=abc.ABCMeta):
             dict: Multiple bands info in form of {"band1": rio_tile.models.Info}.
 
         """
-        if not bands:
-            raise MissingBands("Missing 'bands' option")
+        bands = bands or self.bands
 
         if isinstance(bands, str):
             bands = (bands,)
@@ -859,6 +856,9 @@ class MultiBandReader(BaseReader, metaclass=abc.ABCMeta):
             dict: Multiple assets statistics in form of {"{band}/{expression}": rio_tiler.models.BandStatistics, ...}.
 
         """
+        if not expression:
+            bands = bands or self.bands
+
         data = self.preview(
             bands=bands, expression=expression, max_size=max_size, **kwargs,
         )

--- a/rio_tiler/io/base.py
+++ b/rio_tiler/io/base.py
@@ -366,6 +366,12 @@ class MultiBaseReader(BaseReader, metaclass=abc.ABCMeta):
             dict: Multiple assets info in form of {"asset1": rio_tile.models.Info}.
 
         """
+        if not assets:
+            warnings.warn(
+                "No `assets` option passed, will fetch info for all available assets.",
+                UserWarning,
+            )
+
         assets = assets or self.assets
 
         if isinstance(assets, str):
@@ -397,6 +403,12 @@ class MultiBaseReader(BaseReader, metaclass=abc.ABCMeta):
             dict: Multiple assets statistics in form of {"asset1": {"1": rio_tiler.models.BandStatistics, ...}}.
 
         """
+        if not assets:
+            warnings.warn(
+                "No `assets` option passed, will fetch statistics for all available assets.",
+                UserWarning,
+            )
+
         assets = assets or self.assets
 
         if isinstance(assets, str):
@@ -795,6 +807,12 @@ class MultiBandReader(BaseReader, metaclass=abc.ABCMeta):
             dict: Multiple bands info in form of {"band1": rio_tile.models.Info}.
 
         """
+        if not bands:
+            warnings.warn(
+                "No `bands` option passed, will fetch info for all available bands.",
+                UserWarning,
+            )
+
         bands = bands or self.bands
 
         if isinstance(bands, str):
@@ -857,6 +875,11 @@ class MultiBandReader(BaseReader, metaclass=abc.ABCMeta):
 
         """
         if not expression:
+            if not bands:
+                warnings.warn(
+                    "No `bands` option passed, will fetch statistics for all available bands.",
+                    UserWarning,
+                )
             bands = bands or self.bands
 
         data = self.preview(

--- a/tests/test_io_MultiBand.py
+++ b/tests/test_io_MultiBand.py
@@ -58,7 +58,8 @@ def test_MultiBandReader():
 
         assert sorted(cog.parse_expression("b1/b2")) == ["b1", "b2"]
 
-        meta = cog.info()
+        with pytest.warns(UserWarning):
+            meta = cog.info()
         assert meta.band_descriptions == [("b1", ""), ("b2", "")]
 
         meta = cog.info(bands="b1")
@@ -67,9 +68,10 @@ def test_MultiBandReader():
         meta = cog.info(bands=("b1", "b2"))
         assert meta.band_descriptions == [("b1", ""), ("b2", "")]
 
-        stats = cog.statistics()
-        assert stats["b1"]
-        assert stats["b2"]
+        with pytest.warns(UserWarning):
+            stats = cog.statistics()
+            assert stats["b1"]
+            assert stats["b2"]
 
         stats = cog.statistics(bands="b1")
         assert "b1" in stats

--- a/tests/test_io_MultiBand.py
+++ b/tests/test_io_MultiBand.py
@@ -58,8 +58,8 @@ def test_MultiBandReader():
 
         assert sorted(cog.parse_expression("b1/b2")) == ["b1", "b2"]
 
-        with pytest.raises(MissingBands):
-            cog.info()
+        meta = cog.info()
+        assert meta.band_descriptions == [("b1", ""), ("b2", "")]
 
         meta = cog.info(bands="b1")
         assert meta.band_descriptions == [("b1", "")]
@@ -67,8 +67,9 @@ def test_MultiBandReader():
         meta = cog.info(bands=("b1", "b2"))
         assert meta.band_descriptions == [("b1", ""), ("b2", "")]
 
-        with pytest.raises(MissingBands):
-            cog.statistics()
+        stats = cog.statistics()
+        assert stats["b1"]
+        assert stats["b2"]
 
         stats = cog.statistics(bands="b1")
         assert "b1" in stats

--- a/tests/test_io_stac.py
+++ b/tests/test_io_stac.py
@@ -354,8 +354,10 @@ def test_statistics_valid(rio):
     rio.open = mock_rasterio_open
 
     with STACReader(STAC_PATH) as stac:
-        with pytest.raises(MissingAssets):
-            stac.statistics()
+        stats = stac.statistics()
+        assert stats["red"]
+        assert stats["green"]
+        assert stats["blue"]
 
         with pytest.raises(InvalidAssetName):
             stac.statistics(assets="vert")
@@ -399,6 +401,11 @@ def test_info_valid(rio):
     with STACReader(STAC_PATH) as stac:
         with pytest.raises(InvalidAssetName):
             stac.info(assets="vert")
+
+        meta = stac.info()
+        assert meta["red"]
+        assert meta["green"]
+        assert meta["blue"]
 
         meta = stac.info(assets="green")
         assert meta["green"]

--- a/tests/test_io_stac.py
+++ b/tests/test_io_stac.py
@@ -354,10 +354,11 @@ def test_statistics_valid(rio):
     rio.open = mock_rasterio_open
 
     with STACReader(STAC_PATH) as stac:
-        stats = stac.statistics()
-        assert stats["red"]
-        assert stats["green"]
-        assert stats["blue"]
+        with pytest.warns(UserWarning):
+            stats = stac.statistics()
+            assert stats["red"]
+            assert stats["green"]
+            assert stats["blue"]
 
         with pytest.raises(InvalidAssetName):
             stac.statistics(assets="vert")
@@ -402,10 +403,11 @@ def test_info_valid(rio):
         with pytest.raises(InvalidAssetName):
             stac.info(assets="vert")
 
-        meta = stac.info()
-        assert meta["red"]
-        assert meta["green"]
-        assert meta["blue"]
+        with pytest.warns(UserWarning):
+            meta = stac.info()
+            assert meta["red"]
+            assert meta["green"]
+            assert meta["blue"]
 
         meta = stac.info(assets="green")
         assert meta["green"]


### PR DESCRIPTION
closes #451 