### PR TITLE
add floating point values support in colormap Keys

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 7.2.1 (2024-11-14)
+
+* add official support for floating point values in ColorMap
+
 # 7.2.0 (2024-11-05)
 
 * Ensure compatibility between XarrayReader and other Readers by adding `**kwargs` on class methods (https://github.com/cogeotiff/rio-tiler/pull/762)

--- a/rio_tiler/types.py
+++ b/rio_tiler/types.py
@@ -18,11 +18,15 @@ IntervalTuple = Tuple[NumType, NumType]  # (0, 100)
 # ColorMap Dict: {1: (0, 0, 0, 255), ...}
 GDALColorMapType = Dict[int, ColorTuple]
 
+# Discrete Colormap, like GDALColorMapType but accept Float: {0.1: (0, 0, 0, 255), ...}
+DiscreteColorMapType = Dict[NumType, ColorTuple]
+
 # Intervals ColorMap: [((0, 1), (0, 0, 0, 0)), ...]
 IntervalColorMapType = Sequence[Tuple[IntervalTuple, ColorTuple]]
 
 ColorMapType = Union[
     GDALColorMapType,
+    DiscreteColorMapType,
     IntervalColorMapType,
 ]
 

--- a/tests/test_cmap.py
+++ b/tests/test_cmap.py
@@ -301,6 +301,8 @@ def test_parse_color_bad():
 
 def test_discrete_float():
     """test for titiler issue 738."""
+
+    # make sure we apply discrete colormap when we have less than 256 cmap entries
     cm = {
         0: (0, 255, 255, 255),
         1: (83, 151, 145, 255),
@@ -325,3 +327,20 @@ def test_discrete_float():
     dd, mm = colormap.apply_discrete_cmap(data.copy(), cm)
     assert d.dtype == numpy.uint8
     assert m.dtype == numpy.uint8
+    numpy.testing.assert_array_equal(d, dd)
+    numpy.testing.assert_array_equal(m, mm)
+
+    # make we allow float keys in discrete colormap
+    cm = {
+        0.5: (0, 255, 255, 255),
+        1.5: (83, 151, 145, 255),
+        2.5: (87, 194, 23, 255),
+    }
+
+    data = numpy.random.choice([0.5, 2.5], 256 * 256).reshape(1, 256, 256)
+    d, m = colormap.apply_cmap(data.copy(), cm)
+    dd, mm = colormap.apply_discrete_cmap(data.copy(), cm)
+    assert d.dtype == numpy.uint8
+    assert m.dtype == numpy.uint8
+    numpy.testing.assert_array_equal(d, dd)
+    numpy.testing.assert_array_equal(m, mm)


### PR DESCRIPTION
This was already supported in a sense that if the colormap was recognized as discrete the code would work BUT in titiler the validation within the `/colormap/{ColorMapId}` endpoint would fail. 

