### PR TITLE
split resampling option to RasterIO and Warp options

### DIFF
--- a/docs/src/readers.md
+++ b/docs/src/readers.md
@@ -357,6 +357,7 @@ print(stats["b1"].dict())
 - **unscale**: Apply internal rescaling factors
 - **vrt_options**: Pass WarpedVRT Option (see: https://gdal.org/api/gdalwarp_cpp.html?highlight=vrt#_CPPv415GDALWarpOptions)
 - **resampling_method**: Set default `resampling_method`
+- **reprojection_method**: Set default `reprojection_method`
 - **post_process**: Function to apply after the read operations
 
 ```python

--- a/rio_tiler/io/rasterio.py
+++ b/rio_tiler/io/rasterio.py
@@ -12,7 +12,6 @@ from morecantile import BoundingBox, Coords, Tile, TileMatrixSet
 from morecantile.utils import _parse_tile_arg
 from rasterio import transform
 from rasterio.crs import CRS
-from rasterio.enums import Resampling
 from rasterio.features import bounds as featureBounds
 from rasterio.features import geometry_mask
 from rasterio.io import DatasetReader, DatasetWriter, MemoryFile
@@ -34,7 +33,7 @@ from rio_tiler.errors import (
 from rio_tiler.expression import parse_expression
 from rio_tiler.io.base import BaseReader
 from rio_tiler.models import BandStatistics, ImageData, Info, PointData
-from rio_tiler.types import BBox, DataMaskType, Indexes, NumType
+from rio_tiler.types import BBox, DataMaskType, Indexes, NumType, RIOResampling
 from rio_tiler.utils import create_cutline, has_alpha_band, has_mask_band
 
 
@@ -667,7 +666,7 @@ class ImageReader(Reader):
         indexes: Optional[Indexes] = None,
         expression: Optional[str] = None,
         force_binary_mask: bool = True,
-        resampling_method: Resampling = "nearest",
+        resampling_method: RIOResampling = "nearest",
         unscale: bool = False,
         post_process: Optional[
             Callable[[numpy.ndarray, numpy.ndarray], DataMaskType]
@@ -683,7 +682,7 @@ class ImageReader(Reader):
             indexes (int or sequence of int, optional): Band indexes.
             expression (str, optional): rio-tiler expression (e.g. b1/b2+b3).
             force_binary_mask (bool, optional): Cast returned mask to binary values (0 or 255). Defaults to `True`.
-            resampling_method (rasterio.enums.Resampling, optional): Rasterio's resampling algorithm. Defaults to `nearest`.
+            resampling_method (RIOResampling, optional): RasterIO resampling algorithm. Defaults to `nearest`.
             unscale (bool, optional): Apply 'scales' and 'offsets' on output data value. Defaults to `False`.
             post_process (callable, optional): Function to apply on output data and mask values.
 
@@ -720,7 +719,7 @@ class ImageReader(Reader):
         height: Optional[int] = None,
         width: Optional[int] = None,
         force_binary_mask: bool = True,
-        resampling_method: Resampling = "nearest",
+        resampling_method: RIOResampling = "nearest",
         unscale: bool = False,
         post_process: Optional[
             Callable[[numpy.ndarray, numpy.ndarray], DataMaskType]
@@ -736,7 +735,7 @@ class ImageReader(Reader):
             height (int, optional): Output height of the array.
             width (int, optional): Output width of the array.
             force_binary_mask (bool, optional): Cast returned mask to binary values (0 or 255). Defaults to `True`.
-            resampling_method (rasterio.enums.Resampling, optional): Rasterio's resampling algorithm. Defaults to `nearest`.
+            resampling_method (RIOResampling, optional): RasterIO resampling algorithm. Defaults to `nearest`.
             unscale (bool, optional): Apply 'scales' and 'offsets' on output data value. Defaults to `False`.
             post_process (callable, optional): Function to apply on output data and mask values.
 
@@ -827,7 +826,7 @@ class ImageReader(Reader):
         height: Optional[int] = None,
         width: Optional[int] = None,
         force_binary_mask: bool = True,
-        resampling_method: Resampling = "nearest",
+        resampling_method: RIOResampling = "nearest",
         unscale: bool = False,
         post_process: Optional[
             Callable[[numpy.ndarray, numpy.ndarray], DataMaskType]

--- a/rio_tiler/io/xarray.py
+++ b/rio_tiler/io/xarray.py
@@ -18,7 +18,7 @@ from rio_tiler.constants import WEB_MERCATOR_TMS, WGS84_CRS
 from rio_tiler.errors import PointOutsideBounds, RioTilerError, TileOutsideBounds
 from rio_tiler.io.base import BaseReader
 from rio_tiler.models import BandStatistics, ImageData, Info, PointData
-from rio_tiler.types import BBox
+from rio_tiler.types import BBox, WarpResampling
 
 try:
     import xarray
@@ -196,7 +196,7 @@ class XarrayReader(BaseReader):
         tile_y: int,
         tile_z: int,
         tilesize: int = 256,
-        resampling_method: Resampling = "nearest",
+        resampling_method: WarpResampling = "nearest",
     ) -> ImageData:
         """Read a Web Map tile from a dataset.
 
@@ -205,7 +205,7 @@ class XarrayReader(BaseReader):
             tile_y (int): Tile's vertical index.
             tile_z (int): Tile's zoom level index.
             tilesize (int, optional): Output image size. Defaults to `256`.
-            resampling_method (rasterio.enums.Resampling, optional): Rasterio's resampling algorithm. Defaults to `nearest`.
+            resampling_method (WarpResampling, optional): WarpKernel resampling algorithm. Defaults to `nearest`.
 
         Returns:
             rio_tiler.models.ImageData: ImageData instance with data, mask and tile spatial info.
@@ -248,7 +248,7 @@ class XarrayReader(BaseReader):
         bbox: BBox,
         dst_crs: Optional[CRS] = None,
         bounds_crs: CRS = WGS84_CRS,
-        resampling_method: Resampling = "nearest",
+        resampling_method: WarpResampling = "nearest",
     ) -> ImageData:
         """Read part of a dataset.
 
@@ -256,7 +256,7 @@ class XarrayReader(BaseReader):
             bbox (tuple): Output bounds (left, bottom, right, top) in target crs ("dst_crs").
             dst_crs (rasterio.crs.CRS, optional): Overwrite target coordinate reference system.
             bounds_crs (rasterio.crs.CRS, optional): Bounds Coordinate Reference System. Defaults to `epsg:4326`.
-            resampling_method (rasterio.enums.Resampling, optional): Rasterio's resampling algorithm. Defaults to `nearest`.
+            resampling_method (WarpResampling, optional): WarpKernel resampling algorithm. Defaults to `nearest`.
 
         Returns:
             rio_tiler.models.ImageData: ImageData instance with data, mask and input spatial info.
@@ -356,7 +356,7 @@ class XarrayReader(BaseReader):
         shape: Dict,
         dst_crs: Optional[CRS] = None,
         shape_crs: CRS = WGS84_CRS,
-        resampling_method: Resampling = "nearest",
+        resampling_method: WarpResampling = "nearest",
     ) -> ImageData:
         """Read part of a dataset defined by a geojson feature.
 
@@ -364,6 +364,7 @@ class XarrayReader(BaseReader):
             shape (dict): Valid GeoJSON feature.
             dst_crs (rasterio.crs.CRS, optional): Overwrite target coordinate reference system.
             shape_crs (rasterio.crs.CRS, optional): Input geojson coordinate reference system. Defaults to `epsg:4326`.
+            resampling_method (WarpResampling, optional): WarpKernel resampling algorithm. Defaults to `nearest`.
 
         Returns:
             rio_tiler.models.ImageData: ImageData instance with data, mask and input spatial info.

--- a/rio_tiler/models.py
+++ b/rio_tiler/models.py
@@ -22,7 +22,14 @@ from rasterio.transform import from_bounds
 from rio_tiler.colormap import apply_cmap
 from rio_tiler.errors import InvalidDatatypeWarning, InvalidPointDataError
 from rio_tiler.expression import apply_expression, get_expression_blocks
-from rio_tiler.types import BBox, ColorMapType, GDALColorMapType, IntervalTuple, NumType
+from rio_tiler.types import (
+    BBox,
+    ColorMapType,
+    GDALColorMapType,
+    IntervalTuple,
+    NumType,
+    RIOResampling,
+)
 from rio_tiler.utils import (
     get_array_statistics,
     linear_rescale,
@@ -532,7 +539,7 @@ class ImageData:
         self,
         height: int,
         width: int,
-        resampling_method: Resampling = "nearest",
+        resampling_method: RIOResampling = "nearest",
     ) -> "ImageData":
         """Resize data and mask."""
         data = resize_array(self.data, height, width, resampling_method)

--- a/rio_tiler/reader.py
+++ b/rio_tiler/reader.py
@@ -3,6 +3,7 @@
 import contextlib
 import math
 import warnings
+from enum import IntEnum
 from typing import Callable, Dict, Optional, Tuple, TypedDict, Union
 
 import numpy
@@ -18,7 +19,14 @@ from rasterio.warp import transform_bounds
 from rio_tiler.constants import WGS84_CRS
 from rio_tiler.errors import InvalidBufferSize, PointOutsideBounds, TileOutsideBounds
 from rio_tiler.models import ImageData, PointData
-from rio_tiler.types import BBox, DataMaskType, Indexes, NoData
+from rio_tiler.types import (
+    BBox,
+    DataMaskType,
+    Indexes,
+    NoData,
+    RIOResampling,
+    WarpResampling,
+)
 from rio_tiler.utils import _requested_tile_aligned_with_internal_tile as is_aligned
 from rio_tiler.utils import get_vrt_transform, has_alpha_band, non_alpha_indexes
 
@@ -29,7 +37,8 @@ class Options(TypedDict, total=False):
     force_binary_mask: Optional[bool]
     nodata: Optional[NoData]
     vrt_options: Optional[Dict]
-    resampling_method: Optional[Resampling]
+    resampling_method: Optional[RIOResampling]
+    reproject_method: Optional[WarpResampling]
     unscale: Optional[bool]
     post_process: Optional[Callable[[numpy.ndarray, numpy.ndarray], DataMaskType]]
 
@@ -86,7 +95,8 @@ def read(
     force_binary_mask: bool = True,
     nodata: Optional[NoData] = None,
     vrt_options: Optional[Dict] = None,
-    resampling_method: Resampling = "nearest",
+    resampling_method: RIOResampling = "nearest",
+    reproject_method: WarpResampling = "nearest",
     unscale: bool = False,
     post_process: Optional[
         Callable[[numpy.ndarray, numpy.ndarray], DataMaskType]
@@ -104,7 +114,8 @@ def read(
         window (rasterio.windows.Window, optional): Window to read.
         nodata (int or float, optional): Overwrite dataset internal nodata value.
         vrt_options (dict, optional): Options to be passed to the rasterio.warp.WarpedVRT class.
-        resampling_method (rasterio.enums.Resampling, optional): Rasterio's resampling algorithm. Defaults to `nearest`.
+        resampling_method (RIOResampling, optional): RasterIO resampling algorithm. Defaults to `nearest`.
+        reproject_method (WarpResampling, optional): WarpKernel resampling algorithm. Defaults to `nearest`.
         force_binary_mask (bool, optional): Cast returned mask to binary values (0 or 255). Defaults to `True`.
         unscale (bool, optional): Apply 'scales' and 'offsets' on output data value. Defaults to `False`.
         post_process (callable, optional): Function to apply on output data and mask values.
@@ -122,7 +133,9 @@ def read(
             UserWarning,
         )
 
-    resampling = Resampling[resampling_method]
+    io_resampling = Resampling[resampling_method]
+    warp_resampling = Resampling[reproject_method]
+
     dst_crs = dst_crs or src_dst.crs
     with contextlib.ExitStack() as ctx:
         # Use WarpedVRT when Re-projection or Nodata or User VRT Option (cutline)
@@ -130,7 +143,7 @@ def read(
             vrt_params = {
                 "crs": dst_crs,
                 "add_alpha": True,
-                "resampling": resampling,
+                "resampling": warp_resampling,
             }
 
             nodata = nodata if nodata is not None else src_dst.nodata
@@ -181,7 +194,7 @@ def read(
                 indexes=idx,
                 window=window,
                 out_shape=(len(idx), height, width) if height and width else None,
-                resampling=resampling,
+                resampling=io_resampling,
                 boundless=boundless,
             )
             data, mask = data[0:-1], data[-1].astype("uint8")
@@ -191,13 +204,13 @@ def read(
                 indexes=indexes,
                 window=window,
                 out_shape=(len(indexes), height, width) if height and width else None,
-                resampling=resampling,
+                resampling=io_resampling,
                 boundless=boundless,
             )
             mask = dataset.dataset_mask(
                 window=window,
                 out_shape=(height, width) if height and width else None,
-                resampling=resampling,
+                resampling=io_resampling,
                 boundless=boundless,
             )
 
@@ -257,7 +270,8 @@ def part(
     force_binary_mask: bool = True,
     nodata: Optional[NoData] = None,
     vrt_options: Optional[Dict] = None,
-    resampling_method: Resampling = "nearest",
+    resampling_method: RIOResampling = "nearest",
+    reproject_method: WarpResampling = "nearest",
     unscale: bool = False,
     post_process: Optional[
         Callable[[numpy.ndarray, numpy.ndarray], DataMaskType]
@@ -279,7 +293,8 @@ def part(
         buffer (float, optional): Buffer to apply to each bbox edge. Defaults to `0.`.
         nodata (int or float, optional): Overwrite dataset internal nodata value.
         vrt_options (dict, optional): Options to be passed to the rasterio.warp.WarpedVRT class.
-        resampling_method (rasterio.enums.Resampling, optional): Rasterio's resampling algorithm. Defaults to `nearest`.
+        resampling_method (RIOResampling, optional): RasterIO resampling algorithm. Defaults to `nearest`.
+        reproject_method (WarpResampling, optional): WarpKernel resampling algorithm. Defaults to `nearest`.
         force_binary_mask (bool, optional): Cast returned mask to binary values (0 or 255). Defaults to `True`.
         unscale (bool, optional): Apply 'scales' and 'offsets' on output data value. Defaults to `False`.
         post_process (callable, optional): Function to apply on output data and mask values.
@@ -373,6 +388,7 @@ def part(
             nodata=nodata,
             vrt_options=vrt_params,
             resampling_method=resampling_method,
+            reproject_method=reproject_method,
             force_binary_mask=force_binary_mask,
             unscale=unscale,
             post_process=post_process,
@@ -404,6 +420,7 @@ def part(
             height=height,
             window=window,
             resampling_method=resampling_method,
+            reproject_method=reproject_method,
             force_binary_mask=force_binary_mask,
             unscale=unscale,
             post_process=post_process,
@@ -424,6 +441,7 @@ def part(
         height=height,
         window=window,
         resampling_method=resampling_method,
+        reproject_method=reproject_method,
         force_binary_mask=force_binary_mask,
         unscale=unscale,
         post_process=post_process,
@@ -438,7 +456,8 @@ def point(
     force_binary_mask: bool = True,
     nodata: Optional[NoData] = None,
     vrt_options: Optional[Dict] = None,
-    resampling_method: Resampling = "nearest",
+    resampling_method: RIOResampling = "nearest",
+    reproject_method: WarpResampling = "nearest",
     unscale: bool = False,
     post_process: Optional[
         Callable[[numpy.ndarray, numpy.ndarray], DataMaskType]
@@ -453,7 +472,8 @@ def point(
         coord_crs (rasterio.crs.CRS, optional): Coordinate Reference System of the input coords. Defaults to `epsg:4326`.
         nodata (int or float, optional): Overwrite dataset internal nodata value.
         vrt_options (dict, optional): Options to be passed to the rasterio.warp.WarpedVRT class.
-        resampling_method (rasterio.enums.Resampling, optional): Rasterio's resampling algorithm. Defaults to `nearest`.
+        resampling_method (RIOResampling, optional): RasterIO resampling algorithm. Defaults to `nearest`.
+        reproject_method (WarpResampling, optional): WarpKernel resampling algorithm. Defaults to `nearest`.
         unscale (bool, optional): Apply 'scales' and 'offsets' on output data value. Defaults to `False`.
         post_process (callable, optional): Function to apply on output data and mask values.
 
@@ -465,11 +485,11 @@ def point(
         indexes = (indexes,)
 
     with contextlib.ExitStack() as ctx:
-        # Use WarpedVRT when Re-projection or Nodata or User VRT Option (cutline)
+        # Use WarpedVRT when User provided Nodata or VRT Option (cutline)
         if nodata is not None or vrt_options:
             vrt_params = {
                 "add_alpha": True,
-                "resampling": Resampling[resampling_method],
+                "resampling": Resampling[reproject_method],
             }
             nodata = nodata if nodata is not None else src_dst.nodata
             if nodata is not None:

--- a/rio_tiler/types.py
+++ b/rio_tiler/types.py
@@ -1,6 +1,6 @@
 """rio-tiler types."""
 
-from typing import Dict, Optional, Sequence, Tuple, TypedDict, Union
+from typing import Dict, Literal, Optional, Sequence, Tuple, TypedDict, Union
 
 import numpy
 
@@ -24,6 +24,34 @@ IntervalColorMapType = Sequence[Tuple[IntervalTuple, ColorTuple]]
 ColorMapType = Union[
     GDALColorMapType,
     IntervalColorMapType,
+]
+
+# RasterIO() resampling method.
+# ref: https://gdal.org/api/raster_c_api.html#_CPPv418GDALRIOResampleAlg
+RIOResampling = Literal[
+    "nearest",
+    "bilinear",
+    "cubic",
+    "cubic_spline",
+    "lanczos",
+    "average",
+    "mode",
+    "gauss",
+    "rms",
+]
+
+# WarpKernel resampling method.
+# ref: https://gdal.org/api/gdalwarp_cpp.html#_CPPv4N14GDALWarpKernel9eResampleE
+WarpResampling = Literal[
+    "nearest",
+    "bilinear",
+    "cubic",
+    "cubic_spline",
+    "lanczos",
+    "average",
+    "mode",
+    "sum",
+    "rms",
 ]
 
 

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -23,7 +23,7 @@ from rasterio.warp import calculate_default_transform, transform_geom
 from rio_tiler.colormap import apply_cmap
 from rio_tiler.constants import WEB_MERCATOR_CRS
 from rio_tiler.errors import RioTilerError
-from rio_tiler.types import BBox, ColorMapType, IntervalTuple
+from rio_tiler.types import BBox, ColorMapType, IntervalTuple, RIOResampling
 
 
 def _chunks(my_list: Sequence, chuck_size: int) -> Generator[Sequence, None, None]:
@@ -628,7 +628,7 @@ def resize_array(
     data: numpy.ndarray,
     height: int,
     width: int,
-    resampling_method: Resampling = "nearest",
+    resampling_method: RIOResampling = "nearest",
 ) -> numpy.ndarray:
     """resize array to a given height and width."""
     out_shape: Union[Tuple[int, int], Tuple[int, int, int]]

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -117,8 +117,20 @@ def test_resampling_returns_different_results():
             dst_crs=constants.WEB_MERCATOR_CRS,
             resampling_method="bilinear",
         )
+        assert not numpy.array_equal(arr, arr2)
 
-    assert not numpy.array_equal(arr, arr2)
+        arr, _ = reader.part(
+            src_dst, bounds, 16, 16, dst_crs=constants.WEB_MERCATOR_CRS
+        )
+        arr2, _ = reader.part(
+            src_dst,
+            bounds,
+            16,
+            16,
+            dst_crs=constants.WEB_MERCATOR_CRS,
+            reproject_method="bilinear",
+        )
+        assert not numpy.array_equal(arr, arr2)
 
 
 def test_resampling_with_diff_padding_returns_different_results():

--- a/tests/test_resampling.py
+++ b/tests/test_resampling.py
@@ -1,0 +1,53 @@
+"""test IO and Warp resampling."""
+import os
+
+import pytest
+
+from rio_tiler.io import Reader
+
+PREFIX = os.path.join(os.path.dirname(__file__), "fixtures")
+COGEO = os.path.join(PREFIX, "cog.tif")
+
+# RasterIO() resampling method.
+# ref: https://gdal.org/api/raster_c_api.html#_CPPv418GDALRIOResampleAlg
+io = [
+    "nearest",
+    "bilinear",
+    "cubic",
+    "cubic_spline",
+    "lanczos",
+    "average",
+    "mode",
+    "gauss",
+    "rms",
+]
+
+# WarpKernel resampling method.
+# ref: https://gdal.org/api/gdalwarp_cpp.html#_CPPv4N14GDALWarpKernel9eResampleE
+warp = [
+    "nearest",
+    "bilinear",
+    "cubic",
+    "cubic_spline",
+    "lanczos",
+    "average",
+    "mode",
+    "sum",
+    "rms",
+]
+
+
+@pytest.mark.parametrize("resampling", io)
+def test_read_resampling(resampling):
+    """Test read with all resampling."""
+    with Reader(COGEO) as src:
+        im = src.preview(max_size=64, resampling_method=resampling)
+        assert im.data.any()
+
+
+@pytest.mark.parametrize("resampling", warp)
+def test_warp_resampling(resampling):
+    """Test warp with all resampling."""
+    with Reader(COGEO) as src:
+        im = src.preview(max_size=64, reproject_method=resampling, dst_crs="epsg:4326")
+        assert im.data.any()


### PR DESCRIPTION
This PR adds a `reproject_method` option to `rio_tiler.reader.read` method which enables the selection to a specific WarpKernel resampling method. 

```python
# before
with Reader(src_path) as src:
    im = src.preview(dst_crs="epsg:4326", resampling_method="cubic")  # Use cubic for both Warp and IO (downsampling)

# with this PR 
with Reader(src_path) as src:
    im = src.preview(dst_crs="epsg:4326", resampling_method="nearest", reproject_method="cubic") # use cubic for Warp and nearest for IO
```

I also added 2 `Literal` types to represent the `choices` available for each options

⚠️TBD:  I didn't not change the `resampling_method` for XarrayReader, while it should be `reproject_method` instead of `resampling_method` but rioxarray does not make the separation between both 🙁