### PR TITLE
add on-disk rendering option and default to Deflate for GTiff rendering

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 
 # Unreleased
 
+* add `COMPRESS=DEFLATE` for GTiff `ImageData` rendering when `compress` is not set
+* add `in_memory=True|False` for `utils.render()` function to save temporary image in memory or on disk (default: in memory)
+
 # 7.7.4 (2025-05-29)
 
 * fix band names for Xarray DataArray

--- a/rio_tiler/models.py
+++ b/rio_tiler/models.py
@@ -677,6 +677,8 @@ class ImageData:
                 kwargs.update({"transform": self.transform})
             if "crs" not in kwargs and self.crs:
                 kwargs.update({"crs": self.crs})
+            if "compress" not in kwargs:
+                kwargs.update({"compress": "DEFLATE"})
 
         array = self.array.copy()
 


### PR DESCRIPTION
This PR does:

- add `on-disk` image rendering (`ImageData().render(in_memory=False)`) 

- add `COMPRESS=DEFLATE` by default when rendering image with `GTiff` driver 

cc @emmanuelmathot 