### PR TITLE
add interpolate=True/False to point methods

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 # Unreleased
 
 * use `GDAL_MEM_ENABLE_OPEN=TRUE` when opening a numpy array with rasterio
+* add `interpolate=True/False` to `.point()` methods to allow interpolation of surrounding pixels
 
 # 7.5.0 (2025-02-26)
 

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -423,6 +423,33 @@ def test_point():
         assert pt.mask == numpy.array([0])
         assert pt.band_names == ["b1"]
 
+        # Interpolate=True but with Nearest, so no influence
+        pt = reader.point(
+            src_dst,
+            [-57.566, 73.6885],
+            coord_crs="epsg:4326",
+            indexes=1,
+            nodata=1,
+            interpolate=True,
+        )
+        assert pt.data == numpy.array([2800])
+        assert pt.mask == numpy.array([255])
+        assert pt.band_names == ["b1"]
+
+        # Interpolate=True + resampling=Cubic
+        pt = reader.point(
+            src_dst,
+            [-57.566, 73.6885],
+            coord_crs="epsg:4326",
+            indexes=1,
+            nodata=1,
+            resampling_method="cubic",
+            interpolate=True,
+        )
+        assert pt.data == numpy.array([2812])
+        assert pt.mask == numpy.array([255])
+        assert pt.band_names == ["b1"]
+
     with rasterio.open(COG_SCALE) as src_dst:
         pt = reader.point(src_dst, [310000, 4100000], coord_crs=src_dst.crs, indexes=1)
         assert pt.data == numpy.array([8917])


### PR DESCRIPTION
closes #793 

```python
from rio_tiler.io import Reader

lon, lat = -119.9019, 34.3468
with Reader("https://cdn.proj.org/us_nga_egm96_15.tif") as src:
    print(src.point(lon, lat, coord_crs="epsg:4326").data)
    print(src.point(lon, lat, coord_crs="epsg:4326", resampling_method="bilinear", interpolate=True).data)

[-36.604877]
[-35.990685]
```

cc @scottyhq
