### PR TITLE
fix mask datatype issues

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,0 @@
-[flake8]
-ignore = E501,W503,E203
-exclude = .git,__pycache__,docs/source/conf.py,old,build,dist
-max-complexity = 14
-max-line-length = 90

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,9 @@
 
+# 4.1.8 (2023-02-15)
+
+* Fix dtype issue when working with Mosaics Methods. Mask should always been of type `Uint8`.
+* Fix `ImageData.from_array` method when working with Masked array
+
 # 4.1.7 (2023-02-07)
 
 * add `from_array` and `from_bytes` ImageData creation methods

--- a/rio_tiler/models.py
+++ b/rio_tiler/models.py
@@ -305,24 +305,22 @@ class ImageData:
             yield i
 
     @classmethod
-    def from_array(cls, data: numpy.ndarray) -> "ImageData":
+    def from_array(cls, arr: numpy.ndarray) -> "ImageData":
         """Create ImageData from a numpy array.
 
         Args:
-            data (numpy.ndarray): Numpy array or Numpy masked array.
+            arr (numpy.ndarray): Numpy array or Numpy masked array.
 
         """
-        if len(data.shape) < 3:
-            data = numpy.expand_dims(data, axis=0)
+        if len(arr.shape) < 3:
+            arr = numpy.expand_dims(arr, axis=0)
 
-        if isinstance(data, numpy.ma.MaskedArray):
-            data = data.data
-            mask = ~numpy.logical_or.reduce(numpy.ma.getmaskarray(data)) * numpy.uint8(
-                255
-            )
-            return cls(data, mask)
+        if isinstance(arr, numpy.ma.MaskedArray):
+            data = numpy.ma.getdata(arr)
+            mask = ~numpy.logical_or.reduce(numpy.ma.getmaskarray(arr))
+            return cls(data, mask * numpy.uint8(255))
 
-        return cls(data)
+        return cls(arr)
 
     @classmethod
     def from_bytes(cls, data: bytes) -> "ImageData":

--- a/rio_tiler/mosaic/methods/base.py
+++ b/rio_tiler/mosaic/methods/base.py
@@ -1,6 +1,7 @@
 """rio-tiler.mosaic.methods abc class."""
 
 import abc
+from typing import Optional, Tuple
 
 import numpy
 
@@ -10,11 +11,11 @@ class MosaicMethodBase(abc.ABC):
 
     def __init__(self):
         """Init backend."""
-        self.tile = None
-        self.exit_when_filled = False
+        self.tile: Optional[numpy.ma.MaskedArray] = None
+        self.exit_when_filled: bool = False
 
     @property
-    def is_done(self):
+    def is_done(self) -> bool:
         """Check if the tile filling is done.
 
         Returns:
@@ -30,15 +31,18 @@ class MosaicMethodBase(abc.ABC):
         return False
 
     @property
-    def data(self):
+    def data(self) -> Tuple[Optional[numpy.ndarray], Optional[numpy.ndarray]]:
         """Return data and mask."""
         if self.tile is not None:
-            return self.tile.data, (~self.tile.mask[0] * 255).astype(self.tile.dtype)
+            data = numpy.ma.getdata(self.tile)
+            mask = ~numpy.logical_or.reduce(numpy.ma.getmaskarray(self.tile))
+            return (data, mask * numpy.uint8(255))
+
         else:
             return None, None
 
     @abc.abstractmethod
-    def feed(self, tile):
+    def feed(self, tile: numpy.ma.MaskedArray):
         """Fill mosaic tile.
 
         Args:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -329,6 +329,18 @@ def test_image_from_array():
     assert im.data.shape == (1, 256, 256)
     assert im.mask.all()
 
+    mask = numpy.zeros((256, 256), dtype="uint8")  # 0 no masked
+    mask[0:10, 0:10] = 1  # masked
+    arr = numpy.ma.MaskedArray(
+        numpy.zeros((1, 256, 256), dtype="uint8"),
+        mask,
+    )
+    im = ImageData.from_array(arr)
+    assert im.data.shape == (1, 256, 256)
+    assert not im.mask.all()
+    assert im.mask[0, 0] == 0
+    assert im.mask[11, 11] == 255
+
 
 def test_image_from_bytes():
     """Create ImageData from bytes."""

--- a/tests/test_mosaic.py
+++ b/tests/test_mosaic.py
@@ -72,7 +72,8 @@ def test_mosaic_tiler():
     assert m.shape == (256, 256)
     assert m.all()
     assert t[0][-1][-1] == 8682
-    assert t.dtype == m.dtype
+    assert t.dtype == "uint16"
+    assert m.dtype == "uint8"
 
     img, _ = mosaic.mosaic_reader(assets, _read_tile, x, y, z)
     assert img.band_names == ["b1", "b2", "b3"]
@@ -90,7 +91,8 @@ def test_mosaic_tiler():
     assert m.shape == (256, 256)
     assert m.all()
     assert t[0][-1][-1] == 8057
-    assert t.dtype == m.dtype
+    assert t.dtype == "uint16"
+    assert m.dtype == "uint8"
 
     (t, m), _ = mosaic.mosaic_reader(assets, _read_tile, x, y, z, indexes=1)
     assert t.shape == (1, 256, 256)
@@ -98,7 +100,8 @@ def test_mosaic_tiler():
     assert t.all()
     assert m.all()
     assert t[0][-1][-1] == 8682
