### PR TITLE
Error message should match x, y, z arguments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# unreleased
+
+* better error message for `TileOutsideBounds` errors (author @abarciauskas-bgse, https://github.com/cogeotiff/rio-tiler/pull/712)
+
 # 6.6.1 (2024-05-17)
 
 * fix/support `scale/offset` indexes selection (author @jddeal, https://github.com/cogeotiff/rio-tiler/pull/709)

--- a/rio_tiler/io/base.py
+++ b/rio_tiler/io/base.py
@@ -480,7 +480,7 @@ class MultiBaseReader(SpatialMixin, metaclass=abc.ABCMeta):
         """
         if not self.tile_exists(tile_x, tile_y, tile_z):
             raise TileOutsideBounds(
-                f"Tile {tile_z}/{tile_x}/{tile_y} is outside image bounds"
+                f"Tile(x={tile_x}, y={tile_y}, z={tile_z}) is outside bounds"
             )
 
         if isinstance(assets, str):
@@ -1036,7 +1036,7 @@ class MultiBandReader(SpatialMixin, metaclass=abc.ABCMeta):
         """
         if not self.tile_exists(tile_x, tile_y, tile_z):
             raise TileOutsideBounds(
-                f"Tile {tile_z}/{tile_x}/{tile_y} is outside image bounds"
+                f"Tile(x={tile_x}, y={tile_y}, z={tile_z}) is outside bounds"
             )
 
         if isinstance(bands, str):

--- a/rio_tiler/io/rasterio.py
+++ b/rio_tiler/io/rasterio.py
@@ -343,7 +343,7 @@ class Reader(BaseReader):
         """
         if not self.tile_exists(tile_x, tile_y, tile_z):
             raise TileOutsideBounds(
-                f"Tile {tile_z}/{tile_x}/{tile_y} is outside {self.input} bounds"
+                f"Tile(x={tile_x}, y={tile_y}, z={tile_z}) is outside bounds"
             )
 
         tile_bounds = self.tms.xy_bounds(Tile(x=tile_x, y=tile_y, z=tile_z))

--- a/rio_tiler/io/xarray.py
+++ b/rio_tiler/io/xarray.py
@@ -232,7 +232,7 @@ class XarrayReader(BaseReader):
             reproject_method = resampling_method
 
         if not self.tile_exists(tile_x, tile_y, tile_z):
-            raise TileOutsideBounds(f"Tile {tile_x}/{tile_y}/{tile_z} is outside bounds")
+            raise TileOutsideBounds(f"Tile(x={tile_x}, y={tile_y}, z={tile_z}) is outside bounds")
 
         ds = self.input
         if nodata is not None:

--- a/rio_tiler/io/xarray.py
+++ b/rio_tiler/io/xarray.py
@@ -232,7 +232,9 @@ class XarrayReader(BaseReader):
             reproject_method = resampling_method
 
         if not self.tile_exists(tile_x, tile_y, tile_z):
-            raise TileOutsideBounds(f"Tile(x={tile_x}, y={tile_y}, z={tile_z}) is outside bounds")
+            raise TileOutsideBounds(
+                f"Tile(x={tile_x}, y={tile_y}, z={tile_z}) is outside bounds"
+            )
 
         ds = self.input
         if nodata is not None:

--- a/rio_tiler/io/xarray.py
+++ b/rio_tiler/io/xarray.py
@@ -232,7 +232,7 @@ class XarrayReader(BaseReader):
             reproject_method = resampling_method
 
         if not self.tile_exists(tile_x, tile_y, tile_z):
-            raise TileOutsideBounds(f"Tile {tile_z}/{tile_x}/{tile_y} is outside bounds")
+            raise TileOutsideBounds(f"Tile {tile_x}/{tile_y}/{tile_z} is outside bounds")
 
         ds = self.input
         if nodata is not None:


### PR DESCRIPTION
It's a bit confusing when the error message has a different order than the arguments, so this is a small change to the error message.