### PR TITLE
remove min/max zoom from baseclass attribute

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 * remove python 3.7 support
 * update rasterio requirement to `>=1.3` to allow python 3.10 support
 * `rio_tiler.readers.read()`, `rio_tiler.readers.part()`, `rio_tiler.readers.preview()` now return a ImageData object
+* remove `minzoom` and `maxzoom` attribute in `rio_tiler.io.SpatialMixin` base class
+* remove `minzoom` and `maxzoom` attribute in `rio_tiler.io.COGReader` (now defined as properties).
 
 # 3.1.6 (2022-07-22)
 

--- a/rio_tiler/io/base.py
+++ b/rio_tiler/io/base.py
@@ -31,8 +31,6 @@ class SpatialMixin:
 
     Attributes:
         tms (morecantile.TileMatrixSet, optional): TileMatrixSet grid definition. Defaults to `WebMercatorQuad`.
-        minzoom (int): Dataset Min Zoom level. **Not in __init__**.
-        maxzoom (int): Dataset Max Zoom level. **Not in __init__**.
         bounds (tuple): Dataset bounds (left, bottom, right, top). **Not in __init__**.
         crs (rasterio.crs.CRS): Dataset crs. **Not in __init__**.
         geographic_crs (rasterio.crs.CRS): CRS to use as geographic coordinate system. Defaults to WGS84. **Not in __init__**.
@@ -40,9 +38,6 @@ class SpatialMixin:
     """
 
     tms: TileMatrixSet = attr.ib(default=WEB_MERCATOR_TMS)
-
-    minzoom: int = attr.ib(init=False)
-    maxzoom: int = attr.ib(init=False)
 
     bounds: BBox = attr.ib(init=False)
     crs: CRS = attr.ib(init=False)
@@ -64,7 +59,7 @@ class SpatialMixin:
             )
         except:  # noqa
             warnings.warn(
-                "Cannot dertermine bounds in geographic CRS, will default to (-180.0, -90.0, 180.0, 90.0).",
+                "Cannot determine bounds in geographic CRS, will default to (-180.0, -90.0, 180.0, 90.0).",
                 UserWarning,
             )
             bounds = (-180.0, -90, 180.0, 90)
@@ -243,9 +238,13 @@ class MultiBaseReader(SpatialMixin, metaclass=abc.ABCMeta):
 
     input: Any = attr.ib()
     tms: TileMatrixSet = attr.ib(default=WEB_MERCATOR_TMS)
-    reader_options: Dict = attr.ib(factory=dict)
+
+    minzoom: int = attr.ib(default=None)
+    maxzoom: int = attr.ib(default=None)
 
     reader: Type[BaseReader] = attr.ib(init=False)
+    reader_options: Dict = attr.ib(factory=dict)
+
     assets: Sequence[str] = attr.ib(init=False)
 
     def __enter__(self):
@@ -757,9 +756,13 @@ class MultiBandReader(SpatialMixin, metaclass=abc.ABCMeta):
 
     input: Any = attr.ib()
     tms: TileMatrixSet = attr.ib(default=WEB_MERCATOR_TMS)
-    reader_options: Dict = attr.ib(factory=dict)
+
+    minzoom: int = attr.ib(default=None)
+    maxzoom: int = attr.ib(default=None)
 
     reader: Type[BaseReader] = attr.ib(init=False)
+    reader_options: Dict = attr.ib(factory=dict)
+
     bands: Sequence[str] = attr.ib(init=False)
 
     def __enter__(self):

--- a/rio_tiler/io/cogeo.py
+++ b/rio_tiler/io/cogeo.py
@@ -156,7 +156,7 @@ class COGReader(BaseReader):
         """Support using with Context Managers."""
         self.close()
 
-    def _get_vrt_info(self):
+    def _dst_geom_in_tms_crs(self):
         """Return dataset info in TMS projection."""
         if self.dataset.crs != self.tms.rasterio_crs:
             dst_affine, w, h = calculate_default_transform(
@@ -181,7 +181,7 @@ class COGReader(BaseReader):
             tilesize = self.tms.tileMatrix[0].tileWidth
 
             try:
-                dst_affine, w, h = self._get_vrt_info()
+                dst_affine, w, h = self._dst_geom_in_tms_crs()
 
                 # The minzoom is defined by the resolution of the maximum theoretical overview level
                 # We assume `tilesize`` is the smallest overview size
@@ -208,7 +208,7 @@ class COGReader(BaseReader):
         """Define dataset maximum zoom level."""
         if self._maxzoom is None:
             try:
-                dst_affine, _, _ = self._get_vrt_info()
+                dst_affine, _, _ = self._dst_geom_in_tms_crs()
 
                 # The maxzoom is defined by finding the minimum difference between
                 # the raster resolution and the zoom level resolution

--- a/rio_tiler/io/stac.py
+++ b/rio_tiler/io/stac.py
@@ -164,8 +164,8 @@ class STACReader(MultiBaseReader):
     item: pystac.Item = attr.ib(default=None, converter=_to_pystac_item)
 
     tms: TileMatrixSet = attr.ib(default=WEB_MERCATOR_TMS)
-    minzoom: int = attr.ib(default=None)
-    maxzoom: int = attr.ib(default=None)
+    minzoom: int = attr.ib()
+    maxzoom: int = attr.ib()
 
     geographic_crs: CRS = attr.ib(default=WGS84_CRS)
 
@@ -202,13 +202,13 @@ class STACReader(MultiBaseReader):
         if not self.assets:
             raise MissingAssets("No valid asset found")
 
-        if self.minzoom is None:
-            # TODO get minzoom from PROJ extension
-            self.minzoom = self.tms.minzoom
+    @minzoom.default
+    def _minzoom(self):
+        return self.tms.minzoom
 
-        if self.maxzoom is None:
-            # TODO get maxzoom from PROJ extension
-            self.maxzoom = self.tms.maxzoom
+    @maxzoom.default
+    def _maxzoom(self):
+        return self.tms.maxzoom
 
     def _get_asset_url(self, asset: str) -> str:
         """Validate asset names and return asset's url.

