### PR TITLE
Ensure that `dataset` is still open when reading `tags`

### DIFF
--- a/rio_tiler/reader.py
+++ b/rio_tiler/reader.py
@@ -547,10 +547,10 @@ def point(
             post_process=post_process,
         )
 
-    return PointData(
-        img.array[:, 0, 0],
-        coordinates=coordinates,
-        crs=coord_crs,
-        band_names=img.band_names,
-        metadata=dataset.tags(),
-    )
+        return PointData(
+            img.array[:, 0, 0],
+            coordinates=coordinates,
+            crs=coord_crs,
+            band_names=img.band_names,
+            metadata=dataset.tags(),
+        )


### PR DESCRIPTION
Previously this statement was outside the `ctx` context, and so `dataset` may already have been freed before we call `dataset.tags()`. In my experience, this was sporadically leading to either of the following errors:

```
rasterio.errors.RasterioIOError: Dataset is closed`
```

or 

```
rasterio._err.ObjectNullError: Pointer 'hObject' is NULL in 'GDALGetMetadata'.
```

The corresponding statement for the `read` method was already inside the `ctx` context, so this was only a problem for the `point` method.