### PR TITLE
add and use `resize_array`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 3.0.0a6 (TBD)
+
+* add `rio_tiler.utils.resize_array` to resize array to a given width/height (https://github.com/cogeotiff/rio-tiler/pull/463)
+* use `resize_array` in `ImageData.create_from_list` to avoid trying merging array of different sizes (https://github.com/cogeotiff/rio-tiler/pull/463)
 
 # 3.0.0a5 (2021-11-18)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -103,3 +103,25 @@ def test_16bit_PNG():
             assert (arr[0:10, 0:10] == 0).all()
             assert (arr[10:11, 10:11] == 25700).all()
             assert (arr[11:, 11:] == 65535).all()
+
+
+def test_merge_with_diffsize():
+    """Make sure we raise a warning"""
+    mask = numpy.zeros((256, 256), dtype="uint16") + 255
+    mask[0:10, 0:10] = 0
+    mask[10:11, 10:11] = 100
+
+    with pytest.warns(UserWarning):
+        img1 = ImageData(numpy.zeros((1, 256, 256)))
+        img2 = ImageData(numpy.zeros((1, 128, 128)))
+        img = ImageData.create_from_list([img1, img2])
+
+    assert img.count == 2
+    assert img.width == 256
+    assert img.height == 256
+
+    with pytest.warns(None) as w:
+        img1 = ImageData(numpy.zeros((1, 256, 256)))
+        img2 = ImageData(numpy.zeros((1, 256, 256)))
+        img = ImageData.create_from_list([img1, img2])
+    assert len(w) == 0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -472,3 +472,16 @@ def test_get_array_statistics():
     assert len(stats[0]["histogram"][0]) == 4
     assert len(stats[0]["histogram"][1]) == 4
     assert stats[0]["histogram"][0][3] == 0.0  # there is no value 1000000
+
+
+def test_resize_array():
+    """make sure we resize well."""
+    arr = np.zeros((3, 256, 256), dtype="uint8")
+    arr_r = utils.resize_array(arr, 512, 256)
+    assert arr_r.shape == (3, 512, 256)
+    assert arr_r.dtype == np.uint8
+
+    arr = np.zeros((256, 256), dtype="uint8")
+    arr_r = utils.resize_array(arr, 512, 512)
+    assert arr_r.shape == (512, 512)
+    assert arr_r.dtype == np.uint8


### PR DESCRIPTION
This PR does:
- add a `resize_array` function to resize a numpy array to a given height/width
- check if all the images are of the same size when using `ImageData.create_from_list` and resize array if not.