### PR TITLE
AWS_HTTPS support + fix missing scheme

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# unreleased
+
+* add support for setting the S3 endpoint url scheme via the `AWS_HTTPS` environment variables in `aws_get_object` function using boto3 (https://github.com/cogeotiff/rio-tiler/pull/476)
 
 # 3.0.3 (2022-01-18)
 

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -42,7 +42,7 @@ def aws_get_object(
         session = boto3_session()
         # AWS_S3_ENDPOINT and AWS_HTTPS are GDAL config options of vsis3 driver
         # https://gdal.org/user/virtual_file_systems.html#vsis3-aws-s3-files
-        endpoint_url = os.environ.get("AWS_S3_ENDPOINT", None) 
+        endpoint_url = os.environ.get("AWS_S3_ENDPOINT", None)
         if endpoint_url is not None:
             use_https = os.environ.get("AWS_HTTPS", "YES")
             if use_https.upper() in ["YES", "TRUE", "ON"]:

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -41,7 +41,7 @@ def aws_get_object(
     if not client:
         session = boto3_session()
         endpoint_url = os.environ.get("AWS_S3_ENDPOINT", None)
-        if ( endpoint_url != None ):
+        if ( endpoint_url is not None ):
             use_https = os.environ.get("AWS_HTTPS", "YES")
             if ( use_https == "YES" ):
                 endpoint_url = "https://" + endpoint_url

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -41,6 +41,12 @@ def aws_get_object(
     if not client:
         session = boto3_session()
         endpoint_url = os.environ.get("AWS_S3_ENDPOINT", None)
+        if ( endpoint_url != None ):
+            use_https = os.environ.get("AWS_HTTPS", "YES")
+            if ( use_https == "YES" ):
+                endpoint_url = "https://" + endpoint_url
+            else:
+                endpoint_url = "http://" + endpoint_url
         client = session.client("s3", endpoint_url=endpoint_url)
 
     params = {"Bucket": bucket, "Key": key}

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -40,7 +40,9 @@ def aws_get_object(
     """AWS s3 get object content."""
     if not client:
         session = boto3_session()
-        endpoint_url = os.environ.get("AWS_S3_ENDPOINT", None)
+        # AWS_S3_ENDPOINT and AWS_HTTPS are GDAL config options of vsis3 driver
+        # https://gdal.org/user/virtual_file_systems.html#vsis3-aws-s3-files
+        endpoint_url = os.environ.get("AWS_S3_ENDPOINT", None) 
         if endpoint_url is not None:
             use_https = os.environ.get("AWS_HTTPS", "YES")
             if use_https == "YES":

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -41,9 +41,9 @@ def aws_get_object(
     if not client:
         session = boto3_session()
         endpoint_url = os.environ.get("AWS_S3_ENDPOINT", None)
-        if ( endpoint_url is not None ):
+        if endpoint_url is not None:
             use_https = os.environ.get("AWS_HTTPS", "YES")
-            if ( use_https == "YES" ):
+            if use_https == "YES":
                 endpoint_url = "https://" + endpoint_url
             else:
                 endpoint_url = "http://" + endpoint_url


### PR DESCRIPTION
**Proposed Changes:**

This PR add support for setting the S3 endpoint url scheme via the `AWS_HTTPS` environment variables in `aws_get_object` function using boto3. AWS_HTTPS is aligned on on gdal [vsis3](https://gdal.org/user/virtual_file_systems.html#vsis3-aws-s3-files) implmenation: https://github.com/OSGeo/gdal/blob/12aaf4be2c20a399efe005482e811a579a12a9fb/port/cpl_aws.cpp#L1207

**PR Checklist:**

- [X] This PR has **no** breaking changes.
- [X] Tests pass (run `tox`)
- [X] I have added my changes to the [CHANGELOG](https://github.com/cogeotiff/rio-tiler/blob/master/CHANGES.md)

