### PR TITLE
Update dynamic_tiler.md

### DIFF
--- a/docs/src/advanced/dynamic_tiler.md
+++ b/docs/src/advanced/dynamic_tiler.md
@@ -58,7 +58,7 @@ app = FastAPI(
             "content": {"image/png": {}}, "description": "Return an image.",
         }
     },
-    response_class=ImageResponse,
+    response_class=Response,
     description="Read COG and return a tile",
 )
 def tile(

--- a/docs/src/advanced/dynamic_tiler.md
+++ b/docs/src/advanced/dynamic_tiler.md
@@ -36,15 +36,8 @@ pip install fastapi uvicorn rio-tiler
 """rio-tiler tile server."""
 
 import os
-from enum import Enum
-from typing import Any, Dict, List, Optional
-from types import DynamicClassAttribute
 
-from urllib.parse import urlencode
-
-import uvicorn
-from fastapi import FastAPI, Path, Query
-from rasterio.crs import CRS
+from fastapi import FastAPI, Query
 from starlette.requests import Request
 from starlette.responses import Response
 


### PR DESCRIPTION
removing imports that don't seem to be used in this example

btw.. I am not sure where `ImageResponse` is imported from, see

`response_class=ImageResponse`

also.. I am not familiar with FastAPI, trying to learn from example.. 