### PR TITLE
Return a 1x1 image when bbox is smaller than a single pixel

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+
+# 6.0.3 (2023-09-13)
+
+* return a 1x1 image when bbox is smaller than a single pixel (author @JackDunnNZ, https://github.com/cogeotiff/rio-tiler/pull/637)
+
 # 6.0.2 (2023-08-21)
 
 * Update `data_as_image` to return masked values (author @JackDunnNZ, https://github.com/cogeotiff/rio-tiler/pull/635)

--- a/rio_tiler/reader.py
+++ b/rio_tiler/reader.py
@@ -417,8 +417,8 @@ def part(
             max_size, round(window.height), round(window.width)
         )
 
-    height = height or round(window.height)
-    width = width or round(window.width)
+    height = height or max(1, round(window.height))
+    width = width or max(1, round(window.width))
 
     if buffer:
         bounds, height, width = _apply_buffer(buffer, bounds, height, width)

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -5,6 +5,7 @@ import os
 import numpy
 import pytest
 import rasterio
+from numpy.testing import assert_array_almost_equal
 from rasterio.warp import transform_bounds
 
 from rio_tiler import constants, reader
@@ -632,3 +633,11 @@ def test_part_no_VRT():
         assert img_pad.bounds == bounds_dst_crs
         # Padding should not have any influence when not doing any rescaling/reprojection
         numpy.array_equal(img_pad.data, img.data)
+
+        # Read bbox smaller than one pixel
+        bounds_small = [bounds[0], bounds[1], bounds[0] + 1e-6, bounds[1] + 1e-6]
+        bounds_small_dst_crs = transform_bounds("epsg:4326", src_dst.crs, *bounds_small)
+        img_small = reader.part(src_dst, bounds_small, bounds_crs="epsg:4326")
+        assert img_small.height == 1
+        assert img_small.width == 1
+        assert_array_almost_equal(img_small.bounds, bounds_small_dst_crs)


### PR DESCRIPTION
This was originally motivated by hitting a zero-division error when calling `Reader.feature` with a feature that happened to be smaller than one pixel in the image:

```
File "site-packages/rasterio/transform.py", line 189, in from_bounds
    (east - west) / width, (south - north) / height)
    ~~~~~~~~~~~~^~~~~~~~~
ZeroDivisionError: float division by zero
```

I traced it back to the result of `part` being a 0x0 image when the bbox was smaller than a single pixel of the image, which this change fixes and returns a 1x1 image instead.

I'm not 100% sure about this, but it seems to make sense to me that `part` returning a single pixel is the correct outcome for this case, as this is still the valid image data for the bbox being requested.