-    assert t.dtype == m.dtype
+    assert t.dtype == "uint16"
+    assert m.dtype == "uint8"
 
     # Test darkest pixel selection
     (t, m), assets_used = mosaic.mosaic_reader(
@@ -107,13 +110,15 @@ def test_mosaic_tiler():
     assert len(assets_used) == 2
     assert m.all()
     assert t[0][-1][-1] == 8057
-    assert t.dtype == m.dtype
+    assert t.dtype == "uint16"
+    assert m.dtype == "uint8"
 
     (to, mo), _ = mosaic.mosaic_reader(
         assets_order, _read_tile, x, y, z, pixel_selection=defaults.LowestMethod()
     )
     numpy.testing.assert_array_equal(t[0, m], to[0, mo])
-    assert to.dtype == mo.dtype
+    assert to.dtype == "uint16"
+    assert mo.dtype == "uint8"
 
     # Test brightest pixel selection
     (t, m), _ = mosaic.mosaic_reader(
@@ -121,14 +126,16 @@ def test_mosaic_tiler():
     )
     assert m.all()
     assert t[0][-1][-1] == 8682
-    assert t.dtype == m.dtype
+    assert t.dtype == "uint16"
+    assert m.dtype == "uint8"
 
     (to, mo), _ = mosaic.mosaic_reader(
         assets_order, _read_tile, x, y, z, pixel_selection=defaults.HighestMethod()
     )
     numpy.testing.assert_array_equal(to, t)
     numpy.testing.assert_array_equal(mo, m)
-    assert to.dtype == mo.dtype
+    assert to.dtype == "uint16"
+    assert mo.dtype == "uint8"
 
     # test with default and partially covered tile
     (t, m), _ = mosaic.mosaic_reader(
@@ -136,7 +143,8 @@ def test_mosaic_tiler():
     )
     assert t.any()
     assert not m.all()
-    assert t.dtype == m.dtype
+    assert t.dtype == "uint16"
+    assert m.dtype == "uint8"
 
     # test when tiler raise errors (outside bounds)
     with pytest.raises(EmptyMosaicError):
@@ -150,7 +158,8 @@ def test_mosaic_tiler():
     assert m.shape == (256, 256)
     assert m.all()
     assert t[0][-1][-1] == 8369
-    assert t.dtype == m.dtype
+    assert t.dtype == "uint16"
+    assert m.dtype == "uint8"
 
     # Test mean pixel selection
     (t, m), _ = mosaic.mosaic_reader(
@@ -163,7 +172,8 @@ def test_mosaic_tiler():
     )
     assert m.all()
     assert t[0][-1][-1] == 8369.5
-    assert t.dtype == m.dtype
+    assert t.dtype == "float64"
+    assert m.dtype == "uint8"
 
     # Test median pixel selection
     (t, m), _ = mosaic.mosaic_reader(
@@ -173,7 +183,8 @@ def test_mosaic_tiler():
     assert m.shape == (256, 256)
     assert m.all()
     assert t[0][-1][-1] == 8369
-    assert t.dtype == m.dtype
+    assert t.dtype == "uint16"
+    assert m.dtype == "uint8"
 
     # Test median pixel selection
     (t, m), _ = mosaic.mosaic_reader(
@@ -186,7 +197,8 @@ def test_mosaic_tiler():
     )
     assert m.all()
     assert t[0][-1][-1] == 8369.5
-    assert t.dtype == m.dtype
+    assert t.dtype == "float64"
+    assert m.dtype == "uint8"
 
     (t, m), _ = mosaic.mosaic_reader(
         assets_order,
@@ -201,7 +213,8 @@ def test_mosaic_tiler():
     assert m.shape == (256, 256)
     assert m.all()
     assert t[0][-1][-1] == 8682
-    assert t.dtype == m.dtype
+    assert t.dtype == "uint16"
+    assert m.dtype == "uint8"
 
     (t, m), _ = mosaic.mosaic_reader(
         assets_order,
@@ -216,7 +229,8 @@ def test_mosaic_tiler():
     assert m.shape == (256, 256)
     assert m.all()
     assert t[0][-1][-1] == 8057
-    assert t.dtype == m.dtype
+    assert t.dtype == "uint16"
+    assert m.dtype == "uint8"
 
     # Test pixel selection as _class_, not instance of class
     (t, m), assets_used = mosaic.mosaic_reader(
@@ -226,7 +240,8 @@ def test_mosaic_tiler():
     assert m.shape == (256, 256)
     assert m.all()
     assert t[0][-1][-1] == 8682
-    assert t.dtype == m.dtype
+    assert t.dtype == "uint16"
+    assert m.dtype == "uint8"
 
     # Test invalid Pixel Selection class
     with pytest.raises(InvalidMosaicMethod):
@@ -242,7 +257,8 @@ def test_mosaic_tiler():
     (t, m), _ = mosaic.mosaic_reader(assets, _read_preview, width=256, height=256)
     assert t.shape == (3, 256, 256)
     assert m.shape == (256, 256)
-    assert t.dtype == m.dtype
+    assert t.dtype == "uint16"
+    assert m.dtype == "uint8"
 
 
 def mock_rasterio_open(asset):


### PR DESCRIPTION
closes #575 

This PR updated the mosaic methods to force mask to be of type `Uint8`. By construction the mask is created from Numpy masked array (bool) so it shouldn't break anything

I also added some type annotation and changed some variable names.

This PR also fix an bug introduced in latest release (also added a test to confirm the fix)