### PR TITLE
Update `data_as_image` to return masked values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 6.0.2 (unreleased)
+
+* Update `data_as_image` to return masked values (author @JackDunnNZ, https://github.com/cogeotiff/rio-tiler/pull/635)
 
 # 6.0.1 (2023-07-25)
 

--- a/rio_tiler/models.py
+++ b/rio_tiler/models.py
@@ -514,7 +514,7 @@ class ImageData:
         (bands, rows, columns) -> (rows, columns, bands).
 
         """
-        return reshape_as_image(self.array.data)
+        return reshape_as_image(self.array)
 
     @property
     def width(self) -> int:


### PR DESCRIPTION
Prior to this change, the raw data array was being returned, which could include `nodata` values, throwing off an automatic image color scale. In the following example, the nodata value used is -9999 (for all oceans), which causes the image to basically appear as a land mask:

```
from matplotlib.pyplot import imshow
from rio_tiler.io.rasterio import Reader

with Reader("https://data.chc.ucsb.edu/products/CHIRPS-2.0/global_daily/cogs/p05/2023/chirps-v2.0.2023.02.01.cog") as r:
    img = r.read(nodata=-9999)
    
imshow(img.data_as_image())
```
![image](https://github.com/cogeotiff/rio-tiler/assets/4717044/b359d056-0fd6-4937-81a9-58b7aaa38ce2)

If instead we use the masked array values, the automatic color scale is scoped to just the valid data values:

```
imshow(img.array[0, :, :])
```
![image](https://github.com/cogeotiff/rio-tiler/assets/4717044/6716e982-289f-4c3a-b289-371b8b7b2a2d)
