### PR TITLE
catch and expend image encoding error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 7.2.2 (2024-11-17)
+
+* Catch and expand error message when GDAL cannot encode data using specified image driver
+
 # 7.2.1 (2024-11-14)
 
 * add official support for floating point values in ColorMap

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,7 +10,11 @@ from rasterio.crs import CRS
 from rasterio.errors import NotGeoreferencedWarning
 from rasterio.io import MemoryFile
 
-from rio_tiler.errors import InvalidDatatypeWarning, InvalidPointDataError
+from rio_tiler.errors import (
+    InvalidDatatypeWarning,
+    InvalidFormat,
+    InvalidPointDataError,
+)
 from rio_tiler.models import ImageData, PointData
 
 
@@ -456,3 +460,9 @@ def test_imagedata_coverage():
 
     coverage = im.get_coverage_array(poly, cover_scale=1000)
     assert numpy.round(numpy.unique(coverage), decimals=3).tolist() == [0, 0.125, 0.25]
+
+
+def test_image_encoding_error():
+    """Test ImageData error when using bad data array shape."""
+    with pytest.raises(InvalidFormat):
+        ImageData(numpy.zeros((5, 256, 256), dtype="uint8")).render(img_format="PNG")


### PR DESCRIPTION
ref https://github.com/developmentseed/titiler/issues/1031

cc @drnextgis


```python
from rio_tiler.models import ImageData
import numpy
arr = numpy.ma.zeros((5,266,256), dtype="uint8")
ImageData(arr).render()
---------------------------------------------------------------------------
ObjectNullError                           Traceback (most recent call last)
~/Dev/CogeoTiff/rio-tiler/rio_tiler/utils.py in render(data, mask, img_format, colormap, **creation_options)
    608 
--> 609                 return memfile.read()
    610 

~/Dev/venv/py39/lib/python3.9/site-packages/rasterio/io.py in __exit__(self, *args)
    167     def __exit__(self, *args):
--> 168         self._env.close()
    169         self.close()

/opt/homebrew/Cellar/python@3.9/3.9.19/Frameworks/Python.framework/Versions/3.9/lib/python3.9/contextlib.py in close(self)
    539         """Immediately unwind the context stack."""
--> 540         self.__exit__(None, None, None)
    541 

/opt/homebrew/Cellar/python@3.9/3.9.19/Frameworks/Python.framework/Versions/3.9/lib/python3.9/contextlib.py in __exit__(self, *exc_details)
    531                 fixed_ctx = exc_details[1].__context__
--> 532                 raise exc_details[1]
    533             except BaseException:

/opt/homebrew/Cellar/python@3.9/3.9.19/Frameworks/Python.framework/Versions/3.9/lib/python3.9/contextlib.py in __exit__(self, *exc_details)
    516             try:
--> 517                 if cb(*exc_details):
    518                     suppressed_exc = True

rasterio/_base.pyx in rasterio._base.DatasetBase.__exit__()

rasterio/_base.pyx in rasterio._base.DatasetBase.close()

rasterio/_io.pyx in rasterio._io.BufferedDatasetWriterBase.stop()

rasterio/_err.pyx in rasterio._err.exc_wrap_pointer()

ObjectNullError: Pointer 'hSrcDS' is NULL in 'GDALCreateCopy'. 

The above exception was the direct cause of the following exception:

InvalidFormat                             Traceback (most recent call last)
<ipython-input-4-5f988547d155> in <cell line: 1>()
----> 1 ImageData(arr).render()

~/Dev/CogeoTiff/rio-tiler/rio_tiler/models.py in render(self, add_mask, img_format, colormap, **kwargs)
    705 
    706         if add_mask:
--> 707             return render(
    708                 array.data,
    709                 self.mask,  # We use dataset mask for rendering

~/Dev/CogeoTiff/rio-tiler/rio_tiler/utils.py in render(data, mask, img_format, colormap, **creation_options)
    610 
    611     except Exception as e:
--> 612         raise InvalidFormat(
    613             f"Could not encode array of shape ({count},{height},{width}) and of datatype {data.dtype} using {img_format} driver"
    614         ) from e

InvalidFormat: Could not encode array of shape (5,266,256) and of datatype uint8 using PNG driver

```