### PR TITLE
force GCPS dataset to be in a second WarpedVRT dataset to allow boundless read

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 
 # Unreleased
 
+# 7.7.3 (2025-05-22)
+
+* fix Boundless `part` read when using GCPs dataset
 
 # 7.7.2 (2025-05-15)
 

--- a/rio_tiler/reader.py
+++ b/rio_tiler/reader.py
@@ -308,7 +308,7 @@ def read(
             data,
             bounds=out_bounds,
             crs=dataset.crs,
-            band_names=[f"b{idx}" for idx in indexes],
+            band_names=[dataset.descriptions[ix - 1] or f"b{idx}" for idx in indexes],
             dataset_statistics=dataset_statistics,
             metadata=dataset.tags(),
         )
@@ -396,7 +396,7 @@ def part(
             )
 
     # Use WarpedVRT when Re-projection or User VRT Option (cutline)
-    if (dst_crs != src_dst.crs) or vrt_options:
+    if (dst_crs != src_dst.crs) or vrt_options or isinstance(src_dst, WarpedVRT):
         window = None
         vrt_transform, vrt_width, vrt_height = get_vrt_transform(
             src_dst,

--- a/tests/test_io_rasterio.py
+++ b/tests/test_io_rasterio.py
@@ -1145,3 +1145,17 @@ def test_int16_colormap():
 
             # make sure we keep the nodata part masked
             assert not im.mask.all()
+
+
+def test_titiler_issue_1163_warpedVrt():
+    """When using GCPs we are creating a WarpedVRT we should still be able
+    to perform `boundless` part read.
+    """
+    with Reader(COG_GCPS) as src:
+        assert isinstance(src.dataset, WarpedVRT)
+        assert src.dataset.crs == "epsg:4326"
+
+        img = src.part(
+            (75.0, 9.0, 77.0, 10.0), bounds_crs="epsg:4326", width=500, height=500
+        )
+        assert img.statistics()["b1"].valid_percent


### PR DESCRIPTION
closes https://github.com/developmentseed/titiler/issues/1163