### PR TITLE
use width/height in `get_vrt_transform` when overzooming a dataset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Upload Results
         if: ${{ matrix.python-version == env.LATEST_PY_VERSION }}
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v4
         with:
           file: ./coverage.xml
           flags: unittests

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,8 @@
 
+# 6.4.8 (2024-05-02)
+
+* Better handle over-zooming a dataset
+
 # 6.4.7 (2024-04-17)
 
 * Better handle dataset with inverted origin

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 
-# 6.4.8 (2024-05-02)
+# 6.5.0 (2024-05-03)
 
-* Better handle over-zooming a dataset
+* Revert [#648](https://github.com/cogeotiff/rio-tiler/pull/648) and refactor `get_vrt_transform` method to better handle over-zooming a dataset
 
 # 6.4.7 (2024-04-17)
 

--- a/rio_tiler/reader.py
+++ b/rio_tiler/reader.py
@@ -366,6 +366,8 @@ def part(
         vrt_transform, vrt_width, vrt_height = get_vrt_transform(
             src_dst,
             bounds,
+            height,
+            width,
             dst_crs=dst_crs,
             align_bounds_with_dataset=align_bounds_with_dataset,
         )
@@ -384,6 +386,8 @@ def part(
             vrt_transform, vrt_width, vrt_height = get_vrt_transform(
                 src_dst,
                 bounds,
+                height,
+                width,
                 dst_crs=dst_crs,
                 align_bounds_with_dataset=align_bounds_with_dataset,
             )

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -296,8 +296,8 @@ def get_vrt_transform(
     Args:
         src_dst (rasterio.io.DatasetReader or rasterio.io.DatasetWriter or rasterio.vrt.WarpedVRT): Rasterio dataset.
         bounds (tuple): Bounding box coordinates in target crs (**dst_crs**).
-        height (int, optional): Desired output height of the array for the input bounds.
-        width (int, optional): Desired output width of the array for the input bounds.
+        height (int, optional): Output height of the array for the input bounds.
+        width (int, optional): Output width of the array for the input bounds.
         dst_crs (rasterio.crs.CRS, optional): Target Coordinate Reference System. Defaults to `epsg:3857`.
         align_bounds_with_dataset (bool): Align input bounds with dataset transform. Defaults to `False`.
 
@@ -383,6 +383,13 @@ def get_vrt_transform(
         bounds = windows.bounds(window, dst_transform)
 
     w, s, e, n = bounds
+
+    if height and width:
+        out_transform = from_bounds(w, s, e, n, width, height)
+        # when not overzooming we don't want to set width/height output
+        if (out_transform.a > dst_transform.a) and (out_transform.e < dst_transform.e):
+            width = None
+            height = None
 
     # TODO: Explain
     if not height or not width:


### PR DESCRIPTION
This PR re-add `width` and `height` parameters to the `get_vrt_transform` (removed in #648) but will only be used when over-zooming a dataset


cc @amarouane-ABDELHAK @j08lue 
