### PR TITLE
avoid ZeroDivisionError in statistics

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 
 # Unreleased
 
+* fix `utils.get_array_statistics` method to avoid `ZeroDivisionError` when there is no valid pixel
 * use `GDAL_MEM_ENABLE_OPEN=TRUE` when opening a numpy array with rasterio
 
 # 7.5.0 (2025-02-26)

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -59,8 +59,8 @@ def _weighted_stdev(
     values: NDArray[numpy.floating],
     weights: NDArray[numpy.floating],
 ) -> float:
-    average = numpy.average(values, weights=weights)
-    variance = numpy.average((values - average) ** 2, weights=weights)
+    average = numpy.ma.average(values, weights=weights)
+    variance = numpy.ma.average((values - average) ** 2, weights=weights)
     return float(math.sqrt(variance))
 
 
@@ -174,35 +174,44 @@ def get_array_statistics(
                 _weighted_quantiles(data_comp, masked_coverage.compressed(), pp / 100.0)
                 for pp in percentiles
             ]
-        else:
-            percentiles_values = [numpy.nan] * len(percentiles_names)
-
-        if valid_pixels:
             majority = float(keys[counts.tolist().index(counts.max())].tolist())
             minority = float(keys[counts.tolist().index(counts.min())].tolist())
+            std = _weighted_stdev(data_comp, masked_coverage.compressed())
+            med = _weighted_quantiles(data_comp, masked_coverage.compressed())
+            _min = float(data[b].min())
+            _max = float(data[b].max())
+            _mean = float(data_cov.sum() / masked_coverage.sum())
+            _count = float(masked_coverage.sum())
+            _sum = float(data_cov.sum())
+
         else:
+            percentiles_values = [numpy.nan] * len(percentiles_names)
             majority = numpy.nan
             minority = numpy.nan
-
-        _count = masked_coverage.sum()
-        _sum = data_cov.sum()
+            std = numpy.nan
+            med = numpy.nan
+            _min = numpy.nan
+            _max = numpy.nan
+            _count = 0
+            _sum = 0
+            _mean = numpy.nan
 
         output.append(
             {
                 # Minimum value, not taking coverage fractions into account.
-                "min": float(data[b].min()),
+                "min": _min,
                 # Maximum value, not taking coverage fractions into account.
-                "max": float(data[b].max()),
+                "max": _max,
                 # Mean value, weighted by the percent of each cell that is covered.
-                "mean": float(_sum / _count),
+                "mean": _mean,
                 # Sum of all non-masked cell coverage fractions.
-                "count": float(_count),
+                "count": _count,
                 # Sum of values, weighted by their coverage fractions.
-                "sum": float(_sum),
+                "sum": _sum,
                 # Population standard deviation of cell values, taking into account coverage fraction.
-                "std": _weighted_stdev(data_comp, masked_coverage.compressed()),
+                "std": std,
                 # Median value of cells, weighted by the percent of each cell that is covered.
-                "median": _weighted_quantiles(data_comp, masked_coverage.compressed()),
+                "median": med,
                 # The value occupying the greatest number of cells.
                 "majority": majority,
                 # The value occupying the least number of cells.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -559,6 +559,39 @@ def test_get_array_statistics():
     assert not math.isnan(stats[0]["max"])
     assert not math.isnan(stats[0]["max"])
 
+    # Totally Masked Array
+    arr = np.ma.MaskedArray(data=np.zeros((1, 256, 256), dtype="uint8"), mask=True)
+    stats = utils.get_array_statistics(arr)
+    assert len(stats) == 1
+    assert list(stats[0]) == [
+        "min",
+        "max",
+        "mean",
+        "count",
+        "sum",
+        "std",
+        "median",
+        "majority",
+        "minority",
+        "unique",
+        "percentile_2",
+        "percentile_98",
+        "histogram",
+        "valid_pixels",
+        "masked_pixels",
+        "valid_percent",
+    ]
+    # Make sure the statistics object are JSON serializable
+    assert json.dumps(stats[0])
+    assert math.isnan(stats[0]["min"])
+    assert math.isnan(stats[0]["max"])
+    assert math.isnan(stats[0]["max"])
+    assert math.isnan(stats[0]["mean"])
+    assert stats[0]["count"] == 0
+    assert stats[0]["sum"] == 0
+    assert math.isnan(stats[0]["std"])
+    assert math.isnan(stats[0]["median"])
+
 
 def test_resize_array():
     """make sure we resize well."""


### PR DESCRIPTION
closes #792 


```python
from rio_tiler.io import STACReader

feat = {'type': 'Feature',
 'properties': {},
 'geometry': {'coordinates': [[[-55.47918513197018, -25.376762680029884],
    [-55.47918513197018, -25.386335571133102],
    [-55.47079011394402, -25.386335571133102],
    [-55.47079011394402, -25.376762680029884],
    [-55.47918513197018, -25.376762680029884]]],
  'type': 'Polygon'}}

with STACReader("https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items/S2B_21JXN_20210214_1_L2A") as src:
    img = src.feature(feat, expression="(nir-red)/(nir+red)", asset_as_band=True)
    print(img.statistics()["(nir-red)/(nir+red)"].model_dump_json())


{"min":null,"max":null,"mean":null,"count":0.0,"sum":0.0,"std":null,"median":null,"majority":null,"minority":null,"unique":0.0,"histogram":[[0,0,0,0,0,0,0,0,0,0],[0.0,0.1,0.2,0.30000000000000004,0.4,0.5,0.6000000000000001,0.7000000000000001,0.8,0.9,1.0]],"valid_percent":0.0,"masked_pixels":8989.0,"valid_pixels":0.0,"percentile_2":null,"percentile_98":null}
```