### PR TITLE
add asset_as_band

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,25 @@
+# 4.1.0 (2022-11-22)
+
+* add `asset_as_band` option in `MultiBaseReader` tile, part, preview, feature and point methods
+
+```python
+with STACReader(STAC_PATH) as stac:
+    img = stac.tile(71, 102, 8, assets="green")
+    assert img.band_names == ["green_b1"]
+
+with STACReader(STAC_PATH) as stac:
+    img = stac.tile(71, 102, 8, assets="green", asset_as_band=True)
+    assert img.band_names == ["green"]
+
+# For expression, without `asset_as_band` tag, users have to pass `_b{n}` suffix to indicate the band index
+with STACReader(STAC_PATH) as stac:
+    img = stac.tile(71, 102, 8, expression="green_b1/red_b1")
+    assert img.band_names == ["green_b1/red_b1"]
+
+with STACReader(STAC_PATH) as stac:
+    img = stac.tile(71, 102, 8, expression="green/red", asset_as_band=True)
+    assert img.band_names == ["green/red"]
+```
 
 # 4.0.0 (2022-11-21)
 

--- a/docs/src/readers.md
+++ b/docs/src/readers.md
@@ -673,6 +673,21 @@ assert isinstance(stats["B01_b1/B02_b1"], BandStatistics)
 
 When using `expression`, the user will need to explicitly pass the band number to use within the asset e.g: `asset1_b1 + asset2_b2`.
 
+### Asset As Band
+
+in rio-tiler `4.1.0`, we've added `asset_as_band: bool` option to the data methods (tile, feature, part, preview, point) to tell the reader to treat each asset as a dataset band. This is specifically useful for `expression`
+
+```python
+# For expression, without `asset_as_band` tag, users have to pass `_b{n}` suffix to indicate the band index
+with STACReader(STAC_PATH) as stac:
+    img = stac.tile(71, 102, 8, expression="green_b1/red_b1")
+    assert img.band_names == ["green_b1/red_b1"]
+
+# With `asset_as_band=True`, expression can be the asset names
+with STACReader(STAC_PATH) as stac:
+    img = stac.tile(71, 102, 8, expression="green/red", asset_as_band=True)
+    assert img.band_names == ["green/red"]
+```
 
 ## rio_tiler.io.rasterio.ImageReader
 

--- a/rio_tiler/errors.py
+++ b/rio_tiler/errors.py
@@ -71,3 +71,7 @@ class InvalidColorFormat(RioTilerError):
 
 class InvalidDatatypeWarning(UserWarning):
     """Invalid Output Datatype."""
+
+
+class AssetAsBandError(RioTilerError):
+    """Can't use asset_as_band with multiple bands."""


### PR DESCRIPTION
This PR adds `asset_as_band` for **data** methods. It's is really useful for STAC items that have asset representing bands (e.g Landsat, sentinel).

closes #557 