### PR TITLE
add `merged_statistics` for multiBaseReader

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 * add support for setting the S3 endpoint url scheme via the `AWS_HTTPS` environment variables in `aws_get_object` function using boto3 (https://github.com/cogeotiff/rio-tiler/pull/476)
 * Add semicolon `;` support for multi-blocks expression (https://github.com/cogeotiff/rio-tiler/pull/479)
 * add `rio_tiler.expression.get_expression_blocks` method to split expression (https://github.com/cogeotiff/rio-tiler/pull/479)
+* add `merged_statistics` method for `MultiBaseReader` to get statistics using between assets expression (https://github.com/cogeotiff/rio-tiler/pull/478)
 
 **future deprecation**
 


### PR DESCRIPTION
ref: https://github.com/developmentseed/titiler/discussions/429

In `rio-tiler` v3 we removed the `expression` option in the `statistics` for better consistency (to return Per Assets statistics). We couldn't have `between asset` expression here because the `model` would have been different:

- per asset stats: `Dict[str, Dict[str, BandStatistics]]` -> `{"asset1": {"1": rio_tiler.models.BandStatistics, ...}}`
- merged assets stats: `Dict[str, BandStatistics]]` -> `{"asset1_1": rio_tiler.models.BandStatistics, ...}`

Note: Using `expression` within the MultiBaseReader is really tricky because I guess most of the use case is to use it when STAC is hosting `band per file` dataset (only one band per COG) for which we have specifically design the `MultiBandReader`. The user should be aware that merged assets expression might fail if the assets don't have the same number of bands.

Ideally we could require the expression to be in form of `asset1_b1+asset2_b1` but sadly it's not possible because we are using the `expression` to get names of the `assets` we need to fetch (here https://github.com/cogeotiff/rio-tiler/blob/master/rio_tiler/io/base.py#L374-L378) so adding a suffix to the asset name will make the code instable IMO


@geospatial-jeff @kylebarron I'm happy to discuss this a bit more

cc @giswqs