### PR TITLE
Fix issue #774: Use coverage array for calculation of valid_percent

### DIFF
--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -133,6 +133,8 @@ def get_array_statistics(
     else:
         coverage = numpy.ones((data.shape[1], data.shape[2]))
 
+    coverage_pixels = numpy.count_nonzero(coverage)
+
     # Avoid non masked nan/inf values
     numpy.ma.fix_invalid(data, copy=False)
 
@@ -143,7 +145,7 @@ def get_array_statistics(
 
         valid_pixels = float(numpy.ma.count(data[b]))
         masked_pixels = float(numpy.ma.count_masked(data[b]))
-        valid_percent = round((valid_pixels / data[b].size) * 100, 2)
+        valid_percent = round(min(valid_pixels / coverage_pixels, 1) * 100, 2)
 
         if categorical:
             out_dict = dict(zip(keys.tolist(), counts.tolist()))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -645,6 +645,7 @@ def test_get_array_statistics_coverage():
     assert stats[0]["count"] == 1.75
     assert stats[0]["median"] == 3  # 2 in exactextract
     assert round(stats[0]["std"], 2) == 1.05
+    assert stats[0]["valid_percent"] == 100
 
     stats = utils.get_array_statistics(data)
     assert len(stats) == 1
@@ -652,6 +653,7 @@ def test_get_array_statistics_coverage():
     assert stats[0]["max"] == 4
     assert stats[0]["mean"] == 2.5
     assert stats[0]["count"] == 4
+    assert stats[0]["valid_percent"] == 100
 
     # same test as https://github.com/isciences/exactextract/blob/0883cd585d9c7b6b4e936aeca4aa84a15adf82d2/python/tests/test_exact_extract.py#L48-L110
     data = np.ma.arange(1, 10, dtype=np.int32).reshape(3, 3)
@@ -669,6 +671,14 @@ def test_get_array_statistics_coverage():
     assert stats[0]["percentile_25"] == 3
     assert stats[0]["percentile_75"] == 6
     assert stats[0]["std"] == math.sqrt(5)
+
+    # test correct calculation of valid percent with masked array and coverage array
+    data = np.ma.array(
+        [[[0, 1], [0, 5]]], mask=[[[True, False], [True, False]]], fill_value=0
+    )
+    coverage = np.array([[0, 0.5], [0.75, 1]])
+    stats = utils.get_array_statistics(data, coverage=coverage)
+    assert stats[0]["valid_percent"] == 66.67
 
 
 def test_get_vrt_transform_world_file(dataset_fixture):


### PR DESCRIPTION
**Summary**
This PR updates the calculation of valid_percent in get_array_statistics. Previously, valid_percent was calculated by dividing the number of valid pixels by the total size of the array. Now, it uses the sum of nonzero values in the coverage array for more accurate results.

**Why this change?**
The previous method incorrectly calculated valid_percent when the coverage array was created using a geometry that wasn’t a simple rectangle. This change ensures the calculation properly reflects the valid area within the intended geometry.

**Related Issue**
See issue #774 for a detailed explanation of the problem and the motivation for this change.