### PR TITLE
refactor attribute and remove TMS from BaseReader init, and remove min/maxzoom from info response

### DIFF
--- a/docs/src/migrations/v7_migration.md
+++ b/docs/src/migrations/v7_migration.md
@@ -1,0 +1,80 @@
+
+`rio-tiler` version 7.0 introduced [many breaking changes](../release-notes.md). This
+document aims to help with migrating your code to use `rio-tiler` 7.0.
+
+## `SpatialMixin` class and `TMS`
+
+The `SpatialMixin` class, used in `BaseReader` class had numerous breaking changes:
+
+- removed `tms` and `geographic_crs` attributes
+
+- changed `geographic_bounds(self)` from `property` to `method` -> `geographic_bounds(self, geographic_crs: CRS = WGS84_CRS)`
+
+- removed `_dst_geom_in_tms_crs` method
+
+- removed `_minzoom` and `_maxzoom` property
+
+The main change is the removal of the `tms` attribute, which means the `BaseReader` do not have `tms` information, thus the `.tile()` now needs a tms argument:
+
+```python
+# before
+import morecantile
+from rio_tiler.io import Reader
+
+with Reader("cog.tif", tms=morecantile.tms.get("WebMercatorQuad")) as src:
+    _ = src.tile(0, 0, 0)
+
+# now
+with Reader("cog.tif") as src:
+    _ = src.tile(0, 0, 0, tms=morecantile.tms.get("WebMercatorQuad"))
+```
+
+same for the `tile_exists` method
+
+```python
+# before
+import morecantile
+from rio_tiler.io import Reader
+
+with Reader("cog.tif", tms=morecantile.tms.get("WebMercatorQuad")) as src:
+    _ = src.tile_exists(0, 0, 0)
+
+# now
+with Reader("cog.tif") as src:
+    _ = src.tile_exists(0, 0, 0, tms=morecantile.tms.get("WebMercatorQuad"))
+```
+
+By removing the `tms` attribute, we also removed the `min/max zoom` properties. We've added `.get_zooms(tms: TileMatrixSet)` method to the `SpatialMixin` class to allow users to retrieve the zoom information:
+
+```python
+# before
+import morecantile
+from rio_tiler.io import Reader
+
+with Reader("cog.tif", tms=morecantile.tms.get("WebMercatorQuad")) as src:
+    minzoom, maxzoom = src.minzoom, src.maxzoom
+
+# now
+with Reader("cog.tif") as src:
+    minzoom, maxzoom = src.get_zooms(morecantile.tms.get("WebMercatorQuad"))
+```
+
+Same for the `geographic_bounds`, which now needs to be retrieved using the `geographic_bounds(tms: TileMatrixSet)` method (instead of the `.geographic_bounds` property), because we've removed the `geographic_crs` attribute.
+
+```python
+# before
+from rasterio.crs import CRS
+from rio_tiler.io import Reader
+
+with Reader("cog.tif", geographic_crs=CRS.from_epsg(4326)) as src:
+    _ = src.geographic_bounds
+
+# now
+with Reader("cog.tif") as src:
+    _ = src.geographic_bounds(CRS.from_epsg(4326))
+```
+
+
+## `Info()` and Models
+
+- `rio_tiler.models.SpatialInfo` was removed

--- a/rio_tiler/io/stac.py
+++ b/rio_tiler/io/stac.py
@@ -12,11 +12,9 @@ import pystac
 import rasterio
 from cachetools import LRUCache, cached
 from cachetools.keys import hashkey
-from morecantile import TileMatrixSet
-from rasterio.crs import CRS
 from rasterio.transform import array_bounds
 
-from rio_tiler.constants import WEB_MERCATOR_TMS, WGS84_CRS
+from rio_tiler.constants import WGS84_CRS
 from rio_tiler.errors import InvalidAssetName, MissingAssets
 from rio_tiler.io.base import BaseReader, MultiBaseReader
 from rio_tiler.io.rasterio import Reader
@@ -195,10 +193,6 @@ class STACReader(MultiBaseReader):
     Attributes:
         input (str): STAC Item path, URL or S3 URL.
         item (dict or pystac.Item, STAC): Stac Item.
-        tms (morecantile.TileMatrixSet, optional): TileMatrixSet grid definition. Defaults to `WebMercatorQuad`.
-        minzoom (int, optional): Set minzoom for the tiles.
-        maxzoom (int, optional): Set maxzoom for the tiles.
-        geographic_crs (rasterio.crs.CRS, optional): CRS to use as geographic coordinate system. Defaults to WGS84.
         include_assets (set of string, optional): Only Include specific assets.
         exclude_assets (set of string, optional): Exclude specific assets.
         include_asset_types (set of string, optional): Only include some assets base on their type.
@@ -229,12 +223,6 @@ class STACReader(MultiBaseReader):
 
     input: str = attr.ib()
     item: pystac.Item = attr.ib(default=None, converter=_to_pystac_item)