--- a/tests/benchmarks/test_benchmarks.py
+++ b/tests/benchmarks/test_benchmarks.py
@@ -16,7 +16,7 @@ def read_tile(src_path, tile):
     """Benchmark rio-tiler.utils._tile_read."""
     # We make sure to not store things in cache.
     with rasterio.Env(GDAL_CACHEMAX=0, NUM_THREADS="all"):
-        with COGReader(src_path, minzoom=0, maxzoom=24) as cog:
+        with COGReader(src_path) as cog:
             return cog.tile(*tile)
 
 

--- a/tests/test_io_MultiBand.py
+++ b/tests/test_io_MultiBand.py
@@ -22,9 +22,20 @@ class BandFileReader(MultiBandReader):
 
     input: str = attr.ib()
     tms: morecantile.TileMatrixSet = attr.ib(default=WEB_MERCATOR_TMS)
-    reader_options: Dict = attr.ib(factory=dict)
 
     reader: Type[BaseReader] = attr.ib(init=False, default=COGReader)
+    reader_options: Dict = attr.ib(factory=dict)
+
+    minzoom: int = attr.ib()
+    maxzoom: int = attr.ib()
+
+    @minzoom.default
+    def _minzoom(self):
+        return self.tms.minzoom
+
+    @maxzoom.default
+    def _maxzoom(self):
+        return self.tms.maxzoom
 
     def __attrs_post_init__(self):
         """Parse Sceneid and get grid bounds."""

--- a/tests/test_io_cogeo.py
+++ b/tests/test_io_cogeo.py
@@ -812,7 +812,7 @@ def test_nonearthbody():
     with pytest.warns(UserWarning) as warnings:
         with COGReader(COG_EUROPA, geographic_crs=EUROPA_SPHERE) as cog:
             assert cog.info()
-            assert len(warnings) == 1
+            assert len(warnings) == 2
 
             img = cog.read()
             assert numpy.array_equal(img.data, cog.dataset.read(indexes=(1,)))
@@ -895,3 +895,33 @@ def test_nonearth_custom():
             ),
         ) as cog:
             assert cog.geographic_bounds[0] > -180
+
+
+def test_tms_tilesize_and_zoom():
+    """Test the influence of tms tilesize on COG zoom levels."""
+    with COGReader(COG_NODATA) as cog:
+        assert cog.minzoom == 5
+        assert cog.maxzoom == 9
+
+    tms_128 = TileMatrixSet.custom(
+        WEB_MERCATOR_TMS.xy_bbox,
+        WEB_MERCATOR_TMS.crs,
+        title="mercator with 64 tilesize",
+        tile_width=64,
+        tile_height=64,
+    )
+    with COGReader(COG_NODATA, tms=tms_128) as cog:
+        assert cog.minzoom == 5
+        assert cog.maxzoom == 11
+
+    tms_2048 = TileMatrixSet.custom(
+        WEB_MERCATOR_TMS.xy_bbox,
+        WEB_MERCATOR_TMS.crs,
+        title="mercator with 2048 tilesize",
+        tile_width=2048,
+        tile_height=2048,
+    )
+    with COGReader(COG_NODATA, tms=tms_2048) as cog:
+        print(cog.minzoom, cog.maxzoom)
+        assert cog.minzoom == 5
+        assert cog.maxzoom == 6

--- a/tests/test_io_cogeo.py
+++ b/tests/test_io_cogeo.py
@@ -68,18 +68,6 @@ def test_spatial_info_valid():
     cog.close()
     assert cog.dataset.closed
 
-    with COGReader(COG_NODATA, minzoom=3) as cog:
-        assert cog.minzoom == 3
-        assert cog.maxzoom == 9
-
-    with COGReader(COG_NODATA, maxzoom=12) as cog:
-        assert cog.minzoom == 5
-        assert cog.maxzoom == 12
-
-    with COGReader(COG_NODATA, minzoom=3, maxzoom=12) as cog:
-        assert cog.minzoom == 3
-        assert cog.maxzoom == 12
-
 
 def test_bounds_valid():
     """Should work as expected (get bounds)"""


### PR DESCRIPTION
ref #509 

This PR removes `minzoom` and `maxzoom` from the `SpatialMixin` base class (thus on other classes). The main effect is that now the user can't set `min/max` zoom as attribute in `COGReader`. 

For STACReader (multibase) and `MultiBandReader` those attributes are still available.