### PR TITLE
Feat/set profile in imagedata

### DIFF
--- a/rio_tiler/models.py
+++ b/rio_tiler/models.py
@@ -321,6 +321,7 @@ class ImageData:
         metadata (dict, optional): Additional metadata. Defaults to `{}`.
         band_names (list, optional): name of each band. Defaults to `["1", "2", "3"]` for 3 bands image.
         dataset_statistics (list, optional): dataset statistics `[(min, max), (min, max)]`
+        profile (dict, optional): dataset profile
 
     Note: `mask` should be considered as `PER_BAND` so shape should be similar as the data
 
@@ -337,8 +338,8 @@ class ImageData:
     dataset_statistics: Optional[Sequence[Tuple[float, float]]] = attr.ib(
         default=None, kw_only=True
     )
-    cutline_mask: Optional[numpy.ndarray] = attr.ib(default=None)
-
+    cutline_mask: Optional[numpy.ndarray] = attr.ib(default=None),
+    profile: Optional[Dict] = attr.field(factory=dict, kw_only=True)
     @band_names.default
     def _default_names(self):
         return [f"b{ix + 1}" for ix in range(self.count)]

--- a/rio_tiler/reader.py
+++ b/rio_tiler/reader.py
@@ -283,7 +283,7 @@ def read(
             band_names=[f"b{idx}" for idx in indexes],
             dataset_statistics=dataset_statistics,
             metadata=dataset.tags(),
-            profile=dataset.profile
+            profile=dataset_profile
         )
 
 

--- a/rio_tiler/reader.py
+++ b/rio_tiler/reader.py
@@ -256,11 +256,18 @@ def read(
         # TODO: DEPRECATED, masked array are already using bool
         if force_binary_mask:
             pass
-
+        # profile is added  only if unscaling was requested. This would ensure/signalized
+        # an advanced usage specifically applied to COGS
+        dataset_profile = None
         if unscale:
             data = data.astype("float32", casting="unsafe")
             numpy.multiply(data, dataset.scales[0], out=data, casting="unsafe")
             numpy.add(data, dataset.offsets[0], out=data, casting="unsafe")
+            dataset_profile = dataset.profile
+            if not 'scales' in dataset_profile:
+                dataset_profile['scales'] = dataset.scales
+            if not 'offsets' in dataset_profile:
+                dataset_profile['offsets'] = dataset.offsets
 
         if post_process:
             data = post_process(data)
@@ -276,6 +283,7 @@ def read(
             band_names=[f"b{idx}" for idx in indexes],
             dataset_statistics=dataset_statistics,
             metadata=dataset.tags(),
+            profile=dataset.profile
         )
 
 


### PR DESCRIPTION
@vincentsarago 

This PR adds an optional **profile** attribute to ImageData  in case the reader that created it was requested to unscale the data.

as per https://github.com/developmentseed/titiler/discussions/803

The profile attr will contain the scales and offsets, which at this point are not part of the profile attribute of the rio DatasetReader

This is to accomodate a specific use case when the reader is not STAC or Mosaic.



