### PR TITLE
make  `MultiBaseReader` and `MultiBandReader` their own abc classes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+# 3.0.0a6 (TBD)
+
+* update `MultiBaseReader` and `MultiBandReader` to be their own abstract classes instead of being subclass of `BaseReader`.
+
+**breaking changes**
+
+* put `reader` attribute outside of the `__init__` method for `MultiBaseReader` and `MultiBandReader`.
 
 # 3.0.0a5 (2021-11-18)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# 3.0.0a6 (TBD)
+# 3.0.0a6 (2021-11-22)
 
 * add `rio_tiler.utils.resize_array` to resize array to a given width/height (https://github.com/cogeotiff/rio-tiler/pull/463)
 * use `resize_array` in `ImageData.create_from_list` to avoid trying merging array of different sizes (https://github.com/cogeotiff/rio-tiler/pull/463)

--- a/docs/advanced/custom_readers.md
+++ b/docs/advanced/custom_readers.md
@@ -20,9 +20,10 @@ Main `rio_tiler.io` Abstract Base Class.
 - **maxzoom**: Dataset's maxzoom. Not in the `__init__` method.
 - **bounds**: Dataset's bounding box. Not in the `__init__` method.
 - **crs**: dataset's crs. Not in the `__init__` method.
+- **geographic_crs**: CRS to use as geographic coordinate system. Defaults to WGS84. Not in the `__init__` method.
 
 !!! important
-    BaseClass Arguments outside the `__init__` method **HAVE TO** be set in the `__attrs_post_init__` step.
+    BaseClass Arguments outside the `__init__` method and without default value **HAVE TO** be set in the `__attrs_post_init__` step.
 
 #### Methods
 
@@ -34,7 +35,7 @@ Main `rio_tiler.io` Abstract Base Class.
 
 ##### Abstract Methods
 
-Abstract methods, are mehtod that **HAVE TO** be implemented in the subclass.
+Abstract methods, are method that **HAVE TO** be implemented in the child class.
 
 - **info**: returns dataset info (`rio_tiler.models.Info`)
 - **statistics**: returns dataset band statistics (`Dict[str, rio_tiler.models.BandStatistics]`)
@@ -48,13 +49,15 @@ Example: [`COGReader`](../readers.md#cogreader)
 
 ### **AsyncBaseReader**
 
-Equivalent of `BaseReader` for async-ready readers (e.g [aiocogeo](https://github.com/geospatial-jeff/aiocogeo)). The `AsyncBaseReader` has the same properties/methods as the `BaseReader`.
+Equivalent of `BaseReader` for async-ready readers (e.g [aiocogeo](https://github.com/geospatial-jeff/aiocogeo)). The `AsyncBaseReader` has the same attributes/properties/methods as the `BaseReader`.
 
 see example of reader built using `AsyncBaseReader`: https://github.com/cogeotiff/rio-tiler/blob/832ecbd97f560c2764818bca30ca95ef25408527/tests/test_io_async.py#L49
 
 ### **MultiBaseReader**
 
-This abstract class inherit from `BaseReader`. The goal of the `MultiBaseReader` is to enable readers that need to join results from multiple files (e.g STAC).
+The goal of the `MultiBaseReader` is to enable joining results from multiple files (e.g STAC).
+
+The `MultiBaseReader` has the same attributes/properties/methods as the `BaseReader`.
 
 Example: [`STACReader`](../readers.md#stacreader)
 
@@ -140,7 +143,9 @@ with AssetFileReader(input="my_dir/", prefix="scene_") as cr:
 
 ### **MultiBandsReader**
 
-Almost as the previous `MultiBaseReader`, the `MultiBandsReader` subclasses will merge results extracted from differents assets but taking each assets as individual bands.
+Almost as the previous `MultiBaseReader`, the `MultiBandsReader` children will merge results extracted from different file but taking each file as individual bands.
+
+The `MultiBaseReader` has the same attributes/properties/methods as the `BaseReader`.
 
 Example
 
@@ -300,7 +305,7 @@ class Reader(BaseReader):
     # We force tms to be outside the class __init__
     tms: TileMatrixSet = attr.ib(init=False, default=WEB_MERCATOR_TMS)
 
-    # We can overwrite the baseclass attribute definition and set default
+    # We overwrite the abstract base class attribute definition and set default
     minzoom: int = attr.ib(init=False, default=WEB_MERCATOR_TMS.minzoom)
     maxzoom: int = attr.ib(init=False, default=WEB_MERCATOR_TMS.maxzoom)
 

--- a/rio_tiler/io/base.py
+++ b/rio_tiler/io/base.py
@@ -35,6 +35,7 @@ class SpatialMixin:
         maxzoom (int): Dataset Max Zoom level. **Not in __init__**.
         bounds (tuple): Dataset bounds (left, bottom, right, top). **Not in __init__**.
         crs (rasterio.crs.CRS): Dataset crs. **Not in __init__**.
+        geographic_crs (rasterio.crs.CRS): CRS to use as geographic coordinate system. Defaults to WGS84. **Not in __init__**.
 
     """
 
@@ -325,27 +326,34 @@ class AsyncBaseReader(SpatialMixin, metaclass=abc.ABCMeta):
 
 
 @attr.s
-class MultiBaseReader(BaseReader, metaclass=abc.ABCMeta):
+class MultiBaseReader(SpatialMixin, metaclass=abc.ABCMeta):
     """MultiBaseReader Reader.
 
-    This Reader is suited for dataset that are composed of multiple assets (e.g. STAC).
+    This Abstract Base Class Reader is suited for dataset that are composed of multiple assets (e.g. STAC).
 
     Attributes:
         input (any): input data.
-        reader (rio_tiler.io.BaseReader): reader.
-        reader_options (dict, option): options to forward to the reader. Defaults to `{}`.
         tms (morecantile.TileMatrixSet, optional): TileMatrixSet grid definition. Defaults to `WebMercatorQuad`.
+        reader_options (dict, option): options to forward to the reader. Defaults to `{}`.
+        reader (rio_tiler.io.BaseReader): reader. **Not in __init__**.
         assets (sequence): Asset list. **Not in __init__**.
 
     """
 
     input: Any = attr.ib()
-    reader: Type[BaseReader] = attr.ib()
-
-    reader_options: Dict = attr.ib(factory=dict)
     tms: TileMatrixSet = attr.ib(default=WEB_MERCATOR_TMS)
+    reader_options: Dict = attr.ib(factory=dict)
 
+    reader: Type[BaseReader] = attr.ib(init=False)
     assets: Sequence[str] = attr.ib(init=False)
+
+    def __enter__(self):
+        """Support using with Context Managers."""
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """Support using with Context Managers."""
+        pass
 
     @abc.abstractmethod
     def _get_asset_url(self, asset: str) -> str:
@@ -768,27 +776,34 @@ class MultiBaseReader(BaseReader, metaclass=abc.ABCMeta):
 
 
 @attr.s
-class MultiBandReader(BaseReader, metaclass=abc.ABCMeta):
+class MultiBandReader(SpatialMixin, metaclass=abc.ABCMeta):
     """Multi Band Reader.
 
-    This Reader is suited for dataset that stores spectral bands as separate files  (e.g. Sentinel 2).
+    This Abstract Base Class Reader is suited for dataset that stores spectral bands as separate files  (e.g. Sentinel 2).
 
     Attributes:
         input (any): input data.
-        reader (rio_tiler.io.BaseReader): reader.
-        reader_options (dict, option): options to forward to the reader. Defaults to `{}`.
         tms (morecantile.TileMatrixSet, optional): TileMatrixSet grid definition. Defaults to `WebMercatorQuad`.
+        reader_options (dict, option): options to forward to the reader. Defaults to `{}`.
+        reader (rio_tiler.io.BaseReader): reader. **Not in __init__**.
         bands (sequence): Band list. **Not in __init__**.
 
     """
 
     input: Any = attr.ib()
-    reader: Type[BaseReader] = attr.ib()
-
-    reader_options: Dict = attr.ib(factory=dict)
     tms: TileMatrixSet = attr.ib(default=WEB_MERCATOR_TMS)
+    reader_options: Dict = attr.ib(factory=dict)
 
+    reader: Type[BaseReader] = attr.ib(init=False)
     bands: Sequence[str] = attr.ib(init=False)
+
+    def __enter__(self):
+        """Support using with Context Managers."""
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """Support using with Context Managers."""
+        pass
 
     @abc.abstractmethod
     def _get_band_url(self, band: str) -> str:

--- a/tests/test_io_MultiBand.py
+++ b/tests/test_io_MultiBand.py
@@ -8,13 +8,12 @@ import attr
 import morecantile
 import pytest
 
+from rio_tiler.constants import WEB_MERCATOR_TMS
 from rio_tiler.errors import ExpressionMixingWarning, MissingBands
 from rio_tiler.io import BaseReader, COGReader, MultiBandReader
 from rio_tiler.models import BandStatistics
 
 PREFIX = os.path.join(os.path.dirname(__file__), "fixtures")
-
-default_tms = morecantile.tms.get("WebMercatorQuad")
 
 
 @attr.s
@@ -22,10 +21,10 @@ class BandFileReader(MultiBandReader):
     """Test MultiBand"""
 
     input: str = attr.ib()
-    reader: Type[BaseReader] = attr.ib(default=COGReader)
-
+    tms: morecantile.TileMatrixSet = attr.ib(default=WEB_MERCATOR_TMS)
     reader_options: Dict = attr.ib(factory=dict)
-    tms: morecantile.TileMatrixSet = attr.ib(default=default_tms)
+
+    reader: Type[BaseReader] = attr.ib(init=False, default=COGReader)
 
     def __attrs_post_init__(self):
         """Parse Sceneid and get grid bounds."""


### PR DESCRIPTION
This PR does:

- remove `BaseReader` inheritance for `MultiBaseReader` and `MultiBandReader`. This is to avoid confusion. Previously in those 2 classes, we were requesting the `reader` attribute to be of type `BaseReader`, if a user would have provided a `MultiBaseReader` child to it, from the type POV it would have been ok ... but it won't have worked. By removing the BaseReader inheritance we keep the abstract classes distincts. 

- remove `reader` from the `__init__` method in `MultiBaseReader` and `MultiBandReader`. It has to be set by the user.