### PR TITLE
Fix cutline behavior over edge (#585)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,8 @@
 
+# Next (TBD)
+
+* enable `boundless` cutline (author @yellowcap, https://github.com/cogeotiff/rio-tiler/pull/586)
+
 # 4.1.9 (2023-02-28)
 
 * Automatically expand 2D numpy array to 3D when creating ImageData

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 
 # Next (TBD)
 
-* enable `boundless` cutline (author @yellowcap, https://github.com/cogeotiff/rio-tiler/pull/586)
+* enable `boundless` geometry for cutline (author @yellowcap, https://github.com/cogeotiff/rio-tiler/pull/586)
 
 # 4.1.9 (2023-02-28)
 

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -535,8 +535,6 @@ def _convert_to_raster_space(
     for point in poly_coordinates:
         xs, ys = zip(*coords(point))
         src_y, src_x = rowcol(src_dst.transform, xs, ys)
-        src_x = [max(0, min(src_dst.width, x)) for x in src_x]
-        src_y = [max(0, min(src_dst.height, y)) for y in src_y]
         polygon = ", ".join([f"{x} {y}" for x, y in list(zip(src_x, src_y))])
         polygons.append(f"({polygon})")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -375,7 +375,6 @@ def test_cutline():
     triangle_bounds = featureBounds(triangle_over_image_edge)
 
     with Reader(COG_RGB) as src:
-        from matplotlib import pyplot as plt
 
         cutline = utils.create_cutline(
             src.dataset, triangle_over_image_edge, geometry_crs="epsg:4326"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -34,6 +34,7 @@ PIX4D_PATH = os.path.join(S3_LOCAL, KEY_PIX4D)
 COG_DST = os.path.join(os.path.dirname(__file__), "fixtures", "cog_name.tif")
 COG_WEB_TILED = os.path.join(os.path.dirname(__file__), "fixtures", "web.tif")
 COG_NOWEB = os.path.join(os.path.dirname(__file__), "fixtures", "noweb.tif")
+COG_RGB = os.path.join(os.path.dirname(__file__), "fixtures", "cog_rgb.tif")
 NOCOG = os.path.join(os.path.dirname(__file__), "fixtures", "nocog.tif")
 COGEO = os.path.join(os.path.dirname(__file__), "fixtures", "cog.tif")
 COG_CMAP = os.path.join(os.path.dirname(__file__), "fixtures", "cog_cmap.tif")
@@ -358,6 +359,29 @@ def test_cutline():
     with Reader(COGEO) as src:
         with pytest.raises(RioTilerError):
             utils.create_cutline(src.dataset, bad_poly, geometry_crs="epsg:4326")
+
+    triangle_over_image_edge = {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [-104.775390888988852, 38.953714348778355],
+                [-104.775146720379681, 38.953580769848777],
+                [-104.775389629827075, 38.953472856486307],
+                [-104.775390888988852, 38.953714348778355],
+            ]
+        ],
+    }
+
+    triangle_bounds = featureBounds(triangle_over_image_edge)
+
+    with Reader(COG_RGB) as src:
+        from matplotlib import pyplot as plt
+
+        cutline = utils.create_cutline(
+            src.dataset, triangle_over_image_edge, geometry_crs="epsg:4326"
+        )
+        data, mask = src.part(triangle_bounds, vrt_options={"cutline": cutline})
+        assert np.sum(mask == 255) == 5984
 
 
 def test_parse_expression():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -372,15 +372,17 @@ def test_cutline():
         ],
     }
 
+    # Check when using `boundless cutline`
+    # https://github.com/cogeotiff/rio-tiler/issues/585
     triangle_bounds = featureBounds(triangle_over_image_edge)
-
     with Reader(COG_RGB) as src:
-
         cutline = utils.create_cutline(
             src.dataset, triangle_over_image_edge, geometry_crs="epsg:4326"
         )
         data, mask = src.part(triangle_bounds, vrt_options={"cutline": cutline})
-        assert np.sum(mask == 255) == 5984
+        assert sum(mask[:, 0]) == 0  # first line
+        assert sum(mask[0, :]) == 0  # first column
+        assert sum(mask[:, -1]) == 0  # last column
 
 
 def test_parse_expression():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -380,9 +380,9 @@ def test_cutline():
             src.dataset, triangle_over_image_edge, geometry_crs="epsg:4326"
         )
         data, mask = src.part(triangle_bounds, vrt_options={"cutline": cutline})
-        assert sum(mask[:, 0]) == 0  # first line
-        assert sum(mask[0, :]) == 0  # first column
-        assert sum(mask[:, -1]) == 0  # last column
+        assert sum(mask[:, 0]) == 0  # first column
+        assert sum(mask[0, :]) == 0  # first line
+        assert sum(mask[-1, :]) == 0  # last line
 
 
 def test_parse_expression():


### PR DESCRIPTION
The test does the cutting using the triangle used as illustration in the related issue https://github.com/cogeotiff/rio-tiler/issues/585.

Note that the sum of the mask is hard coded from summing the values while running the new cutline test manually. I tried to come up with a mathematical way to calculate how big the mask should be, but I realized that would take a bit more time than I thought. 

So if it would be important to have a mathematical way to compute to the magic number of `5984` pixels for this mask let me know I can try to compute this number from the geometry. Please advise on this.