### PR TITLE
adds `align_bounds_with_dataset` to adjust bounds in reader.part() method

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,11 @@
 
-# unreleased
+# 6.3.0 (unreleased)
 
 * do not use `warpedVRT` when overwriting the dataset nodata value
+
+* add `align_bounds_with_dataset` option in `rio_tiler.reader.part` to align input bounds with the dataset resolution
+
+    <img src="https://github.com/cogeotiff/rio-tiler/assets/10407788/0e340d3d-e5d9-4558-93f7-3f307c017510" style="max-width: 500px;">
 
 # 6.2.10 (2024-01-08)
 
@@ -88,7 +92,7 @@ This release was made while we waited on a fix for https://github.com/cogeotiff/
 
 * add `cmocean` colormaps
 
-    <img src="https://raw.githubusercontent.com/cogeotiff/rio-tiler/main/docs/src/img/colormaps_for_oceanography.png" style="max-width: 500px;"></a>
+    <img src="https://raw.githubusercontent.com/cogeotiff/rio-tiler/main/docs/src/img/colormaps_for_oceanography.png" style="max-width: 500px;">
 
 * allow uppercase in `cmap.get` method
 

--- a/docs/src/advanced/statistics.md
+++ b/docs/src/advanced/statistics.md
@@ -1,5 +1,5 @@
 
-### Statistics
+#### Form `Readers`
 
 `rio-tiler`'s Readers provide simple `.statistics` method to retrieve dataset global statistics
 
@@ -34,83 +34,19 @@ print(stats["1"].model_dump().keys())
 ]
 ```
 
-### Zonal Statistics
+#### ImageData
 
-You can easily extend the `statistics()` method to create a `.zonal_statistics` one which will accept input features to get statistics from.
+You can get statistics from `ImageData` objects which are returned by all rio-tiler reader methods (e.g. `.tile()`, `.preview()`, `.part()`, ...)
 
 ```python
-
-import attr
-from typing import Any, Union, Optional, List, Dict
-
-from rio_tiler import io
-from rio_tiler.models import BandStatistics
-
-from geojson_pydantic.features import Feature, FeatureCollection
-from geojson_pydantic.geometries import Polygon
-
-class Reader(io.Reader):
-    """Custom Reader with zonal_statistics method."""
-
-    def zonal_statistics(
-            self,
-            geojson: Union[FeatureCollection, Feature],
-            categorical: bool = False,
-            categories: Optional[List[float]] = None,
-            percentiles: Optional[List[int]] = None,
-            hist_options: Optional[Dict] = None,
-            max_size: int = None,
-            **kwargs: Any,
-        ) -> Union[FeatureCollection, Feature]:
-            """Return statistics from GeoJSON features.
-
-            Args:
-                geojson (Feature or FeatureCollection): a GeoJSON Feature or FeatureCollection.
-                categorical (bool): treat input data as categorical data. Defaults to False.
-                categories (list of numbers, optional): list of categories to return value for.
-                percentiles (list of numbers, optional): list of percentile values to calculate. Defaults to `[2, 98]`.
-                hist_options (dict, optional): Options to forward to numpy.histogram function.
-                max_size (int, optional): Limit the size of the longest dimension of the dataset read, respecting bounds X/Y aspect ratio. Defaults to None.
-                kwargs (optional): Options to forward to `self.preview`.
-
-            Returns:
-                Feature or FeatureCollection
-
-            """
-            kwargs = {**self.options, **kwargs}
-
-            hist_options = hist_options or {}
-
-            fc = geojson
-            # We transform the input Feature to a FeatureCollection
-            if isinstance(fc, Feature):
-                fc = FeatureCollection(type="FeatureCollection", features=[geojson])
-
-            for feature in fc:
-                # Get data overlapping with the feature (using Reader.feature method)
-                data = self.feature(
-                    feature.model_dump(exclude_none=True),
-                    max_size=max_size,
-                    **kwargs,
-                )
-                stats = data.statistics(
-                    categorical=categorical,
-                    categories=categories,
-                    percentiles=percentiles,
-                    hist_options=hist_options,
-                )
-
-                # Update input feature properties and add the statistics
-                feature.properties = feature.properties or {}
-                feature.properties.update({"statistics": stats})
-
-            return fc.features[0] if isinstance(geojson, Feature) else fc
+with Reader("cog.tif") as src:
+    image = src.preview()
+    stats = image.statistics()
 ```
-
 
 ### Area Weighted Statistics
 
-When getting statistics from `feature`, you may want to calculate values from the pixels which intersect with the geometry but also take the pixel intersection percentage into account. Starting with rio-tiler `6.2.0`, we've added a `coverage` option to the `statistics` utility which enable the user to pass an array representing the coverage percentage such as:
+When getting statistics from a `feature`, you may want to calculate values from the pixels which intersect with the geometry but also take the pixel intersection percentage into account. Starting with rio-tiler `6.2.0`, we've added a `coverage` option to the `statistics` utility which enable the user to pass an array representing the coverage percentage such as:
 
 ```python
 import numpy
@@ -133,34 +69,110 @@ assert stats[0]["mean"] == 1.125  # (1 * 0.5 + 2 * 0.0 + 3 * 1.0 + 4 * 0.25) / 4
 assert stats[0]["count"] == 1.75  # (0.5 + 0 + 1 + 0.25) sum of the coverage array
 ```
 
-When using with a `feature`, your code might look something like:
+#### Adjusting geometry `align_bounds_with_dataset=True`
+
+In rio-tiler `6.3,0` a new option has been introduced to reduce artifacts and produce more precise zonal statistics. This option is available in the low-level `reader.part()` method used in rio-tiler reader's `.feature()` and `.part()` methods.
 
 ```python
