### PR TITLE
New expression blocks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,20 @@
 # unreleased
 
 * add support for setting the S3 endpoint url scheme via the `AWS_HTTPS` environment variables in `aws_get_object` function using boto3 (https://github.com/cogeotiff/rio-tiler/pull/476)
+* Add semicolon `;` support for multi-blocks expression (https://github.com/cogeotiff/rio-tiler/pull/479)
+* add `rio_tiler.expression.get_expression_blocks` method to split expression (https://github.com/cogeotiff/rio-tiler/pull/479)
+
+**future deprecation**
+
+* using coma `,` in expression to define multiple blocks will be replaced by semicolon `;`
+
+```python
+# before
+expression = "b1+b2,b2"
+
+# new
+expression = "b1+b2;b2"
+```
 
 # 3.0.3 (2022-01-18)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 
 **future deprecation**
 
-* using coma `,` in expression to define multiple blocks will be replaced by semicolon `;`
+* using a comma `,` in an expression to define multiple blocks will be replaced by semicolon `;`
 
 ```python
 # before

--- a/rio_tiler/expression.py
+++ b/rio_tiler/expression.py
@@ -50,7 +50,7 @@ def get_expression_blocks(expression: str) -> List[str]:
     expr = [expr for expr in expression.split(",") if expr]
     if len(expr) > 1:
         warnings.warn(
-            "Using coma `,` for multiband expression will be deprecated in rio-tiler 4.0. Please use semicolon `;`.",
+            "Using comma `,` for multiband expression will be deprecated in rio-tiler 4.0. Please use semicolon `;`.",
             DeprecationWarning,
         )
 

--- a/rio_tiler/io/base.py
+++ b/rio_tiler/io/base.py
@@ -18,7 +18,7 @@ from ..errors import (
     MissingBands,
     TileOutsideBounds,
 )
-from ..expression import apply_expression
+from ..expression import apply_expression, get_expression_blocks
 from ..models import BandStatistics, ImageData, Info
 from ..tasks import multi_arrays, multi_values
 from ..types import BBox, Indexes
@@ -526,7 +526,7 @@ class MultiBaseReader(SpatialMixin, metaclass=abc.ABCMeta):
         )
 
         if expression:
-            blocks = expression.split(",")
+            blocks = get_expression_blocks(expression)
             output.data = apply_expression(blocks, assets, output.data)
             output.band_names = blocks
 
@@ -590,7 +590,7 @@ class MultiBaseReader(SpatialMixin, metaclass=abc.ABCMeta):
         output = multi_arrays(assets, _reader, bbox, **kwargs)
 
         if expression:
-            blocks = expression.split(",")
+            blocks = get_expression_blocks(expression)
             output.data = apply_expression(blocks, assets, output.data)
             output.band_names = blocks
 
@@ -651,7 +651,7 @@ class MultiBaseReader(SpatialMixin, metaclass=abc.ABCMeta):
         output = multi_arrays(assets, _reader, **kwargs)
 
         if expression:
-            blocks = expression.split(",")
+            blocks = get_expression_blocks(expression)
             output.data = apply_expression(blocks, assets, output.data)
             output.band_names = blocks
 
@@ -716,7 +716,7 @@ class MultiBaseReader(SpatialMixin, metaclass=abc.ABCMeta):
 
         values = numpy.array([d for _, d in data.items()])
         if expression:
-            blocks = expression.split(",")
+            blocks = get_expression_blocks(expression)
             values = apply_expression(blocks, assets, values)
 
         return values.tolist()
@@ -779,7 +779,7 @@ class MultiBaseReader(SpatialMixin, metaclass=abc.ABCMeta):
         output = multi_arrays(assets, _reader, shape, **kwargs)
 
         if expression:
-            blocks = expression.split(",")
+            blocks = get_expression_blocks(expression)
             output.data = apply_expression(blocks, assets, output.data)
             output.band_names = blocks
 
@@ -991,7 +991,7 @@ class MultiBandReader(SpatialMixin, metaclass=abc.ABCMeta):
         output = multi_arrays(bands, _reader, tile_x, tile_y, tile_z, **kwargs)
 
         if expression:
-            blocks = expression.split(",")
+            blocks = get_expression_blocks(expression)
             output.data = apply_expression(blocks, bands, output.data)
             output.band_names = blocks
 
@@ -1043,7 +1043,7 @@ class MultiBandReader(SpatialMixin, metaclass=abc.ABCMeta):
         output = multi_arrays(bands, _reader, bbox, **kwargs)
 
         if expression:
-            blocks = expression.split(",")
+            blocks = get_expression_blocks(expression)
             output.data = apply_expression(blocks, bands, output.data)
             output.band_names = blocks
 
@@ -1093,7 +1093,7 @@ class MultiBandReader(SpatialMixin, metaclass=abc.ABCMeta):
         output = multi_arrays(bands, _reader, **kwargs)
 
         if expression:
-            blocks = expression.split(",")
+            blocks = get_expression_blocks(expression)
             output.data = apply_expression(blocks, bands, output.data)
             output.band_names = blocks
 
@@ -1146,7 +1146,7 @@ class MultiBandReader(SpatialMixin, metaclass=abc.ABCMeta):
 
         values = numpy.array([d for _, d in data.items()])
         if expression:
-            blocks = expression.split(",")
+            blocks = get_expression_blocks(expression)
             values = apply_expression(blocks, bands, values)
 
         return values.tolist()
@@ -1197,7 +1197,7 @@ class MultiBandReader(SpatialMixin, metaclass=abc.ABCMeta):
         output = multi_arrays(bands, _reader, shape, **kwargs)
 
         if expression:
-            blocks = expression.split(",")
+            blocks = get_expression_blocks(expression)
             output.data = apply_expression(blocks, bands, output.data)
             output.band_names = blocks
 

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -1,0 +1,85 @@
+"""test rio_tiler.expression functions."""
+
+import numpy
+import pytest
+
+from rio_tiler.expression import (
+    apply_expression,
+    get_expression_blocks,
+    parse_expression,
+)
+
+
+@pytest.mark.parametrize(
+    "expr,expected",
+    [
+        ("b1,b2", [1, 2]),
+        ("B1,b2", [1, 2]),
+        ("B1,B2", [1, 2]),
+        ("where((b1==1) | (b1 > 0.5),1,0);", [1]),
+    ],
+)
+def test_parse(expr, expected):
+    """test parse_expression."""
+    assert sorted(parse_expression(expr)) == expected
+
+
+@pytest.mark.parametrize(
+    "expr,expected",
+    [
+        ("b1,b2", ["1", "2"]),
+        ("B1,b2", ["1", "2"]),
+        ("B1,B2", ["1", "2"]),
+    ],
+)
+def test_parse_cast(expr, expected):
+    """test parse_expression without casting."""
+    assert sorted(parse_expression(expr, cast=False)) == expected
+
+
+@pytest.mark.parametrize(
+    "expr,expected",
+    [
+        ("b1,", ["b1"]),
+        ("b1,b2", ["b1", "b2"]),
+        ("where((b1==1) | (b1 > 0.5),1,0)", ["where((b1==1) | (b1 > 0.5)", "1", "0)"]),
+        ("where((b1==1) | (b1 > 0.5),1,0);", ["where((b1==1) | (b1 > 0.5),1,0)"]),
+    ],
+)
+def test_get_blocks(expr, expected):
+    """test get_expression_blocks."""
+    with pytest.warns(None):
+        assert get_expression_blocks(expr) == expected
+
+
+def test_get_blocks_warn():
+    """test get_expression_blocks."""
+    with pytest.warns(DeprecationWarning):
+        assert get_expression_blocks("b1,b2")
+
+
+def test_apply_expression():
+    """test apply_expression."""
+    # divide b1 by b2
+    data = numpy.zeros(shape=(2, 10, 10), dtype=numpy.uint8)
+    data[0] += 1
+    data[1] += 2
+    d = apply_expression(["b1/b2"], ["b1", "b2"], data)
+    assert numpy.unique(d) == 0.5
+
+    # complex expression
+    data = numpy.zeros(shape=(2, 10, 10), dtype=numpy.uint8)
+    data[0, 0:5, 0:5] += 1
+    d = apply_expression(["where((b1==1) | (b1 > 0.5),1,0)"], ["b1", "b2"], data)
+    # data has 2 bands but expression just use one
+    assert d.shape == (1, 10, 10)
+    assert len(numpy.unique(d)) == 2
+    assert numpy.unique(d[0, 0:5, 0:5]) == [1]
+
+    data = numpy.zeros(shape=(2, 10, 10), dtype=numpy.uint8)
+    data[0, 0:5, 0:5] += 1
+    data[1, 0:5, 0:5] += 5
+    d = apply_expression(
+        ["where((b1==1) | (b1 > 0.5),1,0)", "where(b2 > 5,1,0)"], ["b1", "b2"], data
+    )
+    assert d.shape == (2, 10, 10)


### PR DESCRIPTION
closes #477 

proposed by @geospatial-jeff in slack: use `;` instead of `,` to support multi-blocks expression. 

To avoid breaking change/major release, we will still support `,` delimited blocks, so users who wants to use `,` in expression HAVE TO put a `;` at the end of the expression
```python

expression="where((b1==1) | (b1 > 0.5),1,0)" -> ["where((b1==1) | (b1 > 0.5)" , "1" ,"0)"]  # Not OK

expression="where((b1==1) | (b1 > 0.5),1,0);" -> ["where((b1==1) | (b1 > 0.5),1,0)"]  # OK
```

I understand this is not optimal but IMO it's the better solution (to my knowledge) to avoid using complex regex or hacky solution. But I'm 👂 

Note: 
https://numexpr.readthedocs.io/projects/NumExpr3/en/latest/user_guide.html#supported-functions
`where(bool, number1, number2)`, `arctan2(float1, float2)`, `{real,imag}(complex)`, `complex(float, float)`, `sum(number, axis=None)` and `prod(number, axis=None)` are the NumExpr function which could need a `,`.
