### PR TITLE
add alpha_mask attribute to ImageData and refactor mask

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 
 # Unreleased
 
+* only cast data to `uint8` if colormap values are of type `uint8`
+* add `alpha_mask` attribute to `ImageData` class
+* allow partial alpha values from alpha band
+* better handle non-uint8 alpha band
+* remove deprecated `force_binary_mask` option in `reader.read` function  **breaking change**
+
 # 7.8.1 (2025-06-16)
 
 * apply scale/offset to dataset statistics in ImageData object (used for automatic rescaling)

--- a/docs/src/models.md
+++ b/docs/src/models.md
@@ -15,6 +15,7 @@ This class has helper methods like `render` which forward internal data and mask
 - **band_names**: image band's names
 - **dataset_statistics**: Dataset's min/max values (list of (min,max), optional)
 - **cutline_mask**: array representing the mask for `feature` methods
+- **alpha_nask**: array reprsenting the alpha mask (allowing partial transparency)
 
 ```python
 import numpy

--- a/rio_tiler/colormap.py
+++ b/rio_tiler/colormap.py
@@ -1,5 +1,6 @@
 """rio-tiler colormap functions and classes."""
 
+import itertools
 import json
 import os
 import pathlib
@@ -166,9 +167,10 @@ def apply_discrete_cmap(
 
     data = numpy.transpose(res, [2, 0, 1])
 
-    # If the output data has values between 0-255
+    # If colormap values are between 0-255
     # we cast the output array to Uint8
-    if data.min() >= 0 and data.max() <= 255:
+    cmap_v = list(itertools.chain(*colormap.values()))
+    if min(cmap_v) >= 0 and max(cmap_v) <= 255:
         data = data.astype("uint8")
 
     return data[:-1], data[-1]
@@ -206,9 +208,10 @@ def apply_intervals_cmap(
 
     data = numpy.transpose(res, [2, 0, 1])
 
-    # If the output data has values between 0-255
+    # If colormap values are between 0-255
     # we cast the output array to Uint8
-    if data.min() >= 0 and data.max() <= 255:
+    cmap_v = list(itertools.chain(*[v for k, v in colormap]))
+    if min(cmap_v) >= 0 and max(cmap_v) <= 255:
         data = data.astype("uint8")
 
     return data[:-1], data[-1]

--- a/rio_tiler/io/rasterio.py
+++ b/rio_tiler/io/rasterio.py
@@ -637,7 +637,6 @@ class ImageReader(Reader):
         tilesize: int = 256,
         indexes: Optional[Indexes] = None,
         expression: Optional[str] = None,
-        force_binary_mask: bool = True,
         out_dtype: Optional[Union[str, numpy.dtype]] = None,
         resampling_method: RIOResampling = "nearest",
         unscale: bool = False,
@@ -654,7 +653,6 @@ class ImageReader(Reader):
             tilesize (int, optional): Output image size. Defaults to `256`.
             indexes (int or sequence of int, optional): Band indexes.
             expression (str, optional): rio-tiler expression (e.g. b1/b2+b3).
-            force_binary_mask (bool, optional): Cast returned mask to binary values (0 or 255). Defaults to `True`.
             resampling_method (RIOResampling, optional): RasterIO resampling algorithm. Defaults to `nearest`.
             unscale (bool, optional): Apply 'scales' and 'offsets' on output data value. Defaults to `False`.
             post_process (callable, optional): Function to apply on output data and mask values.
@@ -675,7 +673,6 @@ class ImageReader(Reader):
             max_size=None,
             indexes=indexes,
             expression=expression,
-            force_binary_mask=force_binary_mask,
             out_dtype=out_dtype,
             resampling_method=resampling_method,
             unscale=unscale,
@@ -690,7 +687,6 @@ class ImageReader(Reader):
         max_size: Optional[int] = None,
         height: Optional[int] = None,
         width: Optional[int] = None,
-        force_binary_mask: bool = True,
         out_dtype: Optional[Union[str, numpy.dtype]] = None,
         resampling_method: RIOResampling = "nearest",
         unscale: bool = False,
@@ -707,7 +703,6 @@ class ImageReader(Reader):
             max_size (int, optional): Limit the size of the longest dimension of the dataset read, respecting bounds X/Y aspect ratio.
             height (int, optional): Output height of the array.
             width (int, optional): Output width of the array.
-            force_binary_mask (bool, optional): Cast returned mask to binary values (0 or 255). Defaults to `True`.
             resampling_method (RIOResampling, optional): RasterIO resampling algorithm. Defaults to `nearest`.
             unscale (bool, optional): Apply 'scales' and 'offsets' on output data value. Defaults to `False`.
             post_process (callable, optional): Function to apply on output data and mask values.
@@ -733,7 +728,6 @@ class ImageReader(Reader):
             width=width,
             height=height,
             indexes=indexes,
-            force_binary_mask=force_binary_mask,
             out_dtype=out_dtype,
             resampling_method=resampling_method,
             unscale=unscale,
@@ -804,7 +798,6 @@ class ImageReader(Reader):
         max_size: Optional[int] = None,
         height: Optional[int] = None,
         width: Optional[int] = None,
-        force_binary_mask: bool = True,
         out_dtype: Optional[Union[str, numpy.dtype]] = None,
         resampling_method: RIOResampling = "nearest",
         unscale: bool = False,
@@ -824,7 +817,6 @@ class ImageReader(Reader):
             max_size=max_size,
             height=height,
             width=width,
-            force_binary_mask=force_binary_mask,
             out_dtype=out_dtype,
             resampling_method=resampling_method,
             unscale=unscale,

--- a/rio_tiler/models.py
+++ b/rio_tiler/models.py
@@ -348,7 +348,7 @@ class ImageData:
     @property
     def mask(self) -> numpy.ndarray:
         """Return Mask in form of rasterio dataset mask."""
-        # NOTE: if available we return the alpha_maks
+        # NOTE: if available we return the alpha_mask
         if self.alpha_mask is not None:
             return self.alpha_mask
 

--- a/rio_tiler/reader.py
+++ b/rio_tiler/reader.py
@@ -33,7 +33,6 @@ from rio_tiler.utils import (
 class Options(TypedDict, total=False):
     """Reader Options."""
 
-    force_binary_mask: Optional[bool]
     nodata: Optional[NoData]
     vrt_options: Optional[Dict]
     resampling_method: Optional[RIOResampling]
@@ -97,7 +96,6 @@ def read(
     max_size: Optional[int] = None,
     indexes: Optional[Indexes] = None,
     window: Optional[windows.Window] = None,
-    force_binary_mask: bool = True,
     nodata: Optional[NoData] = None,
     vrt_options: Optional[Dict] = None,
     out_dtype: Optional[Union[str, numpy.dtype]] = None,
@@ -120,7 +118,6 @@ def read(
         vrt_options (dict, optional): Options to be passed to the rasterio.warp.WarpedVRT class.
         resampling_method (RIOResampling, optional): RasterIO resampling algorithm. Defaults to `nearest`.
         reproject_method (WarpResampling, optional): WarpKernel resampling algorithm. Defaults to `nearest`.
-        force_binary_mask (bool, optional): Cast returned mask to binary values (0 or 255). Defaults to `True`.
         unscale (bool, optional): Apply 'scales' and 'offsets' on output data value. Defaults to `False`.
         post_process (callable, optional): Function to apply on output data and mask values.
 
@@ -279,10 +276,6 @@ def read(
         # We only add dataset statistics if we have them for all the indexes
         dataset_statistics = stats if len(stats) == len(indexes) else None
 
-        # TODO: DEPRECATED, masked array are already using bool
-        if force_binary_mask:
-            pass
-
         if unscale:
             data = data.astype("float32", casting="unsafe")
 
@@ -340,7 +333,6 @@ def part(
     minimum_overlap: Optional[float] = None,
     padding: Optional[int] = None,
     buffer: Optional[float] = None,
-    force_binary_mask: bool = True,
     nodata: Optional[NoData] = None,
     vrt_options: Optional[Dict] = None,
     out_dtype: Optional[Union[str, numpy.dtype]] = None,
@@ -477,7 +469,6 @@ def part(
             out_dtype=out_dtype,
             resampling_method=resampling_method,
             reproject_method=reproject_method,
-            force_binary_mask=force_binary_mask,
             unscale=unscale,
             post_process=post_process,
         )
@@ -522,7 +513,6 @@ def part(
             out_dtype=out_dtype,
             resampling_method=resampling_method,
             reproject_method=reproject_method,
-            force_binary_mask=force_binary_mask,
             unscale=unscale,
             post_process=post_process,
         )
@@ -546,7 +536,6 @@ def part(
         out_dtype=out_dtype,
         resampling_method=resampling_method,
         reproject_method=reproject_method,
-        force_binary_mask=force_binary_mask,
         unscale=unscale,
         post_process=post_process,
     )
@@ -557,7 +546,6 @@ def point(
     coordinates: Tuple[float, float],
     indexes: Optional[Indexes] = None,
     coord_crs: CRS = WGS84_CRS,
-    force_binary_mask: bool = True,
     nodata: Optional[NoData] = None,
     vrt_options: Optional[Dict] = None,
     out_dtype: Optional[Union[str, numpy.dtype]] = None,
@@ -663,7 +651,6 @@ def point(
             window=window,
             out_dtype=out_dtype,
             resampling_method=resampling_method,
-            force_binary_mask=force_binary_mask,
             unscale=unscale,
             post_process=post_process,
         )

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -495,7 +495,7 @@ def linear_rescale(
     """
     imin, imax = in_range
     omin, omax = out_range
-    im = numpy.clip(image, imin, imax) - imin
+    im = numpy.clip(image, imin, imax, dtype=numpy.float64) - imin
     im = im / numpy.float64(imax - imin)
     return im * (omax - omin) + omin
 

--- a/tests/test_cmap.py
+++ b/tests/test_cmap.py
@@ -236,6 +236,7 @@ def test_apply_intervals_cmap():
     data[0, 2:5, 2:5] = 1
     data[0, 5:, 5:] = 2
     d, m = colormap.apply_intervals_cmap(data, cm)
+    assert d.dtype == "uint8"
     assert d.shape == (3, 10, 10)
     assert m.shape == (10, 10)
     assert d[0, 3, 4] == 255

--- a/tests/test_io_MultiBand.py
+++ b/tests/test_io_MultiBand.py
@@ -180,7 +180,7 @@ def test_MultiBandReader():
 
         img = src.feature(feat, bands="band1")
         assert img.data.any()
-        assert not img.mask.all()
+        assert not img._mask.all()
         assert img.band_names == ["band1"]
 
         with pytest.warns(ExpressionMixingWarning):

--- a/tests/test_io_image.py
+++ b/tests/test_io_image.py
@@ -31,7 +31,7 @@ def test_non_geo_image():
 
             img = src.tile(0, 0, 3)
             assert img.array.dtype == numpy.uint8
-            assert img.mask.all()
+            assert img._mask.all()
 
             img = src.tile(0, 0, 3, out_dtype="float32")
             assert img.array.dtype == numpy.float32
@@ -42,7 +42,7 @@ def test_non_geo_image():
 
             # Tile at zoom 0 should have masked part
             img = src.tile(0, 0, 0)
-            assert not img.mask.all()
+            assert not img._mask.all()
 
             with pytest.raises(TileOutsideBounds):
                 max_x_tile = src.dataset.width // 256 + 1
@@ -104,7 +104,7 @@ def test_non_geo_image():
     with pytest.warns((NotGeoreferencedWarning)):
         with ImageReader(NO_GEO_PORTRAIT) as src:
             img = src.tile(5, 2, 3)
-            assert not img.mask.all()
+            assert not img._mask.all()
 
 
 def test_with_geo_image():
@@ -118,13 +118,13 @@ def test_with_geo_image():
         assert list(src.tms.xy_bounds(0, 0, 0)) == [0, 1024, 1024, 0]
 
         img = src.tile(10, 12, 4)
-        assert img.mask.all()
+        assert img._mask.all()
         # img should keep the geo information from the dataset
         assert img.crs == src.dataset.crs
         assert img.bounds != list(src.tms.xy_bounds(10, 12, 4))
 
         img = src.tile(0, 0, 3)
-        assert not img.mask.any()
+        assert not img._mask.any()
 
         # Make sure no resampling was done at full resolution
         data = src.dataset.read(window=((0, 256), (0, 256)))
@@ -132,7 +132,7 @@ def test_with_geo_image():
 
         # Tile at zoom 0 should have masked part
         img = src.tile(0, 0, 0)
-        assert not img.mask.all()
+        assert not img._mask.all()
 
         with pytest.raises(TileOutsideBounds):
             max_x_tile = src.dataset.width // 256 + 1
@@ -153,7 +153,7 @@ def test_with_geo_image():
         pt = src.point(0, 0)
         # pixel 0,0 is masked
         assert len(pt.mask) == 1
-        assert pt.mask[0] == 0
+        assert not pt._mask[0]
 
         data = list(src.dataset.sample([(0, 0)]))[0]
         numpy.testing.assert_array_equal(pt.data, data)
@@ -161,7 +161,7 @@ def test_with_geo_image():
         pt = src.point(400, 800)
         # pixel 400,800 has valid values
         assert len(pt.mask) == 1
-        assert pt.mask[0] == 255
+        assert pt._mask[0]
 
         pt = src.point(920, 883)
         data = list(src.dataset.sample([(920, 883)]))[0]

--- a/tests/test_io_rasterio.py
+++ b/tests/test_io_rasterio.py
@@ -150,7 +150,7 @@ def test_tile_valid_default():
         # Full tile
         img = src.tile(43, 24, 7)
         assert img.data.shape == (1, 256, 256)
-        assert img.mask.all()
+        assert img._mask.all()
         assert img.band_names == ["b1"]
 
         # Validate that Tile and Part gives the same result
@@ -259,7 +259,7 @@ def test_point_valid():
         pt = src.point(lon, lat, expression="b1*2;b1-100")
         assert len(pt.data) == 2
         assert len(pt.mask) == 1
-        assert pt.mask[0] == 255
+        assert pt._mask[0]
         assert pt.band_names == ["b1*2", "b1-100"]
 
         with pytest.warns(ExpressionMixingWarning):
@@ -284,7 +284,7 @@ def test_point_valid():
 
         pt = src.point(-59.53, 74.03, indexes=(1, 1, 1))
         assert len(pt.data) == 3
-        assert pt.mask[0] == 0
+        assert not pt._mask[0]
         assert pt.band_names == ["b1", "b1", "b1"]
 
 
@@ -550,11 +550,11 @@ def test_imageData_output():
     with Reader(COG_NODATA) as src:
         img = src.tile(43, 24, 7)
         assert img.data.shape == (1, 256, 256)
-        assert img.mask.all()
+        assert img._mask.all()
         assert img.count == 1
         assert img.data_as_image().shape == (256, 256, 1)
 
-        assert numpy.array_equal(~img.array.mask[0] * 255, img.mask)
+        assert numpy.array_equal(~img.array.mask[0], img._mask)
 
         assert img.crs == WEB_MERCATOR_TMS.crs
         assert img.bounds == WEB_MERCATOR_TMS.xy_bounds(43, 24, 7)
@@ -706,7 +706,7 @@ def test_feature_valid():
         }
 
         img = src.feature(mask_feat, max_size=1024)
-        assert not img.mask.all()
+        assert not img._mask.all()
 
         outside_mask_feature = {
             "type": "Feature",
@@ -727,7 +727,7 @@ def test_feature_valid():
             },
         }
         img = src.feature(outside_mask_feature, max_size=1024)
-        assert not img.mask.all()
+        assert not img._mask.all()
 
 
 def test_equality_part_feature():
@@ -800,7 +800,7 @@ def test_tile_read_alpha():
             not nb == img.count
         )  # rio-tiler removes the alpha band from the `data` array
         assert img.data.shape == (3, 256, 256)
-        assert not img.mask.all()
+        assert not img._mask.all()
 
 
 def test_tile_read_mask():
@@ -811,12 +811,12 @@ def test_tile_read_mask():
             img = src.tile(876431, 1603669, 22, tilesize=16)
             assert img.data.shape == (3, 16, 16)
             assert img.mask.shape == (16, 16)
-            assert not img.mask.all()
+            assert not img._mask.all()
 
             # boundless tile covering the masked part
             img = src.tile(876431, 1603668, 22, tilesize=256)
             assert img.data.shape == (3, 256, 256)
-            assert not img.mask.all()
+            assert not img._mask.all()
 
 
 def test_tile_read_extmask():
@@ -827,7 +827,7 @@ def test_tile_read_extmask():
             img = src.tile(876431, 1603669, 22)
             assert img.data.shape == (3, 256, 256)
             assert img.mask.shape == (256, 256)
-            assert not img.mask.all()
+            assert not img._mask.all()
 
 
 def test_dateline():
@@ -1143,13 +1143,13 @@ def test_int16_colormap():
         assert info.nodata_value == -32768
 
         img = src.preview()
-        assert img.mask.any()
+        assert img._mask.any()
 
         with pytest.warns(UserWarning):
             im = img.apply_colormap(color_map)
 
             # make sure we keep the nodata part masked
-            assert not im.mask.all()
+            assert not im._mask.all()
 
 
 def test_titiler_issue_1163_warpedVrt():

--- a/tests/test_io_xarray.py
+++ b/tests/test_io_xarray.py
@@ -328,40 +328,40 @@ def test_xarray_reader_external_nodata():
 
         # TILE
         img = dst.tile(0, 0, 1)
-        assert img.mask.all()
+        assert img._mask.all()
         assert img.data[0, 0, 0] == 0
         assert img.data[0, 100, 100]
         assert dst.input.rio.nodata is None
 
         # overwrite the nodata value to 0
         img = dst.tile(0, 0, 1, nodata=0)
-        assert not img.mask.all()  # not all the mask value are set to 255
+        assert not img._mask.all()  # not all the mask value are set to 255
         assert img.array.mask[0, 0, 0]  # the top left pixel should be masked
         assert not img.array.mask[0, 100, 100]  # pixel 100,100 shouldn't be masked
         assert dst.input.rio.nodata is None
 
         # PART
         img = dst.part((-160, -80, 160, 80))
-        assert img.mask.all()
+        assert img._mask.all()
         assert img.data[0, 0, 0] == 0
         assert img.data[0, 100, 100]
         assert dst.input.rio.nodata is None
 
         # overwrite the nodata value to 0
         img = dst.part((-160, -80, 160, 80), nodata=0)
-        assert not img.mask.all()  # not all the mask value are set to 255
+        assert not img._mask.all()  # not all the mask value are set to 255
         assert img.array.mask[0, 0, 0]  # the top left pixel should be masked
         assert not img.array.mask[0, 100, 100]  # pixel 100,100 shouldn't be masked
 
         # POINT
         pt = dst.point(-179, 89)
-        assert pt.mask[0] == 255
+        assert pt._mask[0]
         assert dst.input.rio.nodata is None
 
         # overwrite the nodata value to 0
         pt = dst.point(-179, 89, nodata=0)
         assert pt.count == 1
-        assert pt.mask[0] == 0
+        assert not pt._mask[0]
         assert dst.input.rio.nodata is None
 
         feat = {
@@ -383,14 +383,14 @@ def test_xarray_reader_external_nodata():
 
         # FEATURE
         img = dst.feature(feat)
-        assert img.mask.all()
+        assert img._mask.all()
         assert img.data[0, 0, 0] == 0
         assert img.data[0, 50, 100]
         assert dst.input.rio.nodata is None
 
         # overwrite the nodata value to 0
         img = dst.feature(feat, nodata=0)
-        assert not img.mask.all()  # not all the mask value are set to 255
+        assert not img._mask.all()  # not all the mask value are set to 255
         assert img.array.mask[0, 0, 0]  # the top left pixel should be masked
         assert not img.array.mask[0, 50, 100]  # pixel 50,100 shouldn't be masked
         assert dst.input.rio.nodata is None
@@ -421,20 +421,20 @@ def test_xarray_reader_internal_nodata():
     with XarrayReader(data) as dst:
         # TILE
         img = dst.tile(0, 0, 1)
-        assert not img.mask.all()  # not all the mask value are set to 255
+        assert not img._mask.all()  # not all the mask value are set to 255
         assert img.array.mask[0, 0, 0]  # the top left pixel should be masked
         assert not img.array.mask[0, 100, 100]  # pixel 100,100 shouldn't be masked
 
         # PART
         img = dst.part((-160, -80, 160, 80))
-        assert not img.mask.all()  # not all the mask value are set to 255
+        assert not img._mask.all()  # not all the mask value are set to 255
         assert img.array.mask[0, 0, 0]  # the top left pixel should be masked
         assert not img.array.mask[0, 100, 100]  # pixel 100,100 shouldn't be masked
 
         # POINT
         pt = dst.point(-179, 89)
         assert pt.count == 1
-        assert pt.mask[0] == 0
+        assert not pt._mask[0]
 
         feat = {
             "type": "Feature",
@@ -455,7 +455,7 @@ def test_xarray_reader_internal_nodata():
 
         # FEATURE
         img = dst.feature(feat)
-        assert not img.mask.all()  # not all the mask value are set to 255
+        assert not img._mask.all()  # not all the mask value are set to 255
         assert img.array.mask[0, 0, 0]  # the top left pixel should be masked
         assert not img.array.mask[0, 50, 100]  # pixel 50,100 shouldn't be masked
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -211,16 +211,22 @@ def test_resize():
 
 def test_clip():
     """Resize ImageData and check original image"""
-    data = numpy.zeros((3, 1024, 1024), dtype="uint8")
+    data = numpy.zeros((3, 1024, 1024), dtype="int16")
+    data[:, :, :] = 32767
     img = ImageData(data, crs="epsg:4326", bounds=(-180, -90, 180, 90))
 
     img_c = img.clip((-100, -50, 100, 50))
     assert img_c.count == 3
     assert img_c.bounds == (-100, -50, 100, 50)
 
+    img.rescale(((0, 32767),))
     assert img.width == 1024
     assert img.height == 1024
     assert img.mask.shape == (1024, 1024)
+    assert img.array.dtype == "uint8"
+
+    # make sure the clipped image didn't change
+    assert img_c.array.dtype == "int16"
 
 
 def test_point_data():
@@ -229,7 +235,7 @@ def test_point_data():
     assert pt.count == 3
     assert pt.data.shape == (3,)
     assert pt.mask.shape == (1,)
-    assert pt.mask.tolist() == [255]
+    assert pt._mask.tolist() == [True]
     assert pt.band_names == ["b1", "b2", "b3"]
 
     with pytest.raises(ValueError):
@@ -251,7 +257,7 @@ def test_point_data():
     pts = PointData.create_from_list([pt1, pt2])
     assert pts.data.tolist() == [1, 2, 3]
     assert pts.band_names == ["b1", "b2", "b1+b2"]
-    assert pts.mask.tolist() == [255]
+    assert pts._mask.tolist() == [True]
 
     pts = PointData.create_from_list(
         [
@@ -260,7 +266,7 @@ def test_point_data():
         ]
     )
     assert pts.array.mask.tolist() == [False, True]
-    assert pts.mask.tolist() == [0]
+    assert pts._mask.tolist() == [False]
 
     pts = PointData.create_from_list(
         [
@@ -269,7 +275,7 @@ def test_point_data():
         ]
     )
     assert pts.array.mask.tolist() == [False, False]
-    assert pts.mask.tolist() == [255]
+    assert pts._mask.tolist() == [True]
 
     pts = PointData.create_from_list(
         [
@@ -278,7 +284,7 @@ def test_point_data():
         ]
     )
     assert pts.array.mask.tolist() == [True, True]
-    assert pts.mask.tolist() == [0]
+    assert pts._mask.tolist() == [False]
 
     with pytest.raises(InvalidPointDataError):
         PointData.create_from_list([])
@@ -315,7 +321,7 @@ def test_image_apply_colormap():
     assert im.data.shape == (3, 256, 256)
     assert im.data[:, 0, 0].tolist() == [0, 0, 0]
     assert im.mask[0, 0] == 255
-    assert im.mask.all()
+    assert im._mask.all()
 
     cm = {0: (0, 0, 0, 255), 1: (255, 255, 255, 255)}
     data = numpy.zeros((1, 256, 256), dtype="uint8") + 1
@@ -336,6 +342,8 @@ def test_image_apply_colormap():
     assert im.data[:, 0, 0].tolist() == [0, 0, 0]
     assert im.mask[0, 0] == 255
 
+    # Case 1
+    # both input data has masked values
     cm = {0: (0, 0, 0, 255), 1: (255, 255, 255, 255)}
     arr = numpy.zeros((1, 256, 256), dtype="uint8") + 1
     arr[0, 0, 0] = 0
@@ -344,13 +352,71 @@ def test_image_apply_colormap():
     mask[0, 0, 0] = True
 
     im = ImageData(numpy.ma.MaskedArray(arr, mask=mask)).apply_colormap(cm)
-    # data[0, 0, 0] is 0 so after colormap it should be 0,0,0 and mask should be 0 (because it was masked by the original mask)
     assert im.data[:, 0, 0].tolist() == [0, 0, 0]
     assert im.array.mask[:, 1, 1].tolist() == [False, False, False]
     assert im.mask[1, 1] == 255
 
     assert im.array.mask[:, 0, 0].tolist() == [True, True, True]
     assert im.mask[0, 0] == 0
+
+    # Case 2
+    # both input data and colormaped data has masked values
+    cm = {0: (255, 255, 255, 0), 1: (255, 255, 255, 255)}
+    arr = numpy.zeros((1, 256, 256), dtype="uint8") + 1
+    arr[0, 0, 0] = 0
+
+    mask = numpy.zeros((1, 256, 256), dtype="bool")
+    mask[0, 0, 0] = True
+    im = ImageData(numpy.ma.MaskedArray(arr, mask=mask)).apply_colormap(cm)
+    assert im.data[:, 0, 0].tolist() == [255, 255, 255]
+    assert im.array.mask[:, 0, 0].tolist() == [True, True, True]
+    assert im.mask[0, 0] == 0
+
+    assert im.array.mask[:, 1, 1].tolist() == [False, False, False]
+    assert im.mask[1, 1] == 255
+
+    # Case 3
+    # colormaped data has masked values
+    cm = {0: (255, 255, 255, 0), 1: (255, 255, 255, 255)}
+    arr = numpy.zeros((1, 256, 256), dtype="uint8") + 1
+    arr[0, 0, 0] = 0
+
+    mask = numpy.zeros((1, 256, 256), dtype="bool")
+    im = ImageData(numpy.ma.MaskedArray(arr, mask=mask)).apply_colormap(cm)
+    assert im.data[:, 0, 0].tolist() == [255, 255, 255]
+    assert im.array.mask[:, 0, 0].tolist() == [True, True, True]
+    assert im.mask[0, 0] == 0
+
+    assert im.array.mask[:, 1, 1].tolist() == [False, False, False]
+    assert im.mask[1, 1] == 255
+
+
+def test_image_apply_colormap_partial():
+    """Apply colormap with partial transparency."""
+    cm = {
+        0: (255, 255, 255, 0),  # masked
+        1: (255, 255, 255, 50),  # partially masked
+        2: (255, 255, 255, 255),  # not masked
+    }
+
+    arr = numpy.zeros((1, 256, 256), dtype="uint8") + 2
+    arr[0, 1, 1] = 1
+    arr[0, 0, 0] = 0
+
+    # Full Valid data
+    mask = numpy.zeros((1, 256, 256), dtype="bool")
+    im = ImageData(numpy.ma.MaskedArray(arr, mask=mask)).apply_colormap(cm)
+    assert im.data[:, 0, 0].tolist() == [255, 255, 255]
+    assert im.array.mask[:, 0, 0].tolist() == [True, True, True]
+    assert im.mask[0, 0] == 0
+
+    # Partial transparency is considered as a `masked` value
+    assert im.array.mask[:, 1, 1].tolist() == [True, True, True]
+    # But mask has partial alpha value
+    assert im.mask[1, 1] == 50
+
+    assert im.array.mask[:, 2, 2].tolist() == [False, False, False]
+    assert im.mask[2, 2] == 255
 
 
 def test_image_from_bytes():
@@ -360,7 +426,7 @@ def test_image_from_bytes():
 
     im_r = ImageData.from_bytes(im.render(img_format="PNG", add_mask=True))
     assert im_r.data.shape == (1, 256, 256)
-    assert im.mask.all()
+    assert im._mask.all()
 
     data = numpy.zeros((1, 256, 256), dtype="uint8")
     data[0:100, 0:100] = 1
@@ -370,15 +436,15 @@ def test_image_from_bytes():
 
     im = ImageData.from_bytes(img.render(img_format="PNG", add_mask=True))
     assert im.data.shape == (1, 256, 256)
-    assert not im.mask.all()
+    assert not im._mask.all()
 
     im = ImageData.from_bytes(img.render(img_format="PNG", add_mask=False))
     assert im.data.shape == (1, 256, 256)
-    assert im.mask.all()
+    assert im._mask.all()
 
     im = ImageData.from_bytes(img.render(img_format="JPEG", add_mask=False))
     assert im.data.shape == (1, 256, 256)
-    assert im.mask.all()
+    assert im._mask.all()
 
 
 def test_2d_image():
@@ -388,7 +454,7 @@ def test_2d_image():
     assert im.count == 1
     assert im.width == 256
     assert im.height == 256
-    assert im.mask.all()
+    assert im._mask.all()
 
 
 def test_apply_color_formula():
@@ -578,3 +644,173 @@ def test_imageData_to_raster(tmp_path):
         with rasterio.open(tmp_path / "img.tif") as src:
             assert src.count == 4
             assert src.profile["driver"] == "PNG"
+
+
+def test_image_post_process():
+    """Test post_process functionality."""
+    data = numpy.zeros((3, 256, 256), dtype="int16")
+    data[:, 100:256, 100:256] = 32767
+    mask = numpy.zeros((3, 256, 256), dtype="bool")
+    mask[0:50, 0:50] = True
+
+    cf = "gamma b 1.85, gamma rg 1.95, sigmoidal rgb 35 0.13, saturation 1.15"
+
+    img = ImageData(
+        numpy.ma.MaskedArray(data=data, mask=mask),
+    )
+    img_p = img.post_process(color_formula=cf)
+    assert img_p.array.dtype == "uint8"
+    assert img.array.dtype == "int16"
+
+    img_p = img.post_process(in_range=((0, 32767),))
+    assert img_p.array.dtype == "uint8"
+    assert img.array.dtype == "int16"
+
+
+def test_image_rescale():
+    """Test basic rescale functionality."""
+    data = numpy.zeros((1, 256, 256), dtype="int16")
+    data[:, 100:256, 100:256] = 32767
+    mask = numpy.zeros((1, 256, 256), dtype="bool")
+    mask[0:50, 0:50] = True
+
+    img = ImageData(
+        numpy.ma.MaskedArray(data=data, mask=mask),
+    )
+    img.rescale(((0, 32767),))
+    assert img.array[0, 255, 255] == 255
+    assert img.array[0, 60, 60] == 0
+
+
+def test_mask_values():
+    """test mask values."""
+    data = numpy.zeros((1, 256, 256), dtype="int16")
+    data[:, 100:256, 100:256] = 32767
+    mask = numpy.zeros((1, 256, 256), dtype="bool")
+    mask[0:50, 0:50] = True
+    img = ImageData(
+        numpy.ma.MaskedArray(data=data, mask=mask),
+    )
+    assert img.mask[0, 0] == -32768
+    assert img.mask[255, 255] == 32767
+    with pytest.warns(InvalidDatatypeWarning) as w:
+        img.render(img_format="PNG")
+        assert len(w.list) == 1
+
+    data = numpy.zeros((1, 256, 256), dtype="uint16")
+    data[:, 100:256, 100:256] = 65535
+    mask = numpy.zeros((1, 256, 256), dtype="bool")
+    mask[0:50, 0:50] = True
+    img = ImageData(
+        numpy.ma.MaskedArray(data=data, mask=mask),
+    )
+    assert img.mask[0, 0] == 0
+    assert img.mask[255, 255] == 65535
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        img.render(img_format="PNG")
+
+
+def test_alpha_band():
+    """Test ImageData with Alpha Band"""
+    arr = numpy.zeros((1, 256, 256), dtype="uint8")
+    arr[0, 50:100, :] = 50
+    arr[0, 100:150, :] = 100
+    arr[0, 150:200, :] = 150
+    arr[0, 200:, :] = 200
+
+    # Full Valid data
+    mask = numpy.zeros((1, 256, 256), dtype="bool")
+    mask[0, 0:100, 0:100] = True
+
+    data = numpy.ma.MaskedArray(arr, mask=mask)
+
+    # Invalid shape
+    with pytest.raises(ValueError):
+        ImageData(
+            data,
+            alpha_mask=numpy.zeros((512, 512), dtype="uint8"),
+        )
+
+    # Invalid Datatype
+    with pytest.raises(ValueError):
+        ImageData(
+            data,
+            alpha_mask=numpy.zeros((256, 256), dtype="uint16"),
+        )
+
+    # Alpha mask with partial transparency
+    alpha = numpy.zeros((256, 256), dtype="uint8") + 255
+    alpha[0:100, 0:100] = 0
+    alpha[0:50, 0:50] = 150  # Partial transparency
+
+    im = ImageData(data, alpha_mask=alpha, bounds=(-180, -90, 180, 90))
+    numpy.testing.assert_array_equal(im.mask, im.alpha_mask)
+
+    imr = im.resize(100, 100)
+    assert imr.alpha_mask.shape == (100, 100)
+
+    imr = im.clip((0, 0, 180, 90))
+    assert imr.array.shape == (1, 128, 128)
+    assert imr.alpha_mask.shape == (128, 128)
+
+    # ColorFormula/Rescale
+    data = numpy.random.randint(0, 16000, (3, 256, 256)).astype("uint16")
+    alpha = numpy.zeros((256, 256), dtype="uint16") + 65535
+    alpha[0:100, 0:100] = 30000  # Partial transparency
+    alpha[0:50, 0:50] = 0
+    im = ImageData(data, alpha_mask=alpha)
+    imp = im.post_process(
+        color_formula="gamma b 1.85, gamma rg 1.95, sigmoidal rgb 35 0.13, saturation 1.15"
+    )
+    assert imp.alpha_mask.dtype == "uint8"
+    assert imp.alpha_mask[0, 0] == 0
+    assert imp.alpha_mask[50, 50] == 116
+    assert imp.alpha_mask[100, 100] == 255
+
+    imp = im.post_process(in_range=((0, 30000),))
+    assert imp.alpha_mask.dtype == "uint8"
+    assert imp.alpha_mask[0, 0] == 0
+    assert imp.alpha_mask[50, 50] == 116
+    assert imp.alpha_mask[100, 100] == 255
+
+    # ColorMap
+    cm = {
+        0: (255, 255, 255, 0),  # transparent
+        50: (255, 0, 255, 50),  # partially transparent
+        100: (255, 255, 0, 255),  # not transparent
+        150: (255, 0, 0, 255),  # not transparent
+        200: (0, 255, 255, 255),  # not transparent
+    }
+    arr = numpy.zeros((1, 256, 256), dtype="uint8") + 200
+    arr[0, 0:50, :] = 0
+    arr[0, 50:100, :] = 50
+    arr[0, 100:150, :] = 100
+    arr[0, 150:200, :] = 150
+    mask = numpy.zeros((1, 256, 256), dtype="bool")
+    mask[0, 0:10, 0:10] = True
+    data = numpy.ma.MaskedArray(arr, mask=mask)
+    alpha = numpy.zeros((256, 256), dtype="uint8")
+    im = ImageData(data, alpha_mask=alpha)
+
+    # alpha will be ignored when applying colormap
+    with pytest.warns(UserWarning):
+        im_colormaped = im.apply_colormap(cm)
+
+    # make sure array is still masked
+    assert im_colormaped.array.mask[0, 0, 0]
+    assert im_colormaped.mask[0, 0] == 0
+
+    # full transparency from alpha result in masked value
+    assert im_colormaped.array.mask[0, 20, 20]
+    # full transparency from alpha
+    assert im_colormaped.mask[20, 20] == 0
+
+    # partial transparency from alpha result in masked value
+    assert im_colormaped.array.mask[0, 50, 20]
+    # partial transparency from alpha
+    assert im_colormaped.mask[50, 20] == 50
+
+    # no transparency
+    assert not im_colormaped.array.mask[0, 100, 20]
+    assert im_colormaped.mask[100, 20] == 255

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -425,19 +425,19 @@ def test_read_nodata():
     with rasterio.open(COG) as src_dst:
         arr, mask = reader.part(src_dst, bounds, nodata=1)
 
-    masknodata = (arr[0] != 1).astype(numpy.uint8) * 255
+    masknodata = (arr[0] != 1).astype(numpy.uint16) * 65535
     numpy.testing.assert_array_equal(mask, masknodata)
 
     with rasterio.open(COG) as src_dst:
         arr, mask = reader.read(src_dst, nodata=1)
 
-    masknodata = (arr[0] != 1).astype(numpy.uint8) * 255
+    masknodata = (arr[0] != 1).astype(numpy.uint16) * 65535
     numpy.testing.assert_array_equal(mask, masknodata)
 
     with rasterio.open(COG) as src_dst:
         arr, mask = reader.read(src_dst, dst_crs="epsg:3857", nodata=1)
 
-    masknodata = (arr[0] != 1).astype(numpy.uint8) * 255
+    masknodata = (arr[0] != 1).astype(numpy.uint16) * 65535
     numpy.testing.assert_array_equal(mask, masknodata)
 
 
@@ -529,7 +529,7 @@ def test_point():
             nodata=1,
         )
         assert pt.data == numpy.array([2800])
-        assert pt.mask == numpy.array([255])
+        assert pt.mask == numpy.array([[65535]])
         assert pt.band_names == ["b1"]
 
         # resampling_method is useless with interpolate=False
@@ -553,7 +553,7 @@ def test_point():
             interpolate=True,
         )
         assert pt.data == numpy.array([2800])
-        assert pt.mask == numpy.array([255])
+        assert pt.mask == numpy.array([[65535]])
         assert pt.band_names == ["b1"]
         assert pt.pixel_location
         assert isinstance(pt.pixel_location[0], float)
@@ -569,7 +569,7 @@ def test_point():
             interpolate=True,
         )
         assert pt.data == numpy.array([2819])
-        assert pt.mask == numpy.array([255])
+        assert pt.mask == numpy.array([[65535]])
         assert pt.band_names == ["b1"]
 
         # Interpolate=True + resampling=average
@@ -583,7 +583,7 @@ def test_point():
             interpolate=True,
         )
         assert pt.data == numpy.array([2904])
-        assert pt.mask == numpy.array([255])
+        assert pt.mask == numpy.array([[65535]])
         assert pt.band_names == ["b1"]
 
         # Interpolate=True + resampling=Cubic
@@ -597,13 +597,13 @@ def test_point():
             interpolate=True,
         )
         assert pt.data == numpy.array([2812])
-        assert pt.mask == numpy.array([255])
+        assert pt.mask == numpy.array([[65535]])
         assert pt.band_names == ["b1"]
 
     with rasterio.open(COG_SCALE) as src_dst:
         pt = reader.point(src_dst, [310000, 4100000], coord_crs=src_dst.crs, indexes=1)
         assert pt.data == numpy.array([8917])
-        assert pt.mask == numpy.array([255])
+        assert pt.mask == numpy.array([[32767]])
         assert pt.band_names == ["b1"]
 
         pt = reader.point(src_dst, [310000, 4100000], coord_crs=src_dst.crs)
@@ -780,11 +780,11 @@ def test_read():
 
     with rasterio.open(COG) as src:
         img = reader.read(src)
-        assert img.mask.all()
+        assert img._mask.all()
 
     with rasterio.open(COG) as src:
         img = reader.read(src, nodata=1)
-        assert not img.mask.all()
+        assert not img._mask.all()
 
     with rasterio.open(COG) as src:
         img = reader.read(src, window=((0, 100), (0, 100)))
@@ -827,7 +827,7 @@ def test_read():
     # Dataset with Alpha using WarpedVRT
     with rasterio.open(S3_ALPHA_PATH) as src:
         img = reader.read(src, dst_crs="epsg:3857")
-        assert not img.mask.all()
+        assert not img._mask.all()
 
 
 def test_part_no_VRT():
@@ -847,7 +847,7 @@ def test_part_no_VRT():
         img = reader.part(src_dst, bounds, bounds_crs="epsg:4326")
         assert img.height == 1453
         assert img.width == 1613
-        assert img.mask[0, 0] == 255
+        assert img.mask[0, 0] == 65535
         assert img.mask[-1, -1] == 0  # boundless
         assert img.bounds == bounds_dst_crs
 
@@ -855,7 +855,7 @@ def test_part_no_VRT():
         img_crs = reader.part(src_dst, bounds_dst_crs)
         assert img.height == 1453
         assert img.width == 1613
-        assert img_crs.mask[0, 0] == 255
+        assert img_crs.mask[0, 0] == 65535
         assert img_crs.mask[-1, -1] == 0  # boundless
         assert img.bounds == bounds_dst_crs
 
@@ -863,7 +863,7 @@ def test_part_no_VRT():
         img = reader.part(src_dst, bounds, bounds_crs="epsg:4326", max_size=1024)
         assert img.height < 1024
         assert img.width == 1024
-        assert img.mask[0, 0] == 255
+        assert img.mask[0, 0] == 65535
         assert img.mask[-1, -1] == 0  # boundless
         assert img.bounds == bounds_dst_crs
 
@@ -877,7 +877,7 @@ def test_part_no_VRT():
         )
         assert img.height == 100
         assert img.width == 100
-        assert img.mask[0, 0] == 255
+        assert img.mask[0, 0] == 65535
         assert img.mask[-1, -1] == 0  # boundless
         assert img.bounds == bounds_dst_crs
 
@@ -885,7 +885,7 @@ def test_part_no_VRT():
         img = reader.part(src_dst, bounds, bounds_crs="epsg:4326", buffer=1)
         assert img.height == 1455
         assert img.width == 1615
-        assert img.mask[0, 0] == 255
+        assert img.mask[0, 0] == 65535
         assert img.mask[-1, -1] == 0  # boundless
         assert not img.bounds == bounds_dst_crs
 
@@ -894,7 +894,7 @@ def test_part_no_VRT():
         img_pad = reader.part(src_dst, bounds, bounds_crs="epsg:4326", padding=1)
         assert img_pad.height == 1453
         assert img_pad.width == 1613
-        assert img_pad.mask[0, 0] == 255
+        assert img_pad.mask[0, 0] == 65535
         assert img_pad.mask[-1, -1] == 0  # boundless
         assert img_pad.bounds == bounds_dst_crs
         # Padding should not have any influence when not doing any rescaling/reprojection
@@ -1082,7 +1082,7 @@ def test_nodata_orverride():
         assert prev.mask[0, 0] == 0
 
         prev = reader.read(src_dst, max_size=100, nodata=2720)
-        assert prev.mask[0, 0] == 255
+        assert prev.mask[0, 0] == 65535
         assert not numpy.all(prev.mask)
 
 
@@ -1090,8 +1090,8 @@ def test_tile_read_nodata_float():
     """Should work as expected when using NaN as nodata value."""
     with rasterio.open(COG_NODATA_FLOAT_NAN) as src_dst:
         prev = reader.read(src_dst, max_size=100)
-        assert prev.mask[0, 0] == 0
-        assert not numpy.all(prev.mask)
+        assert prev.mask[0, 0] == -3.4028235e38
+        assert not numpy.all(prev._mask)
 
 
 def test_inverted_latitude_point():


### PR DESCRIPTION
This PR does:

- add `alpha_mask` attribute to the ImageData class (ref: https://github.com/developmentseed/titiler/discussions/1183) 

The `alpha_mask` has to be an numpy array in form of `(height x width)` with the same datatype as the data array. Values can be have to be between the min/max data type value (uint8: 0,255; int16: -32768, 32767, ....).

If present, the `alpha_mask` will be returned by the`.mask` property (used in `.render()` method) **breaking change** 

- refactor the `.mask` property to make sure the array has the same datatype as the data

- add more tests for mask datatype and imageData array copy


## ToDo

- [x] add more tests for `alpha_mask` 
- [x] update docs

