### PR TITLE
update black version and fix typos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 19.10b0
+    rev: 21.10b0
     hooks:
       - id: black
         language_version: python

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ data and metadata from any raster source supported by Rasterio/GDAL.
 This includes local files and via HTTP, AWS S3, Google Cloud Storage,
 etc.
 
-At the low level, `rio-tiler` is *just* a wrapper around the [rasterio.vrt.WarpedVRT](https://github.com/rasterio/rasterio/blob/5b76d05fb374e64602166d6cd880c38424fad39b/rasterio/vrt.py#L15) class, which can be useful for doing reprojection and/or property overriding (e.g nodata value).
+At the low level, `rio-tiler` is *just* a wrapper around the [rasterio.vrt.WarpedVRT](https://github.com/rasterio/rasterio/blob/5b76d05fb374e64602166d6cd880c38424fad39b/rasterio/vrt.py#L15) class, which can be useful for doing re-projection and/or property overriding (e.g nodata value).
 
 ## Features
 
@@ -73,7 +73,7 @@ At the low level, `rio-tiler` is *just* a wrapper around the [rasterio.vrt.Warpe
         img = image.point(lon,lat)           # get pixel values for a lon/lat coordinates
     ```
 
-- Enable property assignement (e.g nodata) on data reading
+- Enable property assignment (e.g nodata) on data reading
 
     ```python
     from rio_tiler.io import COGReader

--- a/docs/colormap.md
+++ b/docs/colormap.md
@@ -39,11 +39,11 @@ The `render` method accept colormap in form of:
 }
 ```
 
-Colormaps can be `discrete` (having sparse value) or `linear` (with values stricly from 0 to 255).
+Colormaps can be `discrete` (having sparse value) or `linear` (with values strictly from 0 to 255).
 
 ### Custom colormaps
 
-The `rio_tiler.colormap.cmap` object holds the list of default colormaps and also allow users to registed new ones.
+The `rio_tiler.colormap.cmap` object holds the list of default colormaps and also allow users to registered new ones.
 
 **discrete** (with custom entries, not limited to uint8 type)
 
@@ -96,9 +96,9 @@ ndvi_dict = {idx: value.tolist() for idx, value in enumerate(cmap_uint8)}
 cmap = cmap.register({"ndvi": ndvi_dict})
 ```
 
-### Internvals colormaps
+### Intervals colormaps
 
-Starting with `rio-tiler` 3.0, *intervals* colormap support has been added. This is usefull when you want to define color breaks for a given data.
+Starting with `rio-tiler` 3.0, *intervals* colormap support has been added. This is useful when you want to define color breaks for a given data.
 
 !!! warnings
     For `intervals`, colormap has to be in form of `Sequence[Tuple[Sequence, Sequence]]`:

--- a/docs/models.md
+++ b/docs/models.md
@@ -3,7 +3,7 @@
 
 Reader methods returning image data  (`tile`, `part`, `feature` and `preview`) return a *data holding* class: `rio_tiler.models.ImageData`.
 
-This class has helper methods like `render` which forward internal data and mask to `rio_tiler.utils.render` method, but also helps preserving geospatial informations (`bounds` and `crs`) about the data.
+This class has helper methods like `render` which forward internal data and mask to `rio_tiler.utils.render` method, but also helps preserving geospatial information (`bounds` and `crs`) about the data.
 
 #### Attributes
 

--- a/docs/mosaic.md
+++ b/docs/mosaic.md
@@ -123,14 +123,14 @@ When dealing with an important number of image, you might not want to process th
 ```python
 mosaic_assets = ["1.tif", "2.tif", "3.tif", "4.tif", "5.tif", "6.tif"]
 
-# 1st level loop - Creates chuncks of assets
+# 1st level loop - Creates chunks of assets
 for chunks in _chunks(mosaic_assets, chunk_size):
 
-    # 2nd level loop - Uses threads for process each `chunck`
+    # 2nd level loop - Uses threads for process each `chunk`
     with futures.ThreadPoolExecutor(max_workers=max_threads) as executor:
         future_tasks = [(executor.submit(_tiler, asset), asset) for asset in chunks]
 ```
-By default the chunck_size is equal to the number or threads (or the number of assets if no threads=0)
+By default the chunk_size is equal to the number or threads (or the number of assets if no threads=0)
 
 #### More on threading
 

--- a/docs/readers.md
+++ b/docs/readers.md
@@ -1,11 +1,11 @@
 
-`rio-tiler`'s  COGReader and STACReader are built from its abstract base classes (`AsyncBaseReader`, `BaseReader`, `MultiBandReader`, `MultiBaseReader`). Thoses Classes implements defaults interfaces which helps the integration in broder application. To learn more about `rio-tiler`'s base classes see [Base classes and custom readers](advanced/custom_readers.md)
+`rio-tiler`'s  COGReader and STACReader are built from its abstract base classes (`AsyncBaseReader`, `BaseReader`, `MultiBandReader`, `MultiBaseReader`). Those Classes implements defaults interfaces which helps the integration in broader application. To learn more about `rio-tiler`'s base classes see [Base classes and custom readers](advanced/custom_readers.md)
 
 ## rio_tiler.io.COGReader
 
 The `COGReader` is designed to work with simple raster datasets (e.g COG, GeoTIFF, ...).
 
-The class is derieved from the `rio_tiler.io.base.BaseReader` base class.
+The class is derived from the `rio_tiler.io.base.BaseReader` base class.
 ```python
 from rio_tiler.io import COGReader
 
@@ -19,7 +19,7 @@ COGReader.__mro__
 #### Attributes
 
 - **input** (str): filepath
-- **dataset** (rasterio dataset, optional): rasterio openned dataset
+- **dataset** (rasterio dataset, optional): rasterio opened dataset
 - **tms** (morecantile.TileMatrixSet, optional): morecantile TileMatrixSet used for tile reading (defaults to WebMercator)
 - **minzoom** (int, optional): dataset's minimum zoom level (for input tms)
 - **maxzoom** (int, optional): dataset's maximum zoom level (for input tms)
@@ -366,7 +366,7 @@ with COGReader("my_cog.tif") as cog:
 
 In `rio-tiler` v2, we added a `rio_tiler.io.STACReader` to allow tile/metadata fetching of assets withing a STAC item.
 
-The class is derieved from the `rio_tiler.io.base.MultiBaseReader` base class which help handling responses from multiple `BaseReader` (each asset will be read with a `BaseReader`).
+The class is derived from the `rio_tiler.io.base.MultiBaseReader` base class which help handling responses from multiple `BaseReader` (each asset will be read with a `BaseReader`).
 ```python
 from rio_tiler.io import STACReader
 

--- a/docs/scripts/colormap_thumb.py
+++ b/docs/scripts/colormap_thumb.py
@@ -126,16 +126,14 @@ gradient = np.vstack((gradient, gradient))
 
 
 def make_colormap(name):
-    """Use rio-tiler colormap to create matplotlib colormap
-    """
+    """Use rio-tiler colormap to create matplotlib colormap"""
     colormap = make_lut(cmap.get(name))
     # rescale to 0-1
     return ListedColormap(colormap / 255, name=name)
 
 
 def plot_color_gradients(cmap_category, cmap_list):
-    """Make
-    """
+    """Make"""
     # Create figure and adjust figure height to number of colormaps
     nrows = len(cmap_list)
     figh = 0.35 + 0.15 + (nrows + (nrows - 1) * 0.1) * 0.22

--- a/docs/v3_migration.md
+++ b/docs/v3_migration.md
@@ -4,12 +4,12 @@ document aims to help with migrating your code to use `rio-tiler` 3.0.
 
 ## Morecantile 2.0 -> 3.0
 
-Morecantil 3.0 switched from rasterio to pyproj for the coordinates transformation processes (https://github.com/developmentseed/morecantile/blob/master/CHANGES.md#300a0-2021-09-09).
+Morecantile 3.0 switched from rasterio to pyproj for the coordinates transformation processes (https://github.com/developmentseed/morecantile/blob/master/CHANGES.md#300a0-2021-09-09).
 Morecantile and Pyproj require python >= 3.7 which means rio-tiler had to remove python 3.6 supports.
 
 ## Bounds and CRS properties
 
-Previously the `BaseReader.bounds` property was set to the `wgs84` representation of the dataset bounds but to accomodate to non-earth dataset we changed this and decided to store the native dataset `bounds`. We've also added `BaseReader.crs` to make sure user can work with the `bounds` property.
+Previously the `BaseReader.bounds` property was set to the `wgs84` representation of the dataset bounds but to accommodate to non-earth dataset we changed this and decided to store the native dataset `bounds`. We've also added `BaseReader.crs` to make sure user can work with the `bounds` property.
 
 We've added a `BaseReader.geographic_bounds`, which will return the `bounds` in WGS84.
 

--- a/rio_tiler/colormap.py
+++ b/rio_tiler/colormap.py
@@ -307,7 +307,9 @@ class ColorMaps:
         return list(self.data)
 
     def register(
-        self, custom_cmap: Dict[str, Union[str, Dict]], overwrite: bool = False,
+        self,
+        custom_cmap: Dict[str, Union[str, Dict]],
+        overwrite: bool = False,
     ) -> "ColorMaps":
         """Register a custom colormap.
 

--- a/rio_tiler/errors.py
+++ b/rio_tiler/errors.py
@@ -30,7 +30,7 @@ class InvalidColorMapName(RioTilerError):
 
 
 class AlphaBandWarning(UserWarning):
-    """Automaticaly removed Alpha band from output array."""
+    """Automatically removed Alpha band from output array."""
 
 
 class NoOverviewWarning(UserWarning):

--- a/rio_tiler/expression.py
+++ b/rio_tiler/expression.py
@@ -30,7 +30,9 @@ def parse_expression(expression: str, cast: bool = True) -> Tuple:
 
 
 def apply_expression(
-    blocks: Sequence[str], bands: Sequence[Union[str, int]], data: numpy.ndarray,
+    blocks: Sequence[str],
+    bands: Sequence[Union[str, int]],
+    data: numpy.ndarray,
 ) -> numpy.ndarray:
     """Apply rio-tiler expression.
 

--- a/rio_tiler/io/base.py
+++ b/rio_tiler/io/base.py
@@ -48,7 +48,10 @@ class SpatialMixin:
         """return bounds in WGS84."""
         try:
             bounds = transform_bounds(
-                self.crs, WGS84_CRS, *self.bounds, densify_pts=21,
+                self.crs,
+                WGS84_CRS,
+                *self.bounds,
+                densify_pts=21,
             )
         except:  # noqa
             warnings.warn(
@@ -75,14 +78,20 @@ class SpatialMixin:
 
         try:
             dataset_bounds = transform_bounds(
-                self.crs, self.tms.rasterio_crs, *self.bounds, densify_pts=21,
+                self.crs,
+                self.tms.rasterio_crs,
+                *self.bounds,
+                densify_pts=21,
             )
         except:  # noqa
             # HACK: gdal will first throw an error for invalid transformation
             # but if retried it will then pass.
             # Note: It might return `+/-inf` values
             dataset_bounds = transform_bounds(
-                self.crs, self.tms.rasterio_crs, *self.bounds, densify_pts=21,
+                self.crs,
+                self.tms.rasterio_crs,
+                *self.bounds,
+                densify_pts=21,
             )
 
         return (
@@ -178,7 +187,7 @@ class BaseReader(SpatialMixin, metaclass=abc.ABCMeta):
 
         Args:
             lon (float): Longitude.
-            lat (float): Latittude.
+            lat (float): Latitude.
 
         Returns:
             list: Pixel value per bands/assets.
@@ -233,7 +242,8 @@ class AsyncBaseReader(SpatialMixin, metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     async def statistics(
-        self, **kwargs: Any,
+        self,
+        **kwargs: Any,
     ) -> Coroutine[Any, Any, Dict[str, BandStatistics]]:
         """Return bands statistics from a dataset.
 
@@ -291,7 +301,7 @@ class AsyncBaseReader(SpatialMixin, metaclass=abc.ABCMeta):
 
         Args:
             lon (float): Longitude.
-            lat (float): Latittude.
+            lat (float): Latitude.
 
         Returns:
             list: Pixel value per bands/assets.
@@ -493,7 +503,14 @@ class MultiBaseReader(BaseReader, metaclass=abc.ABCMeta):
                 data.band_names = [f"{asset}_{n}" for n in data.band_names]
                 return data
 
-        output = multi_arrays(assets, _reader, tile_x, tile_y, tile_z, **kwargs,)
+        output = multi_arrays(
+            assets,
+            _reader,
+            tile_x,
+            tile_y,
+            tile_z,
+            **kwargs,
+        )
 
         if expression:
             blocks = expression.split(",")
@@ -641,7 +658,7 @@ class MultiBaseReader(BaseReader, metaclass=abc.ABCMeta):
 
         Args:
             lon (float): Longitude.
-            lat (float): Latittude.
+            lat (float): Latitude.
             assets (sequence of str or str, optional): assets to fetch info from.
             expression (str, optional): rio-tiler expression for the asset list (e.g. asset1/asset2+asset3).
             asset_indexes (dict, optional): Band indexes for each asset (e.g {"asset1": 1, "asset2": (1, 2,)}).
@@ -864,7 +881,7 @@ class MultiBandReader(BaseReader, metaclass=abc.ABCMeta):
             bands (sequence of str or str): bands to fetch info from. Required keyword argument.
             expression (str, optional): rio-tiler expression for the band list (e.g. b1/b2+b3).
             categorical (bool): treat input data as categorical data. Defaults to False.
-            categories (list of numbers, optional): list of caterogies to return value for.
+            categories (list of numbers, optional): list of categories to return value for.
             percentiles (list of numbers, optional): list of percentile values to calculate. Defaults to `[2, 98]`.
             hist_options (dict, optional): Options to forward to numpy.histogram function.
             max_size (int, optional): Limit the size of the longest dimension of the dataset read, respecting bounds X/Y aspect ratio. Defaults to 1024.
@@ -883,7 +900,10 @@ class MultiBandReader(BaseReader, metaclass=abc.ABCMeta):
             bands = bands or self.bands
 
         data = self.preview(
-            bands=bands, expression=expression, max_size=max_size, **kwargs,
+            bands=bands,
+            expression=expression,
+            max_size=max_size,
+            **kwargs,
         )
 
         hist_options = hist_options or {}
@@ -953,7 +973,7 @@ class MultiBandReader(BaseReader, metaclass=abc.ABCMeta):
                 data.band_names = [band]
                 return data
 
-        output = multi_arrays(bands, _reader, tile_x, tile_y, tile_z, **kwargs,)
+        output = multi_arrays(bands, _reader, tile_x, tile_y, tile_z, **kwargs)
 
         if expression:
             blocks = expression.split(",")
@@ -1076,7 +1096,7 @@ class MultiBandReader(BaseReader, metaclass=abc.ABCMeta):
 
         Args:
             lon (float): Longitude.
-            lat (float): Latittude.
+            lat (float): Latitude.
             bands (sequence of str or str, optional): bands to fetch info from.
             expression (str, optional): rio-tiler expression for the band list (e.g. b1/b2+b3).
             kwargs (optional): Options to forward to the `self.reader.point` method.
@@ -1105,7 +1125,7 @@ class MultiBandReader(BaseReader, metaclass=abc.ABCMeta):
         def _reader(band: str, *args, **kwargs: Any) -> Dict:
             url = self._get_band_url(band)
             with self.reader(url, tms=self.tms, **self.reader_options) as cog:  # type: ignore
-                return cog.point(*args, **kwargs)[0]  # We only return the firt value
+                return cog.point(*args, **kwargs)[0]  # We only return the first value
 
         data = multi_values(bands, _reader, lon, lat, **kwargs)
 

--- a/rio_tiler/io/cogeo.py
+++ b/rio_tiler/io/cogeo.py
@@ -174,7 +174,7 @@ class COGReader(BaseReader):
         except:  # noqa
             # if we can't get min/max zoom from the dataset we default to TMS min/max zoom
             warnings.warn(
-                "Cannot dertermine min/max zoom based on dataset informations, will default to TMS min/max zoom.",
+                "Cannot dertermine min/max zoom based on dataset information, will default to TMS min/max zoom.",
                 UserWarning,
             )
             minzoom, maxzoom = self.tms.minzoom, self.tms.maxzoom
@@ -255,7 +255,7 @@ class COGReader(BaseReader):
 
         Args:
             categorical (bool): treat input data as categorical data. Defaults to False.
-            categories (list of numbers, optional): list of caterogies to return value for.
+            categories (list of numbers, optional): list of categories to return value for.
             percentiles (list of numbers, optional): list of percentile values to calculate. Defaults to `[2, 98]`.
             hist_options (dict, optional): Options to forward to numpy.histogram function.
             max_size (int, optional): Limit the size of the longest dimension of the dataset read, respecting bounds X/Y aspect ratio. Defaults to 1024.
@@ -501,7 +501,7 @@ class COGReader(BaseReader):
 
         Args:
             lon (float): Longitude.
-            lat (float): Latittude.
+            lat (float): Latitude.
             coord_crs (rasterio.crs.CRS, optional): Coordinate Reference System of the input coords. Defaults to `epsg:4326`.
             indexes (sequence of int or int, optional): Band indexes.
             expression (str, optional): rio-tiler expression (e.g. b1/b2+b3).

--- a/rio_tiler/io/stac.py
+++ b/rio_tiler/io/stac.py
@@ -177,7 +177,7 @@ class STACReader(MultiBaseReader):
             fetch(self.input, **self.fetch_options), self.input
         )
 
-        # TODO: get bounds/crs using PROJ extension if availble
+        # TODO: get bounds/crs using PROJ extension if available
         self.bounds = self.item.bbox
         self.crs = WGS84_CRS
 

--- a/rio_tiler/mosaic/reader.py
+++ b/rio_tiler/mosaic/reader.py
@@ -77,7 +77,10 @@ def mosaic_reader(
 
     for chunks in _chunks(mosaic_assets, chunk_size):
         tasks = create_tasks(reader, chunks, threads, *args, **kwargs)
-        for img, asset in filter_tasks(tasks, allowed_exceptions=allowed_exceptions,):
+        for img, asset in filter_tasks(
+            tasks,
+            allowed_exceptions=allowed_exceptions,
+        ):
             if isinstance(img, tuple):
                 img = ImageData(*img)
 

--- a/rio_tiler/reader.py
+++ b/rio_tiler/reader.py
@@ -101,7 +101,9 @@ def read(
                 resampling=resampling,
             )
             mask = vrt.dataset_mask(
-                window=window, out_shape=mask_out_shape, resampling=resampling,
+                window=window,
+                out_shape=mask_out_shape,
+                resampling=resampling,
             )
 
         if force_binary_mask:
@@ -135,15 +137,15 @@ def part(
 
     Args:
         src_dst (rasterio.io.DatasetReader or rasterio.io.DatasetWriter or rasterio.vrt.WarpedVRT): Rasterio dataset.
-        bounds (tuple): Output bounds (left, bottom, right, top). By default the cordinates are considered to be in either the dataset CRS or in the `dst_crs` if set. Use `bounds_crs` to set a specific CRS.
+        bounds (tuple): Output bounds (left, bottom, right, top). By default the coordinates are considered to be in either the dataset CRS or in the `dst_crs` if set. Use `bounds_crs` to set a specific CRS.
         height (int, optional): Output height of the array.
         width (int, optional): Output width of the array.
         padding (int, optional): Padding to apply to each edge of the tile when retrieving data to assist in reducing resampling artefacts along edges. Defaults to `0`.
         dst_crs (rasterio.crs.CRS, optional): Target coordinate reference system.
         bounds_crs (rasterio.crs.CRS, optional): Overwrite bounds Coordinate Reference System.
-        minimum_overlap (float, optional): Minimum % overlap for which to raise an error with dataset not covering enought of the tile.
+        minimum_overlap (float, optional): Minimum % overlap for which to raise an error with dataset not covering enough of the tile.
         vrt_options (dict, optional): Options to be passed to the rasterio.warp.WarpedVRT class.
-        max_size (int, optional): Limit output size array if not widht and height.
+        max_size (int, optional): Limit output size array if not width and height.
         kwargs (optional): Additional options to forward to `rio_tiler.reader.read`.
 
     Returns:
@@ -243,7 +245,7 @@ def preview(
 
     Args:
         src_dst (rasterio.io.DatasetReader or rasterio.io.DatasetWriter or rasterio.vrt.WarpedVRT): Rasterio dataset.
-        max_size (int, optional): Limit output size array if not widht and height. Defaults to `1024`.
+        max_size (int, optional): Limit output size array if not width and height. Defaults to `1024`.
         height (int, optional): Output height of the array.
         width (int, optional): Output width of the array.
         kwargs (optional): Additional options to forward to `rio_tiler.reader.read`.

--- a/rio_tiler/tasks.py
+++ b/rio_tiler/tasks.py
@@ -12,7 +12,8 @@ TaskType = Sequence[Tuple[Union[futures.Future, Callable], Any]]
 
 
 def filter_tasks(
-    tasks: TaskType, allowed_exceptions: Optional[Tuple] = None,
+    tasks: TaskType,
+    allowed_exceptions: Optional[Tuple] = None,
 ) -> Generator:
     """Filter Tasks to remove Exceptions.
 

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -81,7 +81,7 @@ def get_array_statistics(
     Args:
         data (numpy.ma.ndarray): input masked array data to get the statistics from.
         categorical (bool): treat input data as categorical data. Defaults to False.
-        categories (list of numbers, optional): list of caterogies to return value for.
+        categories (list of numbers, optional): list of categories to return value for.
         percentiles (list of numbers, optional): list of percentile values to calculate. Defaults to `[2, 98]`.
         kwargs (optional): options to forward to `numpy.histogram` function (only applies for non-categorical data).
 
@@ -257,7 +257,10 @@ def get_vrt_transform(
         src_dst, bounds, height, width, dst_crs
     ):
         col_off, row_off, w, h = windows.from_bounds(
-            *bounds, transform=src_dst.transform, width=width, height=height,
+            *bounds,
+            transform=src_dst.transform,
+            width=width,
+            height=height,
         ).flatten()
 
         w = windows.Window(
@@ -528,7 +531,7 @@ def create_cutline(
 
     Args:
         src_dst (rasterio.io.DatasetReader or rasterio.io.DatasetWriter or rasterio.vrt.WarpedVRT): Rasterio dataset.
-        geometry (dict): GeoJSON feature or GeoJSON geometry. By default the cordinates are considered to be in the dataset CRS. Use `geometry_crs` to set a specific CRS.
+        geometry (dict): GeoJSON feature or GeoJSON geometry. By default the coordinates are considered to be in the dataset CRS. Use `geometry_crs` to set a specific CRS.
         geometry_crs (rasterio.crs.CRS, optional): Input geometry Coordinate Reference System
     Returns:
         str: WKT geometry in form of `POLYGON ((x y, x y, ...)))

--- a/tests/test_io_cogeo.py
+++ b/tests/test_io_cogeo.py
@@ -180,7 +180,15 @@ def test_tile_valid_default():
         data, mask = cog.tile(43, 24, 7, indexes=1)
         assert data.shape == (1, 256, 256)
 
-        img = cog.tile(43, 24, 7, indexes=(1, 1,))
+        img = cog.tile(
+            43,
+            24,
+            7,
+            indexes=(
+                1,
+                1,
+            ),
+        )
         assert img.data.shape == (2, 256, 256)
         assert img.band_names == ["1", "1"]
 
@@ -244,7 +252,14 @@ def test_point_valid():
         pts = cog.point(lon, lat, indexes=1)
         assert len(pts) == 1
 
-        pts = cog.point(lon, lat, indexes=(1, 1,))
+        pts = cog.point(
+            lon,
+            lat,
+            indexes=(
+                1,
+                1,
+            ),
+        )
         assert len(pts) == 2
 
 
@@ -279,7 +294,13 @@ def test_area_valid():
         data, mask = cog.part(bbox, indexes=1)
         assert data.shape == (1, 11, 40)
 
-        img = cog.part(bbox, indexes=(1, 1,))
+        img = cog.part(
+            bbox,
+            indexes=(
+                1,
+                1,
+            ),
+        )
         assert img.data.shape == (2, 11, 40)
         assert img.band_names == ["1", "1"]
 
@@ -306,7 +327,13 @@ def test_preview_valid():
         data, mask = cog.preview(max_size=128, indexes=1)
         assert data.shape == (1, 128, 128)
 
-        img = cog.preview(max_size=128, indexes=(1, 1,))
+        img = cog.preview(
+            max_size=128,
+            indexes=(
+                1,
+                1,
+            ),
+        )
         assert img.data.shape == (2, 128, 128)
         assert img.band_names == ["1", "1"]
 
@@ -606,7 +633,14 @@ def test_feature_valid():
         img = cog.feature(feature, indexes=1, max_size=1024)
         assert img.data.shape == (1, 348, 1024)
 
-        img = cog.feature(feature, indexes=(1, 1,), max_size=1024)
+        img = cog.feature(
+            feature,
+            indexes=(
+                1,
+                1,
+            ),
+            max_size=1024,
+        )
         assert img.data.shape == (2, 348, 1024)
         assert img.band_names == ["1", "1"]
 
@@ -743,7 +777,12 @@ def test_read():
         img = cog.read(indexes=1)
         assert img.data.shape == (1, 2667, 2658)
 
-        img = cog.read(indexes=(1, 1,))
+        img = cog.read(
+            indexes=(
+                1,
+                1,
+            )
+        )
         assert img.data.shape == (2, 2667, 2658)
 
 
@@ -784,7 +823,9 @@ def test_nonearthbody():
 
     europa_crs = CRS.from_authority("ESRI", 104915)
     tms = TileMatrixSet.custom(
-        crs=europa_crs, extent=europa_crs.area_of_use.bounds, matrix_scale=[2, 1],
+        crs=europa_crs,
+        extent=europa_crs.area_of_use.bounds,
+        matrix_scale=[2, 1],
     )
     with pytest.warns(None) as warnings:
         with COGReader(COG_EUROPA, tms=tms) as cog:

--- a/tests/test_io_stac.py
+++ b/tests/test_io_stac.py
@@ -157,14 +157,26 @@ def test_tile_valid(rio):
             102,
             8,
             assets=("green", "red"),
-            asset_indexes={"green": (1, 1,), "red": 1},
+            asset_indexes={
+                "green": (
+                    1,
+                    1,
+                ),
+                "red": 1,
+            },
         )
         assert img.data.shape == (3, 256, 256)
         assert img.mask.shape == (256, 256)
         assert img.band_names == ["green_1", "green_1", "red_1"]
 
         # check backward compatibility for `indexes`
-        img = stac.tile(71, 102, 8, assets=("green", "red"), indexes=1,)
+        img = stac.tile(
+            71,
+            102,
+            8,
+            assets=("green", "red"),
+            indexes=1,
+        )
         assert img.data.shape == (2, 256, 256)
         assert img.mask.shape == (256, 256)
         assert img.band_names == ["green_1", "red_1"]
@@ -220,7 +232,15 @@ def test_part_valid(rio):
             assert img.band_names == ["green/red"]
 
         img = stac.part(
-            bbox, assets=("green", "red"), asset_indexes={"green": (1, 1,), "red": 1}
+            bbox,
+            assets=("green", "red"),
+            asset_indexes={
+                "green": (
+                    1,
+                    1,
+                ),
+                "red": 1,
+            },
         )
         assert img.data.shape == (3, 73, 83)
         assert img.mask.shape == (73, 83)
@@ -274,7 +294,14 @@ def test_preview_valid(rio):
             assert img.band_names == ["green/red"]
 
         img = stac.preview(
-            assets=("green", "red"), asset_indexes={"green": (1, 1,), "red": 1}
+            assets=("green", "red"),
+            asset_indexes={
+                "green": (
+                    1,
+                    1,
+                ),
+                "red": 1,
+            },
         )
         assert img.data.shape == (3, 259, 255)
         assert img.mask.shape == (259, 255)
@@ -332,7 +359,12 @@ def test_point_valid(rio):
         assert len(data[0]) == 2
         assert len(data[1]) == 1
 
-        data = stac.point(-80.477, 33.4453, assets=("green", "red"), indexes=1,)
+        data = stac.point(
+            -80.477,
+            33.4453,
+            assets=("green", "red"),
+            indexes=1,
+        )
         assert len(data) == 2
         assert len(data[0]) == 1
         assert len(data[1]) == 1

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -73,9 +73,10 @@ def test_16bit_PNG():
     mask[10:11, 10:11] = 100
 
     with pytest.warns(None):
-        img = ImageData(numpy.zeros((1, 256, 256), dtype="uint16"), mask,).render(
-            img_format="PNG"
-        )
+        img = ImageData(
+            numpy.zeros((1, 256, 256), dtype="uint16"),
+            mask,
+        ).render(img_format="PNG")
 
         with rasterio.open(BytesIO(img)) as src:
             assert src.count == 2
@@ -88,9 +89,10 @@ def test_16bit_PNG():
             assert (arr[11:, 11:] == 65535).all()
 
     with pytest.warns(None):
-        img = ImageData(numpy.zeros((3, 256, 256), dtype="uint16"), mask,).render(
-            img_format="PNG"
-        )
+        img = ImageData(
+            numpy.zeros((3, 256, 256), dtype="uint16"),
+            mask,
+        ).render(img_format="PNG")
 
         with rasterio.open(BytesIO(img)) as src:
             assert src.count == 4

--- a/tests/test_mosaic.py
+++ b/tests/test_mosaic.py
@@ -253,7 +253,13 @@ def test_stac_mosaic_tiler(rio):
             return stac.tile(*args, **kwargs)
 
     (data, mask), assets_used = mosaic.mosaic_reader(
-        [stac_asset], _reader, 71, 102, 8, assets="green", threads=0,
+        [stac_asset],
+        _reader,
+        71,
+        102,
+        8,
+        assets="green",
+        threads=0,
     )
     assert assets_used == [stac_asset]
     assert data.shape == (1, 256, 256)


### PR DESCRIPTION
This PR does 2 things:
- fix typos found using `Code Spell Checker`
- update **Black** version (https://stackoverflow.com/questions/69912264/python-3-9-8-fails-using-black-and-importing-typed-ast-ast3). This results in a lot of code modification from black 🤷‍♂️ 