### PR TITLE
add flake8 to pre-commit and remove unused imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,9 @@ repos:
         additional_dependencies:
         - types-attrs
         - types-cachetools
+
+  -   repo: https://github.com/pycqa/flake8
+      rev: 6.0.0
+      hooks:
+      -   id: flake8
+          args: ["--ignore", "E203,E501,W503"]

--- a/rio_tiler/models.py
+++ b/rio_tiler/models.py
@@ -14,7 +14,7 @@ from rasterio import windows
 from rasterio.coords import BoundingBox
 from rasterio.crs import CRS
 from rasterio.dtypes import dtype_ranges
-from rasterio.enums import ColorInterp, Resampling
+from rasterio.enums import ColorInterp
 from rasterio.io import MemoryFile
 from rasterio.plot import reshape_as_image
 from rasterio.transform import from_bounds

--- a/rio_tiler/mosaic/methods/base.py
+++ b/rio_tiler/mosaic/methods/base.py
@@ -2,7 +2,7 @@
 
 import abc
 from dataclasses import dataclass, field
-from typing import Optional, Tuple
+from typing import Optional
 
 import numpy
 

--- a/rio_tiler/mosaic/methods/defaults.py
+++ b/rio_tiler/mosaic/methods/defaults.py
@@ -1,7 +1,7 @@
 """rio_tiler.mosaic.methods.defaults: default mosaic filling methods."""
 
 from dataclasses import dataclass, field
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 import numpy
 

--- a/rio_tiler/mosaic/reader.py
+++ b/rio_tiler/mosaic/reader.py
@@ -3,7 +3,6 @@
 from inspect import isclass
 from typing import Any, Callable, List, Optional, Sequence, Tuple, Type, Union, cast
 
-import numpy
 from rasterio.crs import CRS
 
 from rio_tiler.constants import MAX_THREADS

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -1,6 +1,5 @@
 """rio_tiler.utils: utility functions."""
 
-import os
 import warnings
 from io import BytesIO
 from typing import Any, Dict, Generator, List, Optional, Sequence, Tuple, Union

--- a/tests/benchmarks/test_benchmarks.py
+++ b/tests/benchmarks/test_benchmarks.py
@@ -1,7 +1,5 @@
 """Benchmark."""
 
-import os
-
 import morecantile
 import pytest
 import rasterio


### PR DESCRIPTION
Used flake8 to remove unused imports. Also added flake8 to pre-commit hooks. But I suspect there could be a reason flake8 was not included already?