### PR TITLE
remove individual options attributes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,7 +22,7 @@
 
 * `rio_tiler.readers.read()`, `rio_tiler.readers.part()`, `rio_tiler.readers.preview()` now return a ImageData object
 * remove `minzoom` and `maxzoom` attribute in `rio_tiler.io.SpatialMixin` base class
-* remove `minzoom` and `maxzoom` attribute in `rio_tiler.io.COGReader` (now defined as properties).
+* remove `minzoom` and `maxzoom` attribute in `rio_tiler.io.Reader` (now defined as properties).
 * use `b` prefix for band names in `rio_tiler.models.ImageData` class (and in rio-tiler's readers)
     ```python
     # before
@@ -41,7 +41,7 @@
         >>> ["1", "2", "3"]
 
     # now
-    with COGReader("cog.tif") as cog:
+    with Reader("cog.tif") as cog:
         img = cog.read()
         print(img.band_names)
         >>> ["b1", "b2", "b3"]
@@ -100,7 +100,7 @@
             metadata={}
         )
 
-    with COGReader("cog.tif") as cog:
+    with Reader("cog.tif") as cog:
         print(cog.point(10.20, -42.0))
         >>> PointData(
             data=array([3744], dtype=uint16),
@@ -116,6 +116,17 @@
 * deleted `rio_tiler.reader.preview` function and updated `rio_tiler.reader.read` to allow width/height/max_size options
 * reordered keyword options in all `rio_tiler.reader` function for consistency
 * removed `AlphaBandWarning` warning when automatically excluding alpha band from data
+
+* remove `nodata`, `unscale`, `resampling_method`, `vrt_options` and `post_process` options to `Reader` init method and replaced with `options`
+    ```python
+    # before
+    with COGReader("cog.tif", nodata=1, resampling_method="bilinear") as cog:
+        data = cog.preview()
+
+    # now
+    with Reader(COGEO, options={"nodata": 1, "resampling_method": "bilinear"}) as cog:
+        data = cog.preview()
+    ```
 
 
 # 3.1.6 (2022-07-22)

--- a/rio_tiler/io/rasterio.py
+++ b/rio_tiler/io/rasterio.py
@@ -75,12 +75,16 @@ class Reader(BaseReader):
 
     colormap: Dict = attr.ib(default=None)
 
-    options: Dict[str, Any] = attr.ib(factory=dict)
+    options: reader.Options = attr.ib()
 
     # Context Manager to handle rasterio open/close
     _ctx_stack = attr.ib(init=False, factory=contextlib.ExitStack)
     _minzoom: int = attr.ib(init=False, default=None)
     _maxzoom: int = attr.ib(init=False, default=None)
+
+    @options.default
+    def _options_default(self):
+        return {}
 
     def __attrs_post_init__(self):
         """Define _kwargs, open dataset and get info."""
@@ -628,10 +632,14 @@ class GCPCOGReader(Reader):
 
     colormap: Dict = attr.ib(default=None)
 
-    options: Dict[str, Any] = attr.ib(factory=dict)
+    options: reader.Options = attr.ib()
 
     # for GCPCOGReader, dataset is not a input option.
     dataset: WarpedVRT = attr.ib(init=False)
+
+    @options.default
+    def _options_default(self):
+        return {}
 
     def __attrs_post_init__(self):
         """Define _kwargs, open dataset and get info."""

--- a/rio_tiler/reader.py
+++ b/rio_tiler/reader.py
@@ -3,7 +3,7 @@
 import contextlib
 import math
 import warnings
-from typing import Callable, Dict, Optional, Tuple, Union
+from typing import Callable, Dict, Optional, Tuple, TypedDict, Union
 
 import numpy
 from affine import Affine
@@ -21,6 +21,16 @@ from rio_tiler.models import ImageData, PointData
 from rio_tiler.types import BBox, DataMaskType, Indexes, NoData
 from rio_tiler.utils import _requested_tile_aligned_with_internal_tile as is_aligned
 from rio_tiler.utils import get_vrt_transform, has_alpha_band, non_alpha_indexes
+
+
+class Options(TypedDict):
+    """Reader Options."""
+
+    nodata: Optional[NoData]
+    vrt_options: Optional[Dict]
+    resampling_method: Optional[Resampling]
+    unscale: Optional[bool]
+    post_process: Optional[Callable[[numpy.ndarray, numpy.ndarray], DataMaskType]]
 
 
 def _get_width_height(max_size, dataset_height, dataset_width) -> Tuple[int, int]:

--- a/rio_tiler/reader.py
+++ b/rio_tiler/reader.py
@@ -23,7 +23,7 @@ from rio_tiler.utils import _requested_tile_aligned_with_internal_tile as is_ali
 from rio_tiler.utils import get_vrt_transform, has_alpha_band, non_alpha_indexes
 
 
-class Options(TypedDict):
+class Options(TypedDict, total=False):
     """Reader Options."""
 
     nodata: Optional[NoData]


### PR DESCRIPTION
This PR does:
- remove individual options attributes (nodata, unscale, ...) which are forwarded to the low-level reader and are now replaced with a unique `options={}` 
    ```python
    # before
    with COGReader("cog.tif", nodata=1, resampling_method="bilinear") as cog:
        data = cog.preview()
    # now
    with Reader(COGEO, options={"nodata": 1, "resampling_method": "bilinear"}) as cog:
        data = cog.preview()
    ```

This PR is built on top #534 

