### PR TITLE
Fixed duplicate use of y coordinate and fixed order of lat and lon in point() in xarray.py

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 4.1.1 (2022-12-12)
+
+* fix invalid coordinates slicing for `XArrayReader.point()` method (author @benjaminleighton, https://github.com/cogeotiff/rio-tiler/pull/559)
+
 # 4.1.0 (2022-11-24)
 
 * add `asset_as_band` option in `MultiBaseReader` tile, part, preview, feature and point methods

--- a/rio_tiler/io/xarray.py
+++ b/rio_tiler/io/xarray.py
@@ -410,4 +410,3 @@ class XarrayReader(BaseReader):
             dataset_statistics=stats,
             band_names=band_names,
         )
-

--- a/rio_tiler/io/xarray.py
+++ b/rio_tiler/io/xarray.py
@@ -335,17 +335,17 @@ class XarrayReader(BaseReader):
         ds_lon, ds_lat = transform_coords(coord_crs, self.crs, [lon], [lat])
 
         if not (
-            (self.bounds[0] < ds_lat[0] < self.bounds[2])
-            and (self.bounds[1] < ds_lon[0] < self.bounds[3])
+            (self.bounds[0] < ds_lon[0] < self.bounds[2])
+            and (self.bounds[1] < ds_lat[0] < self.bounds[3])
         ):
             raise PointOutsideBounds("Point is outside dataset bounds")
 
-        x, y = rowcol(self.input.rio.transform(), ds_lat, ds_lon)
+        y, x = rowcol(self.input.rio.transform(), ds_lon, ds_lat)
 
         band_names = [str(band) for d in self._dims for band in self.input[d].values]
 
         return PointData(
-            self.input.data[:, x[0], y[0]],
+            self.input.data[:, y[0], x[0]],
             coordinates=(lon, lat),
             crs=coord_crs,
             band_names=band_names,
@@ -410,3 +410,4 @@ class XarrayReader(BaseReader):
             dataset_statistics=stats,
             band_names=band_names,
         )
+

--- a/rio_tiler/io/xarray.py
+++ b/rio_tiler/io/xarray.py
@@ -335,17 +335,17 @@ class XarrayReader(BaseReader):
         ds_lon, ds_lat = transform_coords(coord_crs, self.crs, [lon], [lat])
 
         if not (
-            (self.bounds[0] < ds_lon[0] < self.bounds[2])
-            and (self.bounds[1] < ds_lat[0] < self.bounds[3])
+            (self.bounds[0] < ds_lat[0] < self.bounds[2])
+            and (self.bounds[1] < ds_lon[0] < self.bounds[3])
         ):
             raise PointOutsideBounds("Point is outside dataset bounds")
 
-        x, y = rowcol(self.input.rio.transform(), ds_lon, ds_lat)
+        x, y = rowcol(self.input.rio.transform(), ds_lat, ds_lon)
 
         band_names = [str(band) for d in self._dims for band in self.input[d].values]
 
         return PointData(
-            self.input.data[:, y[0], y[0]],
+            self.input.data[:, x[0], y[0]],
             coordinates=(lon, lat),
             crs=coord_crs,
             band_names=band_names,

--- a/tests/test_io_xarray.py
+++ b/tests/test_io_xarray.py
@@ -15,7 +15,7 @@ planet = os.path.join(PREFIX, "PLANET_SCOPE_3D.nc")
 
 def test_xarray_reader():
     """test XarrayReader."""
-    arr = numpy.random.randn(1, 33, 35)
+    arr = numpy.arange(0.0, 33*35).reshape(1, 33, 35)
     data = xarray.DataArray(
         arr,
         dims=("time", "y", "x"),
@@ -55,6 +55,12 @@ def test_xarray_reader():
         assert pt.count == 1
         assert pt.band_names == ["2022-01-01T00:00:00.000000000"]
         assert pt.coordinates
+        xys = [[0, 2.499], [0, 2.501], [-4.999, 0], [-5.001, 0], [-170, 80]]
+        for xy in xys: 
+            x = xy[0]
+            y = xy[1]
+            pt = dst.point(x, y)
+            assert pt.data[0] == data.sel(x=x, y=y, method='nearest')
 
         feat = {
             "type": "Feature",

--- a/tests/test_io_xarray.py
+++ b/tests/test_io_xarray.py
@@ -15,7 +15,7 @@ planet = os.path.join(PREFIX, "PLANET_SCOPE_3D.nc")
 
 def test_xarray_reader():
     """test XarrayReader."""
-    arr = numpy.arange(0.0, 33*35).reshape(1, 33, 35)
+    arr = numpy.arange(0.0, 33 * 35).reshape(1, 33, 35)
     data = xarray.DataArray(
         arr,
         dims=("time", "y", "x"),
@@ -56,11 +56,11 @@ def test_xarray_reader():
         assert pt.band_names == ["2022-01-01T00:00:00.000000000"]
         assert pt.coordinates
         xys = [[0, 2.499], [0, 2.501], [-4.999, 0], [-5.001, 0], [-170, 80]]
-        for xy in xys: 
+        for xy in xys:
             x = xy[0]
             y = xy[1]
             pt = dst.point(x, y)
-            assert pt.data[0] == data.sel(x=x, y=y, method='nearest')
+            assert pt.data[0] == data.sel(x=x, y=y, method="nearest")
 
         feat = {
             "type": "Feature",


### PR DESCRIPTION
Corrects the slicing of data in generating PointData to use x and y rather than just y. I also believe that the bounds check and rowcol had ds_lat and ds_lon in the wrong place. I'm not sure of the later and mostly determined it emperically testing with "https://pangeo.blob.core.windows.net/pangeo-public/daymet-rio-tiler/na-wgs84.zarr/"