-
-    tms: TileMatrixSet = attr.ib(default=WEB_MERCATOR_TMS)
-    minzoom: int = attr.ib(default=None)
-    maxzoom: int = attr.ib(default=None)
-
-    geographic_crs: CRS = attr.ib(default=WGS84_CRS)
 
     include_assets: Optional[Set[str]] = attr.ib(default=None)
     exclude_assets: Optional[Set[str]] = attr.ib(default=None)
@@ -273,9 +261,6 @@ class STACReader(MultiBaseReader):
                 self.transform = self.item.ext.proj.transform
                 self.bounds = array_bounds(self.height, self.width, self.transform)
                 self.crs = rasterio.crs.CRS.from_string(self.item.ext.proj.crs_string)
-
-        self.minzoom = self.minzoom if self.minzoom is not None else self._minzoom
-        self.maxzoom = self.maxzoom if self.maxzoom is not None else self._maxzoom
 
         self.assets = list(
             _get_assets(

--- a/rio_tiler/models.py
+++ b/rio_tiler/models.py
@@ -57,22 +57,11 @@ class RioTilerBaseModel(BaseModel):
         return {**self.__dict__, **self.__pydantic_extra__}[item]
 
 
-class Bounds(RioTilerBaseModel):
-    """Dataset Bounding box"""
-
-    bounds: BoundingBox
-
-
-class SpatialInfo(Bounds):
-    """Dataset SpatialInfo"""
-
-    minzoom: int
-    maxzoom: int
-
-
-class Info(SpatialInfo):
+class Info(RioTilerBaseModel):
     """Dataset Info."""
 
+    bounds: BoundingBox
+    crs: str
     band_metadata: List[Tuple[str, Dict]]
     band_descriptions: List[Tuple[str, str]]
     dtype: str

--- a/tests/test_io_image.py
+++ b/tests/test_io_image.py
@@ -19,8 +19,9 @@ def test_non_geo_image():
     """Test ImageReader usage with Non-Geo Images."""
     with pytest.warns((NotGeoreferencedWarning)):
         with ImageReader(NO_GEO) as src:
-            assert src.minzoom == 0
-            assert src.maxzoom == 3
+            minzoom, maxzoom = src.get_zooms()
+            assert minzoom == 0
+            assert maxzoom == 3
 
     with pytest.warns((NotGeoreferencedWarning)):
         with ImageReader(NO_GEO) as src:
@@ -98,8 +99,9 @@ def test_non_geo_image():
 def test_with_geo_image():
     """Test ImageReader usage with Geo Images."""
     with ImageReader(GEO) as src:
-        assert src.minzoom == 0
-        assert src.maxzoom == 2
+        minzoom, maxzoom = src.get_zooms()
+        assert minzoom == 0
+        assert maxzoom == 2
 
         assert list(src.tms.xy_bounds(0, 0, 2)) == [0, 256, 256, 0]
         assert list(src.tms.xy_bounds(0, 0, 1)) == [0, 512, 512, 0]


### PR DESCRIPTION
closes #744 

This PR does:
- refactors the `SpatialMixin` base class 
   - removes `tms` attribute
   - removes `geographic_crs` attribute
   - removes `minzoom` and `maxzoom` properties
   -  add `get_zooms(tms: TileMatrixSet)` method 
   - change `geographic_bounds` property to method `geographic_bounds(crs: CRS)` 
   - update `tile_exists` and add `tms` argument 

- changes `.tile()` method and add `tms` argument 

- refactors the `info()` method
    - return dataset bounds (instead of geographic bounds)
    - add `crs` metadata (epsg or wkt)
 
- removes `models.SpatialInfo` and `models.Bounds`

- removes `minzoom/maxzoom` attributes in MultiBaseReader and `MultiBandReader`

- starts a migration guide

```python
# before
import morecantile
from rio_tiler.io import Reader

tms = morecantile.tms.get("WebMercatorQuad")
with Reader("cog.tif", tms=tms, geographic_crs=tms.rasterio_geographic_crs) as src:
    _ = src.tile_exists(0, 0, 0)
    _ = src.tile(0, 0, 0)
    _ = src.minzoom
    _ = src.maxzoom
    _ = src.geographic_bounds

    info = src.info()
    assert info.bounds == src.geographic_bounds
    assert info.minzoom is not None
    assert info.maxzoom is not None

# now
import morecantile
from rio_tiler.io import Reader

tms = morecantile.tms.get("WebMercatorQuad")
with Reader("cog.tif") as src:
    _ = src.tile_exists(0, 0, 0, tms=tms)
    _ = src.tile(0, 0, 0, tms=tms)
    _, _ = src.get_zooms(tms)
    _ = src.geographic_bounds(tms.rasterio_geographic_crs)
    
    info = src.info()
    assert info.bounds == src.bounds == src.dataset.bounds
    assert info.crs == src.crs == src.dataset.crs
    assert not hasattr(info, "minzoom")
    assert not hasattr(info, "maxzoom")
```