### PR TITLE
change arguments in dynamic_tiler.md

### DIFF
--- a/docs/src/advanced/dynamic_tiler.md
+++ b/docs/src/advanced/dynamic_tiler.md
@@ -80,7 +80,7 @@ def tilejson(
     url: str = Query(..., description="Cloud Optimized GeoTIFF URL."),
 ):
     """Return TileJSON document for a COG."""
-    tile_url = request.url_for("tile", z='{z}', x='{x}', y='{y}')
+    tile_url = str(request.url_for("tile", z="{z}", x="{x}", y="{y}"))
     tile_url = f"{tile_url}?url={url}"
 
     with Reader(url) as cog:

--- a/docs/src/advanced/dynamic_tiler.md
+++ b/docs/src/advanced/dynamic_tiler.md
@@ -80,7 +80,7 @@ def tilejson(
     url: str = Query(..., description="Cloud Optimized GeoTIFF URL."),
 ):
     """Return TileJSON document for a COG."""
-    tile_url = request.url_for("tile", {"z": "{z}", "x": "{x}", "y": "{y}"})
+    tile_url = request.url_for("tile", z='{z}', x='{x}', y='{y}')
     tile_url = f"{tile_url}?url={url}"
 
     with Reader(url) as cog:


### PR DESCRIPTION
My environment:
$ uvicorn --version
Running uvicorn 0.21.1 with CPython 3.10.6 on Linux
$ python3 -V
Python 3.10.6

The argument  ("tile", {"z": "{z}", "x": "{x}", "y": "{y}"}) causes errors below.

File "/home/ubuntu/app/app.py", line 48, in tilejson
    tile_url = request.url_for("tile", {"z": "{z}", "x": "{x}", "y": "{y}"})
TypeError: HTTPConnection.url_for() takes 2 positional arguments but 3 were given

("tile", z='{z}', x='{x}', y='{y}') is correct. it works. 