### PR TITLE
add max-pixel limit

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -95,7 +95,7 @@ with Reader("tests/fixtures/cog_tags.tif") as src:
 
 * refactor `XarrayReader.part` method to better handle reprojection and re-usability
 * move `_get_width_height` and `_missing_size` from `rio_tiler.reader` to `rio_tiler.utils`
-* add upper pixel size limit for Xarray dataset. Controled with `RIO_TILER_MAX_PIXELS` env variable.
+* add upper memory limit for Xarray dataset. Controled with `RIO_TILER_MAX_ARRAY_SIZE` env variable.
 
 # 7.9.2 (2025-10-09)
 

--- a/rio_tiler/errors.py
+++ b/rio_tiler/errors.py
@@ -97,5 +97,5 @@ class RioTilerExperimentalWarning(UserWarning):
     """A rio-tiler specific experimental functionality warning."""
 
 
-class MaxPixelsError(RioTilerError):
+class MaxArraySizeError(RioTilerError):
     """Trying to load to many pixels in memory."""


### PR DESCRIPTION
closes #831 

This PR adds a `MAX_PIXELS` constant which limit the shape of data array users could put in Memory (after a xarray `.sel`)
