### PR TITLE
remove geographic_crs and update info model

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,42 @@
     >> InvalidColorMapName: Invalid colormap name: Viridis
     ```
 
+* removed `geographic_crs` attribute in `SpatialMixin` class **breaking change**
+
+* removed `geographic_bounds` property in `SpatialMixin` class **breaking change**
+
+* add `get_geographic_bounds(crs: CRS)` method in `SpatialMixin` class
+
+    ```python
+    from rasterio.crs import CRS
+    from rio_tiler.io import Reader
+
+    # before
+    with Reader("cog.tif", geographic_crs=CRS.from_epsg(4326)) as src:
+        bounds = src.geographic_bounds
+
+    # now
+    with Reader("cog.tif") as src:
+        bounds = src.get_geographic_bounds(CRS.from_epsg(4326))
+    ```
+
+* replace `geographic bounds` with dataset bounds in `Reader.info()` method's response **breaking change**
+
+    ```python
+    from rio_tiler.io import Reader
+
+    # before
+    with Reader("cog.tif") as src:
+        assert src.geographic_bounds == src.info().bounds
+
+    # now
+    with Reader("cog.tif") as src:
+        assert src.bounds == src.info().bounds
+    ```
+
+* add `crs: str` property in `Info` model
+
+* remove `minzoom` and `maxzoom` properties in `Info` model **breaking change**
 
 # 6.7.0 (2024-09-05)
 

--- a/rio_tiler/io/stac.py
+++ b/rio_tiler/io/stac.py
@@ -13,7 +13,6 @@ import rasterio
 from cachetools import LRUCache, cached
 from cachetools.keys import hashkey
 from morecantile import TileMatrixSet
-from rasterio.crs import CRS
 from rasterio.transform import array_bounds
 
 from rio_tiler.constants import WEB_MERCATOR_TMS, WGS84_CRS
@@ -198,7 +197,6 @@ class STACReader(MultiBaseReader):
         tms (morecantile.TileMatrixSet, optional): TileMatrixSet grid definition. Defaults to `WebMercatorQuad`.
         minzoom (int, optional): Set minzoom for the tiles.
         maxzoom (int, optional): Set maxzoom for the tiles.
-        geographic_crs (rasterio.crs.CRS, optional): CRS to use as geographic coordinate system. Defaults to WGS84.
         include_assets (set of string, optional): Only Include specific assets.
         exclude_assets (set of string, optional): Exclude specific assets.
         include_asset_types (set of string, optional): Only include some assets base on their type.
@@ -233,8 +231,6 @@ class STACReader(MultiBaseReader):
     tms: TileMatrixSet = attr.ib(default=WEB_MERCATOR_TMS)
     minzoom: int = attr.ib(default=None)
     maxzoom: int = attr.ib(default=None)
-
-    geographic_crs: CRS = attr.ib(default=WGS84_CRS)
 
     include_assets: Optional[Set[str]] = attr.ib(default=None)
     exclude_assets: Optional[Set[str]] = attr.ib(default=None)

--- a/rio_tiler/io/xarray.py
+++ b/rio_tiler/io/xarray.py
@@ -23,7 +23,7 @@ from rio_tiler.errors import (
 from rio_tiler.io.base import BaseReader
 from rio_tiler.models import BandStatistics, ImageData, Info, PointData
 from rio_tiler.types import BBox, NoData, WarpResampling
-from rio_tiler.utils import _validate_shape_input
+from rio_tiler.utils import CRS_to_uri, _validate_shape_input
 
 try:
     import xarray
@@ -43,7 +43,6 @@ class XarrayReader(BaseReader):
     Attributes:
         dataset (xarray.DataArray): Xarray DataArray dataset.
         tms (morecantile.TileMatrixSet, optional): TileMatrixSet grid definition. Defaults to `WebMercatorQuad`.
-        geographic_crs (rasterio.crs.CRS, optional): CRS to use as geographic coordinate system. Defaults to WGS84.
 
     Examples:
         >>> ds = xarray.open_dataset(
@@ -62,7 +61,6 @@ class XarrayReader(BaseReader):
     input: xarray.DataArray = attr.ib()
 
     tms: TileMatrixSet = attr.ib(default=WEB_MERCATOR_TMS)
-    geographic_crs: CRS = attr.ib(default=WGS84_CRS)
 
     _dims: List = attr.ib(init=False, factory=list)
 
@@ -120,9 +118,8 @@ class XarrayReader(BaseReader):
         metadata = [band.attrs for d in self._dims for band in self.input[d]]
 
         meta = {
-            "bounds": self.geographic_bounds,
-            "minzoom": self.minzoom,
-            "maxzoom": self.maxzoom,
+            "bounds": self.bounds,
+            "crs": CRS_to_uri(self.crs),
             "band_metadata": [(f"b{ix}", v) for ix, v in enumerate(metadata, 1)],
             "band_descriptions": [(f"b{ix}", v) for ix, v in enumerate(bands, 1)],
             "dtype": str(self.input.dtype),

--- a/rio_tiler/models.py
+++ b/rio_tiler/models.py
@@ -61,16 +61,10 @@ class Bounds(RioTilerBaseModel):
     """Dataset Bounding box"""
 
     bounds: BoundingBox
+    crs: str
 
 
-class SpatialInfo(Bounds):
-    """Dataset SpatialInfo"""
-
-    minzoom: int
-    maxzoom: int
-
-
-class Info(SpatialInfo):
+class Info(Bounds):
     """Dataset Info."""
 
     band_metadata: List[Tuple[str, Dict]]

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -789,3 +789,21 @@ def cast_to_sequence(val: Optional[Any] = None) -> Sequence:
         val = (val,)
 
     return val
+
+
+def CRS_to_uri(crs: CRS) -> Optional[str]:
+    """Convert CRS to URI.
+
+    Code adapted from https://github.com/developmentseed/morecantile/blob/1829fe12408e4a1feee7493308f3f02257ef4caf/morecantile/models.py#L148-L161
+    """
+    # attempt to grab the authority, version, and code from the CRS
+    if authority_code := crs.to_authority(confidence_threshold=70):
+        version = "0"
+        authority, code = authority_code
+        # if we have a version number in the authority, split it out
+        if "_" in authority:
+            authority, version = authority.split("_")
+
+        return f"http://www.opengis.net/def/crs/{authority}/{version}/{code}"
+
+    return None

--- a/tests/test_io_xarray.py
+++ b/tests/test_io_xarray.py
@@ -7,6 +7,7 @@ import numpy
 import pytest
 import rioxarray
 import xarray
+from rasterio.crs import CRS as rioCRS
 
 from rio_tiler.errors import InvalidGeographicBounds, MissingCRS
 from rio_tiler.io import XarrayReader
@@ -28,9 +29,11 @@ def test_xarray_reader():
 
     data.rio.write_crs("epsg:4326", inplace=True)
     with XarrayReader(data) as dst:
+        assert dst.minzoom == dst.maxzoom == 0
         info = dst.info()
-        assert info.minzoom == 0
-        assert info.maxzoom == 0
+        assert info.bounds == dst.bounds
+        crs = info.crs
+        assert rioCRS.from_user_input(crs) == dst.crs
         assert info.band_metadata == [("b1", {})]
         assert info.band_descriptions == [("b1", "2022-01-01T00:00:00.000000000")]
         assert info.height == 33
@@ -123,9 +126,8 @@ def test_xarray_reader():
 
     data.rio.write_crs("epsg:4326", inplace=True)
     with XarrayReader(data) as dst:
-        info = dst.info()
-        assert info.minzoom == 5
-        assert info.maxzoom == 7
+        assert dst.minzoom == 5
+        assert dst.maxzoom == 7
 
 
 def test_xarray_reader_external_nodata():


### PR DESCRIPTION
second take at #744 

This PR does: 
- removes min/max zoom from `info()` response  **breaking change**
- adds CRS (uri or wkt) in `info()` response
- replaces `geographic_bounds` with dataset bounds in `info()` response **breaking change**
- removes `geographic_bounds` property from Reader BaseClass  **breaking change**
- adds `get_geographic_bounds(crs: CRS)` method in BaseClass 
- removes `geographic_crs` attribute in BaseClass  **breaking change**

This PR is less `breaking` than #745 and achieve the same result
