### PR TITLE
[715] Enable handling of inverted latitude in reader.point

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # unreleased
 
 * better error message for `TileOutsideBounds` errors (author @abarciauskas-bgse, https://github.com/cogeotiff/rio-tiler/pull/712)
+* handle of inverted latitude in `reader.point` (author @georgespill, https://github.com/cogeotiff/rio-tiler/pull/716)
 
 # 6.6.1 (2024-05-17)
 

--- a/rio_tiler/reader.py
+++ b/rio_tiler/reader.py
@@ -96,9 +96,7 @@ def read(
     resampling_method: RIOResampling = "nearest",
     reproject_method: WarpResampling = "nearest",
     unscale: bool = False,
-    post_process: Optional[
-        Callable[[numpy.ma.MaskedArray], numpy.ma.MaskedArray]
-    ] = None,
+    post_process: Optional[Callable[[numpy.ma.MaskedArray], numpy.ma.MaskedArray]] = None,
 ) -> ImageData:
     """Low level read function.
 
@@ -251,9 +249,7 @@ def read(
         stats = []
         for ix in indexes:
             tags = dataset.tags(ix)
-            if all(
-                stat in tags for stat in ["STATISTICS_MINIMUM", "STATISTICS_MAXIMUM"]
-            ):
+            if all(stat in tags for stat in ["STATISTICS_MINIMUM", "STATISTICS_MAXIMUM"]):
                 stat_min = float(tags.get("STATISTICS_MINIMUM"))
                 stat_max = float(tags.get("STATISTICS_MAXIMUM"))
                 stats.append((stat_min, stat_max))
@@ -316,9 +312,7 @@ def part(
     resampling_method: RIOResampling = "nearest",
     reproject_method: WarpResampling = "nearest",
     unscale: bool = False,
-    post_process: Optional[
-        Callable[[numpy.ma.MaskedArray], numpy.ma.MaskedArray]
-    ] = None,
+    post_process: Optional[Callable[[numpy.ma.MaskedArray], numpy.ma.MaskedArray]] = None,
 ) -> ImageData:
     """Read part of a dataset.
 
@@ -366,12 +360,8 @@ def part(
         src_bounds = transform_bounds(
             src_dst.crs, dst_crs, *src_dst.bounds, densify_pts=21
         )
-        x_overlap = max(
-            0, min(src_bounds[2], bounds[2]) - max(src_bounds[0], bounds[0])
-        )
-        y_overlap = max(
-            0, min(src_bounds[3], bounds[3]) - max(src_bounds[1], bounds[1])
-        )
+        x_overlap = max(0, min(src_bounds[2], bounds[2]) - max(src_bounds[0], bounds[0]))
+        y_overlap = max(0, min(src_bounds[3], bounds[3]) - max(src_bounds[1], bounds[1]))
         cover_ratio = (x_overlap * y_overlap) / (
             (bounds[2] - bounds[0]) * (bounds[3] - bounds[1])
         )
@@ -519,9 +509,7 @@ def point(
     resampling_method: RIOResampling = "nearest",
     reproject_method: WarpResampling = "nearest",
     unscale: bool = False,
-    post_process: Optional[
-        Callable[[numpy.ma.MaskedArray], numpy.ma.MaskedArray]
-    ] = None,
+    post_process: Optional[Callable[[numpy.ma.MaskedArray], numpy.ma.MaskedArray]] = None,
 ) -> PointData:
     """Read a pixel value for a point.
 
@@ -577,8 +565,9 @@ def point(
             dataset.bounds
         )
         # check if latitude is inverted
-        dataset_min_lat, dataset_max_lat = min(dataset_min_lat, dataset_max_lat), max(
-            dataset_min_lat, dataset_max_lat
+        dataset_min_lat, dataset_max_lat = (
+            min(dataset_min_lat, dataset_max_lat),
+            max(dataset_min_lat, dataset_max_lat),
         )
         if not (
             (dataset_min_lon < lon < dataset_max_lon)

--- a/rio_tiler/reader.py
+++ b/rio_tiler/reader.py
@@ -96,7 +96,9 @@ def read(
     resampling_method: RIOResampling = "nearest",
     reproject_method: WarpResampling = "nearest",
     unscale: bool = False,
-    post_process: Optional[Callable[[numpy.ma.MaskedArray], numpy.ma.MaskedArray]] = None,
+    post_process: Optional[
+        Callable[[numpy.ma.MaskedArray], numpy.ma.MaskedArray]
+    ] = None,
 ) -> ImageData:
     """Low level read function.
 
@@ -199,7 +201,9 @@ def read(
                 values = dataset.read(
                     indexes=indexes,
                     window=window,
-                    out_shape=(len(indexes), height, width) if height and width else None,
+                    out_shape=(
+                        (len(indexes), height, width) if height and width else None
+                    ),
                     resampling=io_resampling,
                     boundless=boundless,
                 )
@@ -247,7 +251,9 @@ def read(
         stats = []
         for ix in indexes:
             tags = dataset.tags(ix)
-            if all(stat in tags for stat in ["STATISTICS_MINIMUM", "STATISTICS_MAXIMUM"]):
+            if all(
+                stat in tags for stat in ["STATISTICS_MINIMUM", "STATISTICS_MAXIMUM"]
+            ):
                 stat_min = float(tags.get("STATISTICS_MINIMUM"))
                 stat_max = float(tags.get("STATISTICS_MAXIMUM"))
                 stats.append((stat_min, stat_max))
@@ -310,7 +316,9 @@ def part(
     resampling_method: RIOResampling = "nearest",
     reproject_method: WarpResampling = "nearest",
     unscale: bool = False,
-    post_process: Optional[Callable[[numpy.ma.MaskedArray], numpy.ma.MaskedArray]] = None,
+    post_process: Optional[
+        Callable[[numpy.ma.MaskedArray], numpy.ma.MaskedArray]
+    ] = None,
 ) -> ImageData:
     """Read part of a dataset.
 
@@ -358,8 +366,12 @@ def part(
         src_bounds = transform_bounds(
             src_dst.crs, dst_crs, *src_dst.bounds, densify_pts=21
         )
-        x_overlap = max(0, min(src_bounds[2], bounds[2]) - max(src_bounds[0], bounds[0]))
-        y_overlap = max(0, min(src_bounds[3], bounds[3]) - max(src_bounds[1], bounds[1]))
+        x_overlap = max(
+            0, min(src_bounds[2], bounds[2]) - max(src_bounds[0], bounds[0])
+        )
+        y_overlap = max(
+            0, min(src_bounds[3], bounds[3]) - max(src_bounds[1], bounds[1])
+        )
         cover_ratio = (x_overlap * y_overlap) / (
             (bounds[2] - bounds[0]) * (bounds[3] - bounds[1])
         )
@@ -507,7 +519,9 @@ def point(
     resampling_method: RIOResampling = "nearest",
     reproject_method: WarpResampling = "nearest",
     unscale: bool = False,
-    post_process: Optional[Callable[[numpy.ma.MaskedArray], numpy.ma.MaskedArray]] = None,
+    post_process: Optional[
+        Callable[[numpy.ma.MaskedArray], numpy.ma.MaskedArray]
+    ] = None,
 ) -> PointData:
     """Read a pixel value for a point.
 
@@ -559,9 +573,16 @@ def point(
             xs, ys = transform_coords(coord_crs, dataset.crs, [lon], [lat])
             lon, lat = xs[0], ys[0]
 
+        dataset_min_lon, dataset_min_lat, dataset_max_lon, dataset_max_lat = (
+            dataset.bounds
+        )
+        # check if latitude is inverted
+        dataset_min_lat, dataset_max_lat = min(dataset_min_lat, dataset_max_lat), max(
+            dataset_min_lat, dataset_max_lat
+        )
         if not (
-            (dataset.bounds[0] < lon < dataset.bounds[2])
-            and (dataset.bounds[1] < lat < dataset.bounds[3])
+            (dataset_min_lon < lon < dataset_max_lon)
+            and (dataset_min_lat < lat < dataset_max_lat)
         ):
             raise PointOutsideBounds("Point is outside dataset bounds")
 

--- a/rio_tiler/reader.py
+++ b/rio_tiler/reader.py
@@ -565,6 +565,12 @@ def point(
             dataset.bounds
         )
         # check if latitude is inverted
+        if dataset_min_lat > dataset_max_lat:
+            warnings.warn(
+                "BoundingBox of the dataset is inverted (minLat > maxLat).",
+                UserWarning,
+            )
+
         dataset_min_lat, dataset_max_lat = (
             min(dataset_min_lat, dataset_max_lat),
             max(dataset_min_lat, dataset_max_lat),

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -35,7 +35,7 @@ COG_NODATA = os.path.join(os.path.dirname(__file__), "fixtures", "cog_nodata.tif
 COG_NODATA_FLOAT_NAN = os.path.join(
     os.path.dirname(__file__), "fixtures", "cog_nodata_float_nan.tif"
 )
-COG_INVERTED = os.path.join(PREFIX, "inverted_lat.tif")
+COG_INVERTED = os.path.join(os.path.dirname(__file__), "fixtures", "inverted_lat.tif")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -35,6 +35,7 @@ COG_NODATA = os.path.join(os.path.dirname(__file__), "fixtures", "cog_nodata.tif
 COG_NODATA_FLOAT_NAN = os.path.join(
     os.path.dirname(__file__), "fixtures", "cog_nodata_float_nan.tif"
 )
+COG_INVERTED = os.path.join(PREFIX, "inverted_lat.tif")
 
 
 @pytest.fixture(autouse=True)
@@ -850,3 +851,10 @@ def test_tile_read_nodata_float():
         prev = reader.read(src_dst, max_size=100)
         assert prev.mask[0, 0] == 0
         assert not numpy.all(prev.mask)
+
+
+def test_inverted_latitude_point():
+    """Make sure we can read a point from a file with inverted latitude."""
+    with rasterio.open(COG_INVERTED) as src_dst:
+        pt = reader.point(src_dst, [-104.77519499, 38.95367054])
+        assert pt.data[0] == -9999.0


### PR DESCRIPTION
`reader.point` raises a `PointOutsideBounds` error if the input coordinates are outside the dataset bounds. However, the current implementation assumes that `bounds[1] < bounds[3]`. This is not true for inverted latitude coordinates. This PR updates the implementation to handle the inverted case.

Fixes https://github.com/cogeotiff/rio-tiler/issues/715

See https://github.com/cogeotiff/rio-tiler/pull/696 for a similar issue