### PR TITLE
Per-band unscaling works with indexes

### DIFF
--- a/rio_tiler/reader.py
+++ b/rio_tiler/reader.py
@@ -263,8 +263,8 @@ def read(
             data = data.astype("float32", casting="unsafe")
 
             # reshaped to match data
-            scales = numpy.array(dataset.scales).reshape(-1, 1, 1)
-            offsets = numpy.array(dataset.offsets).reshape(-1, 1, 1)
+            scales = numpy.array(dataset.scales)[numpy.array(indexes)-1].reshape((-1, 1, 1))
+            offsets = numpy.array(dataset.offsets)[numpy.array(indexes)-1].reshape((-1, 1, 1))
 
             numpy.multiply(data, scales, out=data, casting="unsafe")
             numpy.add(data, offsets, out=data, casting="unsafe")

--- a/tests/test_io_rasterio.py
+++ b/tests/test_io_rasterio.py
@@ -440,6 +440,10 @@ def test_Reader_Options():
         p = src.point(310000, 4100000, coord_crs=src.dataset.crs)
         numpy.testing.assert_allclose(p.data, [1000.892, 2008.917], atol=1e-03)
 
+        # applies correctly when passing indexes=[...]
+        p = src.point(310000, 4100000, coord_crs=src.dataset.crs, indexes=[2])
+        numpy.testing.assert_allclose(p.data, [2008.917], atol=1e-03)
+
         # passing unscale in method should overwrite the defaults
         p = src.point(310000, 4100000, coord_crs=src.dataset.crs, unscale=False)
         numpy.testing.assert_equal(p.data, [8917, 8917])


### PR DESCRIPTION
This updates the per-band unscaling to support when indexes=[...] are passed. I didn't account for that in the PR a couple days ago, sorry about that!

Fortunately a quick fix to select from the scales/offsets arrays so that they continue to match the shape of the image data. I've been testing this with files we make containing dozens of bands with different (or no) scale/offset rules and I haven't noticed any issues with mismatching or incorrect shapes.

You also should be able to edit this forked repo now. Not sure what I'm missing in the settings, but it is part of my work org and maybe there's something I can't see getting in the way by default. I added you with write permission on the repo to hopefully get around that.