### PR TITLE
enable GCPs dataset in COGReader

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,18 @@
+
+# NEXT (TBD)
+
+* Deprecate `rio_tiler.io.GCPCOGReader` and allow GPCS dataset to be opened by `rio_tiler.io.COGReader`
+
+```python
+# before
+with GCPCOGReader("my.tif") as cog:
+    ...
+
+# now, COGReader will find the gcps and create an internal WarpedVRT using the gpcs and crs
+with COGReader("my.tif") as cog:
+    ...
+```
+
 # 3.1.4 (2022-04-14)
 
 * Fix cutline creation for MultiPolygon (author @Fernigithub, https://github.com/cogeotiff/rio-tiler/pull/493)

--- a/docs/src/advanced/custom_readers.md
+++ b/docs/src/advanced/custom_readers.md
@@ -244,7 +244,7 @@ import pystac
 
 @attr.s
 class CustomSTACReader(COGReader):
-    """Custom COG Reader with GCPS support."""
+    """Custom COG Reader support."""
 
     # This will keep the STAC item info within the instance
     item: pystac.Item = attr.ib(default=None, init=False)

--- a/tests/test_io_cogeo.py
+++ b/tests/test_io_cogeo.py
@@ -522,6 +522,7 @@ def test_cog_with_internal_gcps():
         assert data.shape == (1, 256, 256)
         assert mask.shape == (256, 256)
     assert cog.dataset.closed
+    assert cog.dataset.src_dataset.closed
 
     # Pass dataset (should be a WarpedVRT)
     with rasterio.open(COG_GCPS) as dst:
@@ -550,7 +551,10 @@ def test_cog_with_internal_gcps():
                 assert mask.shape == (256, 256)
 
             assert not cog.dataset.closed
+            assert not cog.dataset.src_dataset.closed
+
         assert cog.dataset.closed
+    assert cog.dataset.src_dataset.closed
 
 
 def parse_img(content: bytes) -> Dict[Any, Any]:


### PR DESCRIPTION
This PR does:
- Deprecate `GCPCOGReader` 
- enable GPCs dataset in COGReader


cc @lossyrob 