### PR TITLE
use cachetools.LRUCache to allow unashable options

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+
+# 3.0.2 (TBD)
+
+* switch from `functools.lru_cache` to `cachetools.LRUCache` to allow unashable options in `rio_tiler.io.stac.fetch` function (https://github.com/cogeotiff/rio-tiler/pull/471)
+
 # 3.0.1 (2021-12-03)
 
 * avoid useless call to `transform_bounds` if input/output CRS are equals (https://github.com/cogeotiff/rio-tiler/pull/466)

--- a/rio_tiler/io/stac.py
+++ b/rio_tiler/io/stac.py
@@ -1,6 +1,5 @@
 """rio_tiler.io.stac: STAC reader."""
 
-import functools
 import json
 from typing import Any, Dict, Iterator, Optional, Set, Type, Union
 from urllib.parse import urlparse
@@ -8,6 +7,8 @@ from urllib.parse import urlparse
 import attr
 import httpx
 import pystac
+from cachetools import LRUCache, cached
+from cachetools.keys import hashkey
 from morecantile import TileMatrixSet
 from rasterio.crs import CRS
 
@@ -31,7 +32,10 @@ DEFAULT_VALID_TYPE = {
 }
 
 
-@functools.lru_cache(maxsize=512)
+@cached(
+    LRUCache(maxsize=512),
+    key=lambda filepath, **kargs: hashkey(filepath, json.dumps(kargs)),
+)
 def fetch(filepath: str, **kwargs: Any) -> Dict:
     """Fetch STAC items.
 

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ inst_reqs = [
     "rasterio>=1.1.7",
     "httpx",
     "rio-color",
+    "cachetools",
     "importlib_resources>=1.1.0;python_version<'3.9'",
 ]
 

--- a/tests/test_io_stac.py
+++ b/tests/test_io_stac.py
@@ -566,13 +566,29 @@ def test_fetch_stac_client_options(httpx, s3_get):
 
     with STACReader(
         "http://somewhereovertherainbow.io/mystac.json",
-        fetch_options={"auth": ("user", "pass")},
+        fetch_options={
+            "auth": ("user", "pass"),
+            "headers": {"Authorization": "Bearer token"},
+        },
     ) as stac:
         assert stac.assets == ["red", "green", "blue"]
     httpx.get.assert_called_once()
     assert httpx.get.call_args[1]["auth"] == ("user", "pass")
+    assert httpx.get.call_args[1]["headers"] == {"Authorization": "Bearer token"}
     s3_get.assert_not_called()
-    httpx.mock_reset()
+
+    with STACReader(
+        "http://somewhereovertherainbow.io/mystac.json",
+        fetch_options={
+            "auth": ("user", "pass"),
+            "headers": {"Authorization": "Bearer token"},
+        },
+    ) as stac:
+        assert stac.assets == ["red", "green", "blue"]
+
+    # Check if it was cached
+    assert httpx.get.call_count == 1
+    s3_get.assert_not_called()
 
     # S3
     with open(STAC_PATH, "r") as f:


### PR DESCRIPTION
closes #470 

This PR add `cachetools` in the dependencies but it's a really light one.