### PR TITLE
call reader.read within reader.point

### DIFF
--- a/rio_tiler/io/rasterio.py
+++ b/rio_tiler/io/rasterio.py
@@ -893,7 +893,7 @@ class ImageReader(Reader):
             expression=expression,
             unscale=unscale,
             post_process=post_process,
-            window=Window(x, y, 1, 1),
+            window=Window(col_off=x, row_off=y, width=1, height=1),
         )
 
         return PointData(

--- a/tests/test_io_image.py
+++ b/tests/test_io_image.py
@@ -54,9 +54,17 @@ def test_non_geo_image():
             assert img.height == 1024
 
             pt = src.point(0, 0)
+            assert list(pt.data) == [31, 34, 17]
             assert len(pt.mask) == 1
             assert pt.mask[0] == 255
             data = list(src.dataset.sample([(0, 0)]))[0]
+            numpy.testing.assert_array_equal(pt.data, data)
+
+            pt = src.point(50, 100)
+            assert list(pt.data) == [48, 55, 14]
+            assert len(pt.mask) == 1
+            assert pt.mask[0] == 255
+            data = list(src.dataset.sample([(50, 100)]))[0]
             numpy.testing.assert_array_equal(pt.data, data)
 
             pt = src.point(1999, 1999)

--- a/tests/test_io_xarray.py
+++ b/tests/test_io_xarray.py
@@ -84,4 +84,3 @@ def test_xarray_reader():
         assert img.count == 1
         assert img.band_names == ["2022-01-01T00:00:00.000000000"]
         assert img.crs.to_epsg() == 3857
-        print(img)


### PR DESCRIPTION
Improve reusability of the code by using `reader.read` within `reader.point`. Also makes sure that all `reader.Options` are compatible with `reader.point` function