### PR TITLE
make sure geographic_bounds return only valid float values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
-# 3.0.1 (TBD)
+# 3.0.1 (2021-12-03)
 
 * avoid useless call to `transform_bounds` if input/output CRS are equals (https://github.com/cogeotiff/rio-tiler/pull/466)
+* make sure `geographic_bounds` don't return inf or nan values (https://github.com/cogeotiff/rio-tiler/pull/467)
 
 # 3.0.0 (2021-11-29)
 

--- a/rio_tiler/io/base.py
+++ b/rio_tiler/io/base.py
@@ -64,7 +64,14 @@ class SpatialMixin:
             )
         except:  # noqa
             warnings.warn(
-                "Cannot dertermine bounds in WGS84, will default to (-180.0, -90.0, 180.0, 90.0).",
+                "Cannot dertermine bounds in geographic CRS, will default to (-180.0, -90.0, 180.0, 90.0).",
+                UserWarning,
+            )
+            bounds = (-180.0, -90, 180.0, 90)
+
+        if not all(numpy.isfinite(bounds)):
+            warnings.warn(
+                "Transformation to geographic CRS returned invalid values, will default to (-180.0, -90.0, 180.0, 90.0).",
                 UserWarning,
             )
             bounds = (-180.0, -90, 180.0, 90)


### PR DESCRIPTION
ref: https://github.com/developmentseed/titiler/issues/413

For some reason, consecutive calls to `geographic_bounds` will return `inf` or `nan` values (we've seen this behaviour in previous proj (<8.2) gdal (<3.3) versions) (https://github.com/developmentseed/morecantile/blob/master/tests/test_morecantile.py#L243-L266). This PR is just a fail safe for previous rasterio/gdal versions. 