-from rio_tiler.io import Reader
-from rio_tiler.constants import WGS84_CRS
+with Reader("cog.tif") as src:
+    data = src.feature(
+        shape,
+        shape_crs=WGS84_CRS,
+        align_bounds_with_dataset=True,
+    )
 
-with Reader(path) as src:
-    # First get the array for the feature
-    data = src_dst.feature(
+    coverage_array = data.get_coverage_array(
         shape,
         shape_crs=WGS84_CRS,
     )
 
-    # Get the coverage % array, using ImageData.get_coverage_array method
-    coverage_array = data.get_coverage_array(
-        shape, shape_crs=WGS84_CRS
-    )
-
-    # Get statistics (ImageData.statistics is calling `rio_tiler.utils.get_array_statistics`)
     stats = data.statistics(coverage=coverage_array)
 ```
 
-!!! warnings
-    The coverage weights will only have influence on specific statistics:
+When passing `align_bounds_with_dataset=True` to the  `reader.part()` method (forwared from `.feature` or `.part` reader's method), rio-tiler will adjust the input geometry bounds to math the input dataset resolution/transform and avoid unnecessary resampling.
 
-    - `mean`
-    - `count`
-    - `sum`
-    - `std`
-    - `median`
+<img src="https://github.com/cogeotiff/rio-tiler/assets/10407788/0e340d3d-e5d9-4558-93f7-3f307c017510" style="max-width: 800px;">
 
+
+### Zonal Statistics method
+
+You can easily extend the rio-tiler's reader to add a `.zonal_statistics()` method as:
+
+```python
+
+import attr
+from typing import Any, Union, Optional, List, Dict
+
+from rio_tiler import io
+from rio_tiler.models import BandStatistics
+
+from geojson_pydantic.features import Feature, FeatureCollection
+from geojson_pydantic.geometries import Polygon
+
+class Reader(io.Reader):
+    """Custom Reader with zonal_statistics method."""
+
+    def zonal_statistics(
+        self,
+        geojson: Union[FeatureCollection, Feature],
+        categorical: bool = False,
+        categories: Optional[List[float]] = None,
+        percentiles: Optional[List[int]] = None,
+        hist_options: Optional[Dict] = None,
+        max_size: int = None,
+        **kwargs: Any,
+    ) -> Union[FeatureCollection, Feature]:
+        """Return statistics from GeoJSON features.
+
+        Args:
+            geojson (Feature or FeatureCollection): a GeoJSON Feature or FeatureCollection.
+            categorical (bool): treat input data as categorical data. Defaults to False.
+            categories (list of numbers, optional): list of categories to return value for.
+            percentiles (list of numbers, optional): list of percentile values to calculate. Defaults to `[2, 98]`.
+            hist_options (dict, optional): Options to forward to numpy.histogram function.
+            max_size (int, optional): Limit the size of the longest dimension of the dataset read, respecting bounds X/Y aspect ratio. Defaults to None.
+            kwargs (optional): Options to forward to `self.preview`.
+
+        Returns:
+            Feature or FeatureCollection
+
+        """
+        kwargs = {**self.options, **kwargs}
+
+        hist_options = hist_options or {}
+
+        fc = geojson
+        # We transform the input Feature to a FeatureCollection
+        if isinstance(fc, Feature):
+            fc = FeatureCollection(type="FeatureCollection", features=[geojson])
+
+        for feature in fc:
+            geom = feature.model_dump(exclude_none=True)
+
+            # Get data overlapping with the feature (using Reader.feature method)
+            data = self.feature(
+                geom,
+                shape_crs=WGS84_CRS,
+                align_bounds_with_dataset=True,
+                max_size=max_size,
+                **kwargs,
+            )
+            coverage_array = data.get_coverage_array(
+                geom,
+                shape_crs=WGS84_CRS,
+            )
+
+            stats = data.statistics(
+                categorical=categorical,
+                categories=categories,
+                percentiles=percentiles,
+                hist_options=hist_options,
+                coverage=coverage_array,
+            )
+
+            # Update input feature properties and add the statistics
+            feature.properties = feature.properties or {}
+            feature.properties.update({"statistics": stats})
+
+        return fc.features[0] if isinstance(geojson, Feature) else fc
+```


### PR DESCRIPTION
Thanks to @abarciauskas-bgse for deep-diving into this issue.

When doing zonal statistics, users might not want to get the stats from resampled data but `clip` the data to the closest rounding window (full pixel) and then use the `coverage` option within the statistics method to adjust the values.


<img width="1151" alt="Screenshot 2024-01-16 at 12 38 42 PM" src="https://github.com/cogeotiff/rio-tiler/assets/10407788/774340ae-6bfe-4066-b21b-ef4d13012815">

With this PR we're introduction an option in `rio_tiler.reader.part` to adjust the bounds to the dataset transform. This option might be used from `feature() or `part()` reader's method such as 

```python
with Reader("cog.tif") as src:
    data = src.feature(
        shape,
        shape_crs=WGS84_CRS,
        align_bounds_with_dataset=True,
    )

    coverage_array = data.get_coverage_array(
        shape,
        shape_crs=WGS84_CRS,
    )

    stats = data.statistics(coverage=coverage_array)
```
