### PR TITLE
patch: default to Deflate compression for GTiff rendering

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 
 # Unreleased
 
+# 7.7.5 (2025-06-03)
+
+* add `COMPRESS=DEFLATE` for GTiff rendering when `compress` is not set
+
 # 7.7.4 (2025-05-29)
 
 * fix band names for Xarray DataArray

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -528,7 +528,7 @@ def _requested_tile_aligned_with_internal_tile(
     return True
 
 
-def render(
+def render(  # noqa: C901
     data: numpy.ndarray,
     mask: Optional[numpy.ndarray] = None,
     img_format: str = "PNG",
@@ -608,6 +608,9 @@ def render(
         "width": width,
     }
     output_profile.update(creation_options)
+
+    if output_profile.get("driver") == "GTIFF" and "compress" not in output_profile:
+        output_profile["compress"] = "DEFLATE"
 
     try:
         with warnings.catch_warnings():


### PR DESCRIPTION
almost like #808 but without the `on-disk` part which might be unnecessary