### PR TITLE
allow morecantile 4.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -91,6 +91,8 @@
 
 - make `boto3` an optional dependency (`python -m pip install rio-tiler["s3"]`)
 
+- update `morecantile` dependency to `>=4.0`
+
 # 4.1.10 (2023-03-24)
 
 * enable `boundless` geometry for cutline (author @yellowcap, https://github.com/cogeotiff/rio-tiler/pull/586)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "httpx",
     "numexpr",
     "numpy",
-    "morecantile>=3.1,<4.0",
+    "morecantile>=3.1,<5.0",
     "pydantic",
     "pystac>=0.5.4",
     "rasterio>=1.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "httpx",
     "numexpr",
     "numpy",
-    "morecantile>=3.1,<5.0",
+    "morecantile>=4.0,<5.0",
     "pydantic",
     "pystac>=0.5.4",
     "rasterio>=1.3.0",

--- a/rio_tiler/io/rasterio.py
+++ b/rio_tiler/io/rasterio.py
@@ -141,10 +141,11 @@ class Reader(BaseReader):
 
     def _dst_geom_in_tms_crs(self):
         """Return dataset info in TMS projection."""
-        if self.crs != self.tms.rasterio_crs:
+        tms_crs = self.tms.rasterio_crs
+        if self.crs != tms_crs:
             dst_affine, w, h = calculate_default_transform(
                 self.crs,
-                self.tms.rasterio_crs,
+                tms_crs,
                 self.dataset.width,
                 self.dataset.height,
                 *self.dataset.bounds,
@@ -161,7 +162,7 @@ class Reader(BaseReader):
         if self._minzoom is None:
             # We assume the TMS tilesize to be constant over all matrices
             # ref: https://github.com/OSGeo/gdal/blob/dc38aa64d779ecc45e3cd15b1817b83216cf96b8/gdal/frmts/gtiff/cogdriver.cpp#L274
-            tilesize = self.tms.tileMatrix[0].tileWidth
+            tilesize = self.tms.matrix(self.tms.minzoom).tileWidth
 
             try:
                 dst_affine, w, h = self._dst_geom_in_tms_crs()
@@ -349,11 +350,12 @@ class Reader(BaseReader):
             )
 
         tile_bounds = self.tms.xy_bounds(Tile(x=tile_x, y=tile_y, z=tile_z))
+        dst_crs = self.tms.rasterio_crs
 
         return self.part(
             tile_bounds,
-            dst_crs=self.tms.rasterio_crs,
-            bounds_crs=None,
+            dst_crs=dst_crs,
+            bounds_crs=dst_crs,
             height=tilesize,
             width=tilesize,
             max_size=None,

--- a/rio_tiler/io/rasterio.py
+++ b/rio_tiler/io/rasterio.py
@@ -162,7 +162,7 @@ class Reader(BaseReader):
         if self._minzoom is None:
             # We assume the TMS tilesize to be constant over all matrices
             # ref: https://github.com/OSGeo/gdal/blob/dc38aa64d779ecc45e3cd15b1817b83216cf96b8/gdal/frmts/gtiff/cogdriver.cpp#L274
-            tilesize = self.tms.matrix(self.tms.minzoom).tileWidth
+            tilesize = self.tms.tileMatrices[0].tileWidth
 
             try:
                 dst_affine, w, h = self._dst_geom_in_tms_crs()

--- a/rio_tiler/io/xarray.py
+++ b/rio_tiler/io/xarray.py
@@ -101,7 +101,7 @@ class XarrayReader(BaseReader):
         if self._minzoom is None:
             # We assume the TMS tilesize to be constant over all matrices
             # ref: https://github.com/OSGeo/gdal/blob/dc38aa64d779ecc45e3cd15b1817b83216cf96b8/gdal/frmts/gtiff/cogdriver.cpp#L274
-            tilesize = self.tms.matrix(self.tms.minzoom).tileWidth
+            tilesize = self.tms.tileMatrices[0].tileWidth
 
             try:
                 dst_affine, w, h = self._dst_geom_in_tms_crs()


### PR DESCRIPTION
ref #605 

This PR changes how the TileMatrixSet are use to allow morecantile `3.1` and `>=4.0` version. The TMS value didn't change so in theory tiles created with Morecantile==3.1 and ==4.0 should be the same 