### PR TITLE
Keep two asterisks for `**kwargs` in docs

### DIFF
--- a/docs/src/mosaic.md
+++ b/docs/src/mosaic.md
@@ -45,7 +45,7 @@ Inputs:
 - **chunk_size**: optional, control the number of assets to process per loop.
 - **threads**: optional, number of threads to use in each loop.
 - **allowed_exceptions**: optional, allow some exceptions to be ignored.
-- **\*kwargs**: tiler specific keyword arguments.
+- **\*\*kwargs**: tiler specific keyword arguments.
 
 Returns:
 - img, assets_used : tuple of ImageData and list of used assets to construct the output data.


### PR DESCRIPTION
The rich diff:
<img width="419" alt="image" src="https://user-images.githubusercontent.com/15164633/165130483-abc288ca-eea9-4cad-b85b-d58271dfd16e.png">

Follow up from https://github.com/cogeotiff/rio-tiler/pull/496