### PR TITLE
add rio_tiler.types and fix type hint issues

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@
 
 * allow the definition of `geographic_crs` used in the `geographic_bounds` property (https://github.com/cogeotiff/rio-tiler/pull/458)
 * use `contextlib.ExitStack` to better manager opening/closing rasterio dataset (https://github.com/cogeotiff/rio-tiler/pull/459)
+* moves `BBox, ColorTuple, Indexes, NoData, NumType` type definitions in `rio_tiler.types`
+* better types definition for ColorMap objects
+* fix some types issues
 
 # 3.0.0a4 (2021-11-10)
 

--- a/rio_tiler/constants.py
+++ b/rio_tiler/constants.py
@@ -2,16 +2,11 @@
 
 import multiprocessing
 import os
-from typing import Sequence, Tuple, Union
 
 import morecantile
 from rasterio.crs import CRS
 
-NumType = Union[float, int]
-BBox = Tuple[float, float, float, float]
-ColorTuple = Tuple[int, int, int, int]
-NoData = Union[float, int, str]
-Indexes = Union[Sequence[int], int]
+from .types import BBox, ColorTuple, Indexes, NoData, NumType  # noqa
 
 MAX_THREADS = int(
     os.environ.get("RIO_TILER_MAX_THREADS", multiprocessing.cpu_count() * 5)

--- a/rio_tiler/io/base.py
+++ b/rio_tiler/io/base.py
@@ -11,7 +11,7 @@ from morecantile import Tile, TileMatrixSet
 from rasterio.crs import CRS
 from rasterio.warp import transform_bounds
 
-from ..constants import WEB_MERCATOR_TMS, WGS84_CRS, BBox, Indexes
+from ..constants import WEB_MERCATOR_TMS, WGS84_CRS
 from ..errors import (
     ExpressionMixingWarning,
     MissingAssets,
@@ -21,6 +21,7 @@ from ..errors import (
 from ..expression import apply_expression
 from ..models import BandStatistics, ImageData, Info
 from ..tasks import multi_arrays, multi_values
+from ..types import BBox, Indexes
 from ..utils import get_array_statistics
 
 
@@ -694,12 +695,12 @@ class MultiBaseReader(BaseReader, metaclass=abc.ABCMeta):
 
         data = multi_values(assets, _reader, lon, lat, **kwargs)
 
-        values = [d for _, d in data.items()]
+        values = numpy.array([d for _, d in data.items()])
         if expression:
             blocks = expression.split(",")
-            values = apply_expression(blocks, assets, values).tolist()
+            values = apply_expression(blocks, assets, values)
 
-        return values
+        return values.tolist()
 
     def feature(
         self,
@@ -1117,12 +1118,12 @@ class MultiBandReader(BaseReader, metaclass=abc.ABCMeta):
 
         data = multi_values(bands, _reader, lon, lat, **kwargs)
 
-        values = [d for _, d in data.items()]
+        values = numpy.array([d for _, d in data.items()])
         if expression:
             blocks = expression.split(",")
-            values = apply_expression(blocks, bands, values).tolist()
+            values = apply_expression(blocks, bands, values)
 
-        return values
+        return values.tolist()
 
     def feature(
         self,

--- a/rio_tiler/io/cogeo.py
+++ b/rio_tiler/io/cogeo.py
@@ -18,7 +18,7 @@ from rasterio.vrt import WarpedVRT
 from rasterio.warp import calculate_default_transform, transform_bounds
 
 from .. import reader
-from ..constants import WEB_MERCATOR_TMS, WGS84_CRS, BBox, Indexes, NoData, NumType
+from ..constants import WEB_MERCATOR_TMS, WGS84_CRS
 from ..errors import (
     ExpressionMixingWarning,
     IncorrectTileBuffer,
@@ -27,6 +27,7 @@ from ..errors import (
 )
 from ..expression import apply_expression, parse_expression
 from ..models import BandStatistics, ImageData, Info
+from ..types import BBox, DataMaskType, Indexes, NoData, NumType
 from ..utils import (
     create_cutline,
     get_array_statistics,
@@ -95,7 +96,7 @@ class COGReader(BaseReader):
     resampling_method: Optional[Resampling] = attr.ib(default=None)
     vrt_options: Optional[Dict] = attr.ib(default=None)
     post_process: Optional[
-        Callable[[numpy.ndarray, numpy.ndarray], Tuple[numpy.ndarray, numpy.ndarray]]
+        Callable[[numpy.ndarray, numpy.ndarray], DataMaskType]
     ] = attr.ib(default=None)
 
     # We use _kwargs to store values of nodata, unscale, vrt_options and resampling_method.
@@ -695,7 +696,7 @@ class GCPCOGReader(COGReader):
     resampling_method: Optional[Resampling] = attr.ib(default=None)
     vrt_options: Optional[Dict] = attr.ib(default=None)
     post_process: Optional[
-        Callable[[numpy.ndarray, numpy.ndarray], Tuple[numpy.ndarray, numpy.ndarray]]
+        Callable[[numpy.ndarray, numpy.ndarray], DataMaskType]
     ] = attr.ib(default=None)
 
     # for GCPCOGReader, dataset is not a input option.

--- a/rio_tiler/models.py
+++ b/rio_tiler/models.py
@@ -17,8 +17,8 @@ from rasterio.transform import from_bounds
 from rio_color.operations import parse_operations
 from rio_color.utils import scale_dtype, to_math_type
 
-from .constants import ColorTuple, NumType
 from .errors import InvalidDatatypeWarning
+from .types import ColorMapType, GDALColorMapType, IntervalTuple, NumType
 from .utils import linear_rescale, render
 
 
@@ -63,7 +63,7 @@ class Info(SpatialInfo):
     colorinterp: Optional[List[str]]
     scale: Optional[float]
     offset: Optional[float]
-    colormap: Optional[Dict[int, ColorTuple]]
+    colormap: Optional[GDALColorMapType]
 
     class Config:
         """Config for model."""
@@ -221,8 +221,8 @@ class ImageData:
         self,
         data: numpy.ndarray,
         mask: numpy.ndarray,
-        in_range: Sequence[Tuple[NumType, NumType]],
-        out_range: Sequence[Tuple[NumType, NumType]] = ((0, 255),),
+        in_range: Sequence[IntervalTuple],
+        out_range: Sequence[IntervalTuple] = ((0, 255),),
         out_dtype: Union[str, numpy.number] = "uint8",
     ):
         """Rescale data."""
@@ -247,7 +247,7 @@ class ImageData:
 
     def post_process(
         self,
-        in_range: Optional[Sequence[Tuple[NumType, NumType]]] = None,
+        in_range: Optional[Sequence[IntervalTuple]] = None,
         out_dtype: Union[str, numpy.number] = "uint8",
         color_formula: Optional[str] = None,
         **kwargs: Any,
@@ -293,7 +293,7 @@ class ImageData:
         self,
         add_mask: bool = True,
         img_format: str = "PNG",
-        colormap: Optional[Union[Dict, Sequence]] = None,
+        colormap: Optional[ColorMapType] = None,
         **kwargs,
     ) -> bytes:
         """Render data to image blob.

--- a/rio_tiler/mosaic/methods/defaults.py
+++ b/rio_tiler/mosaic/methods/defaults.py
@@ -144,7 +144,7 @@ class LastBandHigh(MosaicMethodBase):
         else:
             return None, None
 
-    def feed(self, tile: numpy.ma.array):
+    def feed(self, tile: numpy.ma.MaskedArray):
         """Add data to tile."""
         if self.tile is None:
             self.tile = tile
@@ -174,7 +174,7 @@ class LastBandLow(MosaicMethodBase):
         else:
             return None, None
 
-    def feed(self, tile: numpy.ma.array):
+    def feed(self, tile: numpy.ma.MaskedArray):
         """Add data to tile."""
         if self.tile is None:
             self.tile = tile

--- a/rio_tiler/mosaic/reader.py
+++ b/rio_tiler/mosaic/reader.py
@@ -5,10 +5,11 @@ from typing import Any, Callable, List, Optional, Sequence, Tuple, Type, Union, 
 
 from rasterio.crs import CRS
 
-from ..constants import MAX_THREADS, BBox
+from ..constants import MAX_THREADS
 from ..errors import EmptyMosaicError, InvalidMosaicMethod, TileOutsideBounds
 from ..models import ImageData
 from ..tasks import create_tasks, filter_tasks
+from ..types import BBox
 from ..utils import _chunks
 from .methods.base import MosaicMethodBase
 from .methods.defaults import FirstMethod

--- a/rio_tiler/reader.py
+++ b/rio_tiler/reader.py
@@ -14,8 +14,9 @@ from rasterio.vrt import WarpedVRT
 from rasterio.warp import transform as transform_coords
 from rasterio.warp import transform_bounds
 
-from .constants import WGS84_CRS, BBox, Indexes, NoData
+from .constants import WGS84_CRS
 from .errors import AlphaBandWarning, PointOutsideBounds, TileOutsideBounds
+from .types import BBox, DataMaskType, Indexes, NoData
 from .utils import _requested_tile_aligned_with_internal_tile as is_aligned
 from .utils import get_vrt_transform, has_alpha_band, non_alpha_indexes
 
@@ -32,9 +33,9 @@ def read(
     resampling_method: Resampling = "nearest",
     vrt_options: Optional[Dict] = None,
     post_process: Optional[
-        Callable[[numpy.ndarray, numpy.ndarray], Tuple[numpy.ndarray, numpy.ndarray]]
+        Callable[[numpy.ndarray, numpy.ndarray], DataMaskType]
     ] = None,
-) -> Tuple[numpy.ndarray, numpy.ndarray]:
+) -> DataMaskType:
     """Low level read function.
 
     Args:
@@ -132,7 +133,7 @@ def part(
     vrt_options: Optional[Dict] = None,
     max_size: Optional[int] = None,
     **kwargs: Any,
-) -> Tuple[numpy.ndarray, numpy.ndarray]:
+) -> DataMaskType:
     """Read part of a dataset.
 
     Args:
@@ -240,7 +241,7 @@ def preview(
     height: int = None,
     width: int = None,
     **kwargs: Any,
-) -> Tuple[numpy.ndarray, numpy.ndarray]:
+) -> DataMaskType:
     """Read decimated version of a dataset.
 
     Args:
@@ -280,7 +281,7 @@ def point(
     resampling_method: Resampling = "nearest",
     vrt_options: Optional[Dict] = None,
     post_process: Optional[
-        Callable[[numpy.ndarray, numpy.ndarray], Tuple[numpy.ndarray, numpy.ndarray]]
+        Callable[[numpy.ndarray, numpy.ndarray], DataMaskType]
     ] = None,
 ) -> List:
     """Read a pixel value for a point.

--- a/rio_tiler/types.py
+++ b/rio_tiler/types.py
@@ -12,7 +12,7 @@ Indexes = Union[Sequence[int], int]
 
 DataMaskType = Tuple[numpy.ndarray, numpy.ndarray]
 
-ColorTuple = Tuple[int, int, int, int]
+ColorTuple = Tuple[int, int, int, int]  # (red, green, blue, alpha)
 IntervalTuple = Tuple[NumType, NumType]  # (0, 100)
 
 # ColorMap Dict: {1: (0, 0, 0, 255), ...}

--- a/rio_tiler/types.py
+++ b/rio_tiler/types.py
@@ -1,0 +1,27 @@
+"""rio-tiler types."""
+
+from typing import Dict, Sequence, Tuple, Union
+
+import numpy
+
+NumType = Union[float, int]
+
+BBox = Tuple[float, float, float, float]
+NoData = Union[float, int, str]
+Indexes = Union[Sequence[int], int]
+
+DataMaskType = Tuple[numpy.ndarray, numpy.ndarray]
+
+ColorTuple = Tuple[int, int, int, int]
+IntervalTuple = Tuple[NumType, NumType]  # (0, 100)
+
+# ColorMap Dict: {1: (0, 0, 0, 255), ...}
+GDALColorMapType = Dict[int, ColorTuple]
+
+# Intervals ColorMap: [((0, 1), (0, 0, 0, 0)), ...]
+IntervalColorMapType = Sequence[Tuple[IntervalTuple, ColorTuple]]
+
+ColorMapType = Union[
+    GDALColorMapType,
+    IntervalColorMapType,
+]

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -18,8 +18,9 @@ from rasterio.vrt import WarpedVRT
 from rasterio.warp import calculate_default_transform, transform_geom
 
 from .colormap import apply_cmap
-from .constants import WEB_MERCATOR_CRS, BBox, NumType
+from .constants import WEB_MERCATOR_CRS
 from .errors import RioTilerError
+from .types import BBox, ColorMapType, IntervalTuple
 
 
 def _chunks(my_list: Sequence, chuck_size: int) -> Generator[Sequence, None, None]:
@@ -70,7 +71,7 @@ def get_bands_names(
 
 
 def get_array_statistics(
-    data: numpy.ma.array,
+    data: numpy.ma.MaskedArray,
     categorical: bool = False,
     categories: Optional[List[float]] = None,
     percentiles: List[int] = [2, 98],
@@ -79,7 +80,7 @@ def get_array_statistics(
     """Calculate per band array statistics.
 
     Args:
-        data (numpy.ma.ndarray): input masked array data to get the statistics from.
+        data (numpy.ma.MaskedArray): input masked array data to get the statistics from.
         categorical (bool): treat input data as categorical data. Defaults to False.
         categories (list of numbers, optional): list of categories to return value for.
         percentiles (list of numbers, optional): list of percentile values to calculate. Defaults to `[2, 98]`.
@@ -337,8 +338,8 @@ def non_alpha_indexes(src_dst: Union[DatasetReader, DatasetWriter, WarpedVRT]) -
 
 def linear_rescale(
     image: numpy.ndarray,
-    in_range: Tuple[NumType, NumType],
-    out_range: Tuple[NumType, NumType] = (0, 255),
+    in_range: IntervalTuple,
+    out_range: IntervalTuple = (0, 255),
 ) -> numpy.ndarray:
     """Apply linear rescaling to a numpy array.
 
@@ -392,7 +393,7 @@ def render(
     data: numpy.ndarray,
     mask: Optional[numpy.ndarray] = None,
     img_format: str = "PNG",
-    colormap: Optional[Union[Dict, Sequence]] = None,
+    colormap: Optional[ColorMapType] = None,
     **creation_options: Any,
 ) -> bytes:
     """Translate numpy.ndarray to image bytes.

--- a/tests/test_cmap.py
+++ b/tests/test_cmap.py
@@ -95,15 +95,15 @@ def test_remove_value():
 def test_update_cmap():
     """Should update the colormap."""
     cm = colormap.cmap.get("viridis")
-    val = {1: [0, 0, 0], 2: [255, 255, 255, 255]}
+    val = {1: (0, 0, 0, 0), 2: (255, 255, 255, 255)}
     colormap._update_cmap(cm, val)
-    assert cm[1] == [0, 0, 0, 255]
-    assert cm[2] == [255, 255, 255, 255]
+    assert cm[1] == (0, 0, 0, 0)
+    assert cm[2] == (255, 255, 255, 255)
 
 
 def test_make_lut():
     """Should create valid lookup table."""
-    cm = {1: [100, 100, 100, 255], 2: [255, 255, 255, 255]}
+    cm = {1: (100, 100, 100, 255), 2: (255, 255, 255, 255)}
     lut = colormap.make_lut(cm)
     assert len(lut) == 256
     assert lut[0].tolist() == [0, 0, 0, 0]
@@ -113,7 +113,7 @@ def test_make_lut():
 
 def test_apply_cmap():
     """Should return valid data and mask."""
-    cm = {1: [0, 0, 0, 255], 2: [255, 255, 255, 255]}
+    cm = {1: (0, 0, 0, 255), 2: (255, 255, 255, 255)}
     data = numpy.zeros(shape=(1, 10, 10), dtype=numpy.uint8)
     data[0, 2:5, 2:5] = 1
     data[0, 5:, 5:] = 2
@@ -137,7 +137,7 @@ def test_apply_cmap():
 
 def test_apply_discrete_cmap():
     """Should return valid data and mask."""
-    cm = {1: [0, 0, 0, 255], 2: [255, 255, 255, 255]}
+    cm = {1: (0, 0, 0, 255), 2: (255, 255, 255, 255)}
     data = numpy.zeros(shape=(1, 10, 10), dtype=numpy.uint16)
     data[0, 0:2, 0:2] = 1000
     data[0, 2:5, 2:5] = 1
@@ -155,7 +155,7 @@ def test_apply_discrete_cmap():
     assert d.dtype == numpy.uint8
     assert m.dtype == numpy.uint8
 
-    cm = {1: [0, 0, 0, 255], 1000: [255, 255, 255, 255]}
+    cm = {1: (0, 0, 0, 255), 1000: (255, 255, 255, 255)}
     d, m = colormap.apply_cmap(data, cm)
     dd, mm = colormap.apply_discrete_cmap(data, cm)
     numpy.testing.assert_array_equal(dd, d)
@@ -163,12 +163,12 @@ def test_apply_discrete_cmap():
 
     cm = deepcopy(colormap.EMPTY_COLORMAP)
     cm.pop(255)
-    cm[1000] = [255, 255, 255, 255]
+    cm[1000] = (255, 255, 255, 255)
 
     d, m = colormap.apply_cmap(data, cm)
     dd, mm = colormap.apply_discrete_cmap(data, cm)
 
-    cm = {1: [0, 0, 0, 255], 256: [255, 255, 255, 255]}
+    cm = {1: (0, 0, 0, 255), 256: (255, 255, 255, 255)}
     assert colormap.apply_cmap(data, cm)
 
 
@@ -176,8 +176,8 @@ def test_apply_intervals_cmap():
     """Should return valid data and mask."""
     cm = [
         # ([min, max], [r, g, b, a])
-        ([1, 2], [0, 0, 0, 255]),
-        ([2, 3], [255, 255, 255, 255]),
+        ((1, 2), (0, 0, 0, 255)),
+        ((2, 3), (255, 255, 255, 255)),
     ]
     data = numpy.zeros(shape=(1, 10, 10), dtype=numpy.uint16)
     data[0, 0:2, 0:2] = 1000
@@ -198,10 +198,10 @@ def test_apply_intervals_cmap():
     assert m.dtype == numpy.uint8
 
     cm = [
-        # ([min, max], [r, g, b, a])
-        ([1, 2], [0, 0, 0, 255]),
-        ([2, 3], [255, 255, 255, 255]),
-        ([2, 1000], [255, 0, 0, 255]),
+        # ((min, max), (r, g, b, a))
+        ((1, 2), (0, 0, 0, 255)),
+        ((2, 3), (255, 255, 255, 255)),
+        ((3, 1000), (255, 0, 0, 255)),
     ]
     d, m = colormap.apply_intervals_cmap(data, cm)
     assert d.shape == (3, 10, 10)

--- a/tests/test_io_async.py
+++ b/tests/test_io_async.py
@@ -10,9 +10,10 @@ import attr
 import morecantile
 import pytest
 
-from rio_tiler.constants import WEB_MERCATOR_TMS, BBox
+from rio_tiler.constants import WEB_MERCATOR_TMS
 from rio_tiler.io import AsyncBaseReader, COGReader
 from rio_tiler.models import BandStatistics, ImageData, Info
+from rio_tiler.types import BBox
 
 try:
     import contextvars  # Python 3.7+ only or via contextvars backport.

--- a/tests/test_io_cogeo.py
+++ b/tests/test_io_cogeo.py
@@ -106,7 +106,7 @@ def test_info_valid():
         assert meta["colormap"]
         assert meta.colormap
 
-    with COGReader(COG_NODATA, colormap={1: [0, 0, 0, 0]}) as cog:
+    with COGReader(COG_NODATA, colormap={1: (0, 0, 0, 0)}) as cog:
         assert cog.colormap
         meta = cog.info()
         assert meta.colormap

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -44,7 +44,7 @@ def test_imageData_AutoRescaling():
 
     # Make sure that we do not rescale uint16 data when there is a colormap
     with pytest.warns(None) as w:
-        cm = {1: [0, 0, 0, 255], 1000: [255, 255, 255, 255]}
+        cm = {1: (0, 0, 0, 255), 1000: (255, 255, 255, 255)}
         ImageData(numpy.zeros((1, 256, 256), dtype="uint16")).render(
             img_format="JPEG", colormap=cm
         )

--- a/tests/test_mosaic.py
+++ b/tests/test_mosaic.py
@@ -1,7 +1,6 @@
 """tests ard_tiler.mosaic."""
 
 import os
-from typing import Tuple
 from unittest.mock import patch
 
 import numpy
@@ -15,6 +14,7 @@ from rio_tiler.errors import EmptyMosaicError, InvalidMosaicMethod, TileOutsideB
 from rio_tiler.io import COGReader, STACReader
 from rio_tiler.models import ImageData
 from rio_tiler.mosaic.methods import defaults
+from rio_tiler.types import DataMaskType
 
 asset1 = os.path.join(os.path.dirname(__file__), "fixtures", "mosaic_cog1.tif")
 asset2 = os.path.join(os.path.dirname(__file__), "fixtures", "mosaic_cog2.tif")
@@ -51,9 +51,7 @@ def _read_part(src_path: str, *args, **kwargs) -> ImageData:
         return cog.part(*args, **kwargs)
 
 
-def _read_preview(
-    src_path: str, *args, **kwargs
-) -> Tuple[numpy.ndarray, numpy.ndarray]:
+def _read_preview(src_path: str, *args, **kwargs) -> DataMaskType:
     """Read preview from an asset"""
     with COGReader(src_path) as cog:
         data, mask = cog.preview(*args, **kwargs)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -127,10 +127,10 @@ def test_render_valid_colormapDict():
     """Create 'colormaped' PNG image buffer from one band array using discrete cmap."""
     arr = np.random.randint(0, 255, size=(1, 512, 512), dtype=np.uint8)
     cmap = {
-        1: [255, 255, 255, 255],
-        50: [255, 255, 0, 255],
-        100: [255, 0, 0, 255],
-        150: [0, 0, 255, 255],
+        1: (255, 255, 255, 255),
+        50: (255, 255, 0, 255),
+        100: (255, 0, 0, 255),
+        150: (0, 0, 255, 255),
     }
     assert utils.render(arr, colormap=cmap)
 


### PR DESCRIPTION
This PR does:
- better define types of the ColorMap objects
- fix type issues for numpy masked array
- create `rio_tiler.types` submodule to store custom type definition