### PR TITLE
Add test for diagonal coverage with cover_scale

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -460,6 +460,7 @@ def test_imagedata_coverage():
     coverage = im.get_coverage_array({"type": "Feature", "geometry": poly})
     assert numpy.unique(coverage).tolist() == [0.25]
 
+    # non-default CRS
     poly = {
         "type": "Polygon",
         "coordinates": [
@@ -480,3 +481,19 @@ def test_imagedata_coverage():
         {"type": "Feature", "geometry": poly}, shape_crs="epsg:3857"
     )
     assert numpy.unique(coverage).tolist() == [0.25]
+
+    # polygon with diagonal cut - requires higher cover_scale
+    im = ImageData(
+        numpy.ma.array((1, 2, 3, 4)).reshape((1, 2, 2)),
+        crs="epsg:4326",
+        bounds=(-180, -90, 180, 90),
+    )
+    poly = {
+        "type": "Polygon",
+        "coordinates": [
+            [[-90.0, -45.0], [90.0, -45.0], [-90.0, 45.0], [-90.0, -45.0]]
+        ],
+    }
+    
+    coverage = im.get_coverage_array(poly, cover_scale=100)
+    assert numpy.allclose(numpy.unique(coverage), [0, 0.125, 0.25], rtol=1e3)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -496,4 +496,4 @@ def test_imagedata_coverage():
     }
     
     coverage = im.get_coverage_array(poly, cover_scale=100)
-    assert numpy.allclose(numpy.unique(coverage), [0, 0.125, 0.25], rtol=1e3)
+    assert numpy.round(numpy.unique(coverage), decimals=3).tolist() == [0, 0.125, 0.25]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -495,5 +495,5 @@ def test_imagedata_coverage():
         ],
     }
     
-    coverage = im.get_coverage_array(poly, cover_scale=100)
+    coverage = im.get_coverage_array(poly, cover_scale=1000)
     assert numpy.round(numpy.unique(coverage), decimals=3).tolist() == [0, 0.125, 0.25]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -490,10 +490,8 @@ def test_imagedata_coverage():
     )
     poly = {
         "type": "Polygon",
-        "coordinates": [
-            [[-90.0, -45.0], [90.0, -45.0], [-90.0, 45.0], [-90.0, -45.0]]
-        ],
+        "coordinates": [[[-90.0, -45.0], [90.0, -45.0], [-90.0, 45.0], [-90.0, -45.0]]],
     }
-    
+
     coverage = im.get_coverage_array(poly, cover_scale=1000)
     assert numpy.round(numpy.unique(coverage), decimals=3).tolist() == [0, 0.125, 0.25]


### PR DESCRIPTION
- [x] Add test where a triangle polygon cuts diagonally through cells. One pixel per hemisphere in WGS84, triangle cuts from -90E 45N to 90E -45N. Reveals the accuracy effect of `cover_scale`

![image](https://github.com/cogeotiff/rio-tiler/assets/3404817/673a9644-cd56-4d80-8a15-64075364743a)