### PR TITLE
feat: add geozarr reader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Run Benchmark
         run: |
-          uv run --group performance pytest tests/benchmarks/benchmarks.py --benchmark-only --benchmark-columns 'min, max, mean, median' --benchmark-sort 'min' --benchmark-json output.json
+          uv run --group performance --frozen pytest tests/benchmarks/benchmarks.py --benchmark-only --benchmark-columns 'min, max, mean, median' --benchmark-sort 'min' --benchmark-json output.json
 
       - name: Store and Compare benchmark result
         uses: benchmark-action/github-action-benchmark@a60cea5bc7b49e15c1f58f411161f99e0df48372 # v1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,10 +4,11 @@
 * changed: `rio_tiler.experimental.zarr.ZarrReader` -> `rio_tiler.experimental._zarr.ZarrReader` 
 * changed: `rio_tiler.experimental._async` -> `rio_tiler.experimental.geotiff` 
 * changed: `rio_tiler.experimental._async.AsyncBaseReader` -> `rio_tiler.io.base.AsyncBaseReader`
-* add: `rio_tiler.experimental.zarr.Reader` (async zarr-python reader)
 * changed: `rio_tiler.experimental._async.warp` -> `rio_tiler._warp.warp`
 * changed: `rio_tiler.io.xarray.MAX_ARRAY_SIZE` -> `rio_tiler.constant.MAX_ARRAY_SIZE` 
 * changed: `async` -> `geotiff` optional-dependencies
+* add: `rio_tiler.experimental.zarr.Reader` (async zarr-python reader)
+* add: `rio_tiler.experimental.zarr.GeoZarrReader`  (async zarr-python reader for GeoZAR/EOPF product)
 
 ## 9.0.6 (2026-04-08)
 

--- a/docs/src/experimental.md
+++ b/docs/src/experimental.md
@@ -44,7 +44,7 @@ with VSIReader("https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a
 - https://github.com/rasterio/rasterio/pull/2141
 
 
-## geotiff.Reader
+## GeoTIFF Reader
 
 A asynchronous rio-tiler reader built on top [`async-geotiff`](https://github.com/developmentseed/async-geotiff). This reader is considered experimental because the API might evolve in the future and the `part()` method might be refactored to avoid using `rasterio.warp.reproject`.
 
@@ -70,9 +70,9 @@ await with GeoTIFFReader(geotiff) as src:
     img = await src.tile(493, 741, 11)
 ```
 
-## zarr.Reader
+## ZARR Reader (Array)
 
-A asynchronous rio-tiler reader built on top [`zarr-python`](https://zarr.readthedocs.io/).
+A asynchronous rio-tiler reader built on top [`zarr-python`](https://zarr.readthedocs.io/) that can read single array.
 
 Required dependencies:
 - `zarr>=3.0`
@@ -139,4 +139,95 @@ ds = ZarrReader(
     band_names=[str(d) for d in time_arrray.tolist()],
 )
 img = await ds.tile(9, 10, 5, indexes=10)
+```
+
+## GeoZARR Reader (Group + GeoZARR conventions)
+
+A asynchronous rio-tiler reader built on top [`zarr-python`](https://zarr.readthedocs.io/) that can read Groups of arrays.
+
+Required dependencies:
+- `zarr>=3.0`
+- `obstore` 
+
+
+#### Open Top level group in the Zarr store
+
+```python
+from obstore.store import HTTPStore
+import zarr
+from zarr.storage import ObjectStore
+
+from rio_tiler.experimental.zarr import GeoZarrReader
+
+from matplotlib.pyplot import imshow
+
+# Create Obstore Store
+store = HTTPStore("https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2B_MSIL2A_20260216T142149_N0512_R096_T25WFV_20260216T165051.zarr")
+zarr_store = ObjectStore(store=store, read_only=True)
+geozarr = await zarr.api.asynchronous.open_group(store=zarr_store, mode="r")
+
+# Initiate the reader
+reader = GeoZarrReader(geozarr)
+
+print(reader.bounds)
+# the top level zarr store doesn't have spatial:bbox attributes
+>> (-180, -90, 180, 90)
+
+# List available variables (arrays with group or array Geo/Spatial conventions)
+variables = await reader.list_variables()
+print(variables)
+>>> ['measurements/reflectance:b01', 'measurements/reflectance:b02', 'measurements/reflectance:b03', 'measurements/reflectance:b04', 'measurements/reflectance:b05', 'measurements/reflectance:b06', 'measurements/reflectance:b07', 'measurements/reflectance:b08', 'measurements/reflectance:b09', 'measurements/reflectance:b11', 'measurements/reflectance:b12', 'measurements/reflectance:b8a', 'quality/atmosphere/r10m:aot', 'quality/atmosphere/r10m:wvp', 'quality/atmosphere/r20m:aot', 'quality/atmosphere/r20m:wvp', 'quality/atmosphere/r60m:aot', 'quality/atmosphere/r60m:wvp', 'quality/mask/r10m:b02', 'quality/mask/r10m:b03', 'quality/mask/r10m:b04', 'quality/mask/r10m:b08', 'quality/mask/r20m:b05', 'quality/mask/r20m:b06', 'quality/mask/r20m:b07', 'quality/mask/r20m:b11', 'quality/mask/r20m:b12', 'quality/mask/r20m:b8a', 'quality/mask/r60m:b01', 'quality/mask/r60m:b09', 'quality/mask/r60m:b10', 'quality/probability/r20m:cld', 'quality/probability/r20m:snw']
+
+# Get the preview for a specific variable
+img = await reader.preview(variables=["measurements/reflectance:b02"], max_size=128)
+
+# Get Bounds for a specific set of variables (The root store can have multiple spatial extents)
+bounds = await reader.get_bounds(variables=["measurements/reflectance:b02"], crs="EPSG:4326")
+
+# Get Minzoom for a specific set of variables (The root store doesn't have transform/shape)
+minzoom = await reader.get_minzoom(variables=["measurements/reflectance:b02"])
+
+# Get Time image
+tile = reader.tms.tile(bounds[0], bounds[1], minzoomminzoom)
+img = await dreaders.tile(tile.x, tile.y, tile.z, variables=("measurements/reflectance:b04", "measurements/reflectance:b03", "measurements/reflectance:b02"))
+```
+
+#### Open a specific Zarr Group
+
+```python
+from obstore.store import HTTPStore
+import zarr
+from zarr.storage import ObjectStore
+
+from rio_tiler.experimental.zarr import GeoZarrReader
+
+from matplotlib.pyplot import imshow
+
+# Create Obstore Store
+store = HTTPStore("https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2B_MSIL2A_20260216T142149_N0512_R096_T25WFV_20260216T165051.zarr/measurements/reflectance/")
+zarr_store = ObjectStore(store=store, read_only=True)
+geozarr = await zarr.api.asynchronous.open_group(store=zarr_store, mode="r")
+
+# Initiate the reader
+reader = GeoZarrReader(geozarr)
+
+# The `/measurements/reflectance` group has spatial/geo conventions
+print(reader.bounds)
+>> (600005.0, 7890245.0, 709795.0, 8000035.0)
+
+print(reader.crs)
+>> CRS.from_epsg(32625)
+
+# List available variables (arrays with group or array Geo/Spatial conventions)
+variables = await reader.list_variables()
+print(variables)
+>>> ['b01', 'b02', 'b03', 'b04', 'b05', 'b06', 'b07', 'b08', 'b09', 'b11', 'b12', 'b8a']
+
+# Get the preview for a specific variable
+img = await reader.preview(variables=["b02"], max_size=128)
+
+bounds = 
+# Get Time image
+tile = reader.tms.tile(bounds[0], bounds[1], reader.minzoom)
+img = await reader.tile(tile.x, tile.y, tile.z, variables=("b04", "b03", "b02"))
 ```

--- a/rio_tiler/errors.py
+++ b/rio_tiler/errors.py
@@ -21,6 +21,10 @@ class PointOutsideBounds(RioTilerError):
     """Point is outside image bounds."""
 
 
+class InvalidBounds(RioTilerError):
+    """Requested BBOX does not intersect dataset bounds."""
+
+
 class InvalidBandName(RioTilerError):
     """Invalid band name."""
 

--- a/rio_tiler/experimental/zarr.py
+++ b/rio_tiler/experimental/zarr.py
@@ -27,6 +27,7 @@ from rio_tiler._warp import warp
 from rio_tiler.constants import MAX_ARRAY_SIZE, WEB_MERCATOR_TMS, WGS84_CRS
 from rio_tiler.errors import (
     ExpressionMixingWarning,
+    InvalidBounds,
     MaxArraySizeError,
     PointOutsideBounds,
     TileOutsideBounds,
@@ -87,6 +88,21 @@ def _get_proj_crs(attributes: dict) -> CRS:
         )
     )
     return CRS.from_user_input(proj_string)
+
+
+def _get_transform(attributes: dict) -> Affine | None:
+    transform_type = attributes.get("spatial:transform_type") or "affine"
+    tr = attributes.get("spatial:transform")
+    if transform_type == "affine" and tr is not None:
+        if attributes.get("spatial:registration", "pixel") == "node":
+            # NOTE: If the registration is "node", we need to adjust the transform to
+            # account for the fact that the coordinates refer to the center of the pixel rather than the edge.
+            tr[2] -= tr[0] / 2
+            tr[5] -= tr[4] / 2
+
+        return Affine(*tr)
+
+    return None
 
 
 @attr.s
@@ -150,16 +166,8 @@ class Reader(AsyncBaseReader):
 
         # Transform
         if not self.transform and _has_spatial(conventions):
-            transform_type = attributes.get("spatial:transform_type") or "affine"
-            tr = attributes.get("spatial:transform")
-            if transform_type == "affine" and tr is not None:
-                if attributes.get("spatial:registration", "pixel") == "node":
-                    # NOTE: If the registration is "node", we need to adjust the transform to
-                    # account for the fact that the coordinates refer to the center of the pixel rather than the edge.
-                    tr[2] -= tr[0] / 2
-                    tr[5] -= tr[4] / 2
-
-                self.transform = Affine(*tr)
+            if tr := _get_transform(attributes):
+                self.transform = tr
 
         assert self.transform, (
             "Affine transform is required, either as an argument or in `spatial` zarr_conventions"
@@ -470,7 +478,7 @@ class Reader(AsyncBaseReader):
         col_end = min(self.width, math.ceil(rasterio_win.col_off + rasterio_win.width))
         row_end = min(self.height, math.ceil(rasterio_win.row_off + rasterio_win.height))
         if col_off >= col_end or row_off >= row_end:
-            raise ValueError("Input BBOX and dataset bounds do not intersect")
+            raise InvalidBounds("Input BBOX and dataset bounds do not intersect")
 
         # Clamp window to array bounds
         clipped_col_off = max(0, col_off)
@@ -882,9 +890,19 @@ class ArrayMetadata(TypedDict):
 
     array: zarr.AsyncArray
     crs: CRS
+    transform: Affine
     height: int
     width: int
-    transform: Affine
+
+
+class GroupMetadata(TypedDict):
+    """Group Metadata."""
+
+    crs: CRS | None
+    bbox: BBox | None
+    transform: Affine | None
+    multiscale: bool
+    arrays: dict[str, list[ArrayMetadata]]
 
 
 def calculate_output_transform(
@@ -1041,7 +1059,6 @@ def get_multiscale_level(
 class GeoZarrInfo(Bounds):
     """GeoZarr Info."""
 
-    multiscales: bool
     variables: list[str]
     attributes: dict[str, Any]
 
@@ -1073,12 +1090,11 @@ class GeoZarrReader(AsyncBaseReader):
     # Group bounds (calculated from shape + transform)
     bounds: BBox = attr.ib(init=False)
 
-    multiscales: bool = attr.ib(init=False)
-
     colormap: dict | None = attr.ib(default=None)
 
-    # list of availables arrays in the group
-    _variables: dict[str, list[ArrayMetadata]] = attr.ib(init=False, default=None)
+    # list of availables the groups with variables (used for cache)
+    _groups: dict[str, GroupMetadata] = attr.ib(init=False, factory=dict)
+    _variables: list[str] = attr.ib(init=False, default=None)
 
     async def __aenter__(self):
         """Support using with Context Managers."""
@@ -1094,111 +1110,97 @@ class GeoZarrReader(AsyncBaseReader):
         attributes = cast(dict[str, Any], self.input.attrs)
         conventions: list[dict] = attributes.get("zarr_conventions", [])
 
-        self.multiscales = _has_multiscales(conventions)
+        # Default CRS/Bounds for a Zarr Store
+        self.crs = WGS84_CRS
+        self.bounds = (-180.0, -90.0, 180.0, 90.0)
 
-        self.spatial = _has_spatial(conventions)
-        assert self.spatial, (
-            "GeoZarr convention requires 'spatial' convention to be present in zarr_conventions"
-        )
-
-        self.proj = _has_proj(conventions)
-        assert self.proj, (
-            "GeoZarr convention requires 'geo-proj' convention to be present in zarr_conventions"
-        )
-
-        # CRS
-        self.crs = _get_proj_crs(attributes)
-
-        if spatial_shape := attributes.get("spatial:shape"):
-            self.height = spatial_shape[0]
-            self.width = spatial_shape[1]
-
-        if bbox := attributes.get("spatial:bbox"):
-            self.bounds = bbox
-
-        # Transform
-        # Case 1: Transform at group level
-        tr = attributes.get("spatial:transform")
-        transform_type = attributes.get("spatial:transform_type", "affine")
-        if tr is not None and transform_type == "affine":
-            if attributes.get("spatial:registration", "pixel") == "node":
-                # NOTE: If the registration is "node", we need to adjust the transform to
-                # account for the fact that the coordinates refer to the center of the pixel rather than the edge.
-                tr[2] -= tr[0] / 2
-                tr[5] -= tr[4] / 2
-
-            self.transform = Affine(*tr)
-
-        # Case 2: check multiscales for transform and shape
-        if self.multiscales:
-            # assume the first layout is the highest resolution
-            first_res = attributes["multiscales"]["layout"][0]
-
-            if spatial_shape := attributes.get("spatial:shape"):
-                self.height = self.height or spatial_shape[0]
-                self.width = self.width or spatial_shape[1]
+        transform: Affine | None = None
+        height: int | None = None
+        width: int | None = None
+        bounds: BBox | None = None
+        if _has_spatial(conventions) and _has_proj(conventions):
+            # CRS
+            crs = _get_proj_crs(attributes)
 
             if bbox := attributes.get("spatial:bbox"):
-                self.bounds = self.bounds or bbox
+                bounds = bbox
 
-            tr = first_res.get("spatial:transform")
-            transform_type = first_res.get("spatial:transform_type", "affine")
-            if tr is not None and transform_type == "affine":
-                if first_res.get("spatial:registration", "pixel") == "node":
-                    # NOTE: If the registration is "node", we need to adjust the transform to
-                    # account for the fact that the coordinates refer to the center of the pixel rather than the edge.
-                    tr[2] -= tr[0] / 2
-                    tr[5] -= tr[4] / 2
+            # Transform
+            # Case 1: Transform at group level
+            transform = _get_transform(attributes)
 
-            self.transform = self.transform or Affine(*tr)
+            if spatial_shape := attributes.get("spatial:shape"):
+                height = spatial_shape[0]
+                width = spatial_shape[1]
 
-        assert self.transform, (
-            "spatial:transform is required either at group level or in the first layout of multiscales convention"
-        )
+            # Case 2: check multiscales for transform and shape
+            if _has_multiscales(conventions):
+                # assume the first layout is the highest resolution
+                first_res = attributes["multiscales"]["layout"][0]
 
-        if not self.bounds and all([self.width, self.height]):
-            self.bounds = array_bounds(self.height, self.width, self.transform)
+                if bbox := attributes.get("spatial:bbox"):
+                    bounds = bounds or bbox
 
-        assert self.bounds, (
-            "spatial:bbox or spatial:shape is required either at group level or in the first layout of multiscales convention"
-        )
+                transform = transform or _get_transform(first_res)
+
+                if spatial_shape := attributes.get("spatial:shape"):
+                    height = height or spatial_shape[0]
+                    width = width or spatial_shape[1]
+
+            if not bounds and all([width, height, transform]):
+                bounds = array_bounds(height, width, transform)
+
+            if all([transform, bounds]):
+                self.crs = crs
+                self.transform = transform
+                self.bounds = bounds
+
+            if all([height, width]):
+                self.height = height
+                self.width = width
 
     @property
-    def minzoom(self):
+    def minzoom(self) -> int:
         """Return dataset minzoom."""
-        if self.multiscales:
+        attributes = cast(dict[str, Any], self.input.attrs)
+        conventions: list[dict] = attributes.get("zarr_conventions", [])
+
+        if _has_multiscales(conventions):
             attributes = cast(dict[str, Any], self.input.attrs)
             # assume the last layout is the lowest resolution
             last_res = attributes["multiscales"]["layout"][-1]
             shape = last_res.get("spatial:shape")
-            transform = last_res.get("spatial:transform")
+            transform = _get_transform(last_res)
             if all([transform, shape]):
                 return _get_zoom(
                     tms=self.tms,
                     crs=self.crs,
                     width=shape[1],
                     height=shape[0],
-                    bounds=array_bounds(shape[0], shape[1], Affine(*transform)),
+                    bounds=array_bounds(shape[0], shape[1], transform),
                 )
 
         return self.maxzoom
 
     @property
-    def maxzoom(self):
+    def maxzoom(self) -> int:
         """Return dataset maxzoom."""
-        if self.multiscales:
+        attributes = cast(dict[str, Any], self.input.attrs)
+        conventions: list[dict] = attributes.get("zarr_conventions", [])
+
+        if _has_multiscales(conventions):
             attributes = cast(dict[str, Any], self.input.attrs)
             # assume the last layout is the highest resolution
             first_res = attributes["multiscales"]["layout"][0]
             shape = first_res.get("spatial:shape")
-            transform = first_res.get("spatial:transform")
+            transform = _get_transform(first_res)
             if all([transform, shape]):
                 return _get_zoom(
                     tms=self.tms,
                     crs=self.crs,
                     width=shape[1],
                     height=shape[0],
-                    bounds=array_bounds(shape[0], shape[1], Affine(*transform)),
+                    bounds=array_bounds(shape[0], shape[1], transform),
                 )
 
         if not all([self.bounds, self.width, self.height]):
@@ -1217,124 +1219,239 @@ class GeoZarrReader(AsyncBaseReader):
 
         return self._maxzoom
 
-    @property
-    async def variables(self) -> dict[str, list[ArrayMetadata]]:  # noqa: C901
-        """Return list of variables (arrays) with their geospatial metadata."""
-        if self._variables:
+    async def get_bounds(
+        self,
+        *,
+        variables: Sequence[str] | str,
+        crs: CRS = WGS84_CRS,
+    ) -> BBox:  # noqa: C901
+        """Get BBox for variables."""
+        variables = cast_to_sequence(variables)
+
+        async def _get_bounds(variable: str) -> BBox:
+            group_name = "root"
+            if ":" in variable:
+                group_name, variable = variable.split(":", 1)
+
+            group_metadata = await self.get_group_metadata(group_name)
+            array = group_metadata["arrays"].get(variable)
+            if not array:
+                raise ValueError(
+                    f"Variable '{variable}' not found in '{group_name}' group."
+                )
+
+            bounds_crs = group_metadata["crs"]
+            bbox = group_metadata["bbox"]
+            if not bounds_crs or not bbox:
+                array_metadata = self.select_variable(array)
+                bbox = array_bounds(
+                    array_metadata["height"],
+                    array_metadata["width"],
+                    array_metadata["transform"],
+                )
+                bounds_crs = array_metadata["crs"]
+
+            if bounds_crs != crs:
+                return cast(
+                    BBox, transform_bounds(bounds_crs, crs, *bbox, densify_pts=21)
+                )
+
+            return bbox
+
+        bounds = await asyncio.gather(*(_get_bounds(variable) for variable in variables))
+        minx, miny, maxx, maxy = zip(*bounds)
+        return (min(minx), min(miny), max(maxx), max(maxy))
+
+    async def list_variables(self) -> list[str]:
+        """List variables in the Zarr store."""
+        if self._variables is not None:
             return self._variables
 
-        variables: dict[str, list[ArrayMetadata]] = {}
-        if self.multiscales:
-            attributes = cast(dict[str, Any], self.input.attrs)
-            conventions: list[dict] = attributes.get("zarr_conventions", [])
+        ms_groups = []
+        variables: list[str] = []
 
-            crs = _get_proj_crs(attributes) if _has_proj(conventions) else self.crs
+        group = "root"
+        group_metadata = await self.get_group_metadata(group)
 
-            # 1. Get MS groups + geospatial metadata (crs, transform)
-            ms_group: dict[str, dict[str, Any]] = {}
-            for layout in attributes["multiscales"]["layout"]:
-                transform_type = layout.get("spatial:transform_type") or "affine"
-                tr = layout.get("spatial:transform")
-                if transform_type == "affine" and tr is not None:
-                    if layout.get("spatial:registration", "pixel") == "node":
-                        # NOTE: If the registration is "node", we need to adjust the transform to
-                        # account for the fact that the coordinates refer to the center of the pixel rather than the edge.
-                        tr[2] -= tr[0] / 2
-                        tr[5] -= tr[4] / 2
+        # Zarr store is a multiscale group
+        if group_metadata["multiscale"]:
+            ms_groups.append(group)
 
-                ms_group[layout["asset"]] = {
-                    "crs": crs,
-                    "transform": tr,
-                }
+        # Zarr Store has top level arrays
+        if vars := group_metadata["arrays"].keys():
+            variables.extend(vars)
 
-            # 2. list all arrays for each layout
-            for group_name, meta in ms_group.items():
-                group = await self.input.getitem(group_name)
+        # Check sub-groups
+        else:
+            async for name, member in self.input.members(max_depth=10):
+                if any(name.startswith(msg) for msg in ms_groups):
+                    continue
 
-                # NOTE: `ms_group` reference group names so we know `getitem` return a group
-                group = cast(zarr.AsyncGroup, group)
-                async for array in group.array_values():
+                # Check Group for variables
+                if isinstance(member, zarr.AsyncGroup):
+                    group_metadata = await self.get_group_metadata(name)
+                    if group_metadata["multiscale"]:
+                        ms_groups.append(name)
+
+                    if vars := group_metadata["arrays"].keys():
+                        variables.extend([f"{name}:{v}" for v in vars])
+
+        self._variables = sorted(set(variables))
+        return self._variables
+
+    async def get_group_metadata(  # noqa: C901
+        self,
+        group: str,
+    ) -> GroupMetadata:
+        """Find arrays in a Zarr store and extract spatial metadata."""
+        if group in self._groups:
+            return self._groups[group]
+
+        g = self.input if group == "root" else await self.input.getitem(group)
+
+        arrays: dict[str, list[ArrayMetadata]] = {}
+
+        root_crs: CRS | None = None
+        root_transform: Affine | None = None
+        root_bbox: BBox | None = None
+
+        # NOTE: root is an Array
+        if isinstance(g, zarr.AsyncArray):
+            conventions = g.attrs.get("zarr_conventions", [])
+            if _has_proj(conventions):
+                root_crs = _get_proj_crs(g.attrs)
+
+            if _has_spatial(conventions):
+                root_transform = _get_transform(g.attrs)
+                root_bbox = g.attrs.get("spatial:bbox")
+
+            # TODO: is this always true ?
+            height, width = g.shape[-2:]
+
+            if all([root_crs, root_transform]):
+                arrays["/"] = [
+                    {
+                        "array": g,
+                        "crs": root_crs,
+                        "height": height,
+                        "width": width,
+                        "transform": root_transform,
+                    }
+                ]
+
+            self._groups[group] = {
+                "crs": root_crs,
+                "bbox": root_bbox,
+                "transform": root_transform,
+                "arrays": arrays,
+                "multiscale": False,
+            }
+
+        else:
+            conventions = g.attrs.get("zarr_conventions", [])
+            # Top Level spatial/geo metadata
+            # 1. Group level metadata (crs, transform)
+            if _has_proj(conventions):
+                root_crs = _get_proj_crs(g.attrs)
+
+            if _has_spatial(conventions):
+                root_transform = _get_transform(g.attrs)
+                root_bbox = g.attrs.get("spatial:bbox")
+
+            group_is_multiscale = _has_multiscales(conventions)
+            if group_is_multiscale:
+                # NOTE: We assume a group with multiscale should have geo-proj convention
+                assert root_crs, (
+                    f"`proj:code` missing for multiscales group '{g.name}' metadata"
+                )
+
+                # 1. Multiscales metadata
+                ms_group: dict[str, dict[str, Any]] = {}
+                for layout in g.attrs["multiscales"]["layout"]:
+                    ms_group[layout["asset"]] = {
+                        "transform": _get_transform(layout),
+                    }
+
+                # 2. list all arrays for each layout
+                for group_name, meta in ms_group.items():
+                    msgroup = await g.getitem(group_name)
+
+                    # NOTE: `ms_group` reference group names so we know `getitem` return a group
+                    msgroup = cast(zarr.AsyncGroup, msgroup)
+                    async for array in msgroup.array_values():
+                        # NOTE: skip non-data arrays
+                        # TODO: be smarter
+                        if array.ndim < 2:
+                            continue
+
+                        variable_name = array.name.split("/")[-1]
+                        if variable_name not in arrays:
+                            arrays[variable_name] = []
+
+                        # NOTE: Transform from the array or the multiscale layout
+                        transform = _get_transform(array.attrs) or meta["transform"]
+                        assert transform, (
+                            f"`spatial:transform` missing for multiscales layout {group_name} (path: '{array.name}')"
+                        )
+
+                        # TODO: is this always true ?
+                        height, width = array.shape[-2:]
+
+                        arrays[variable_name].append(
+                            {
+                                "array": array,
+                                "crs": root_crs,
+                                "height": height,
+                                "width": width,
+                                "transform": transform,
+                            }
+                        )
+
+            else:
+                # List arrays in group
+                async for array in g.array_values():
+                    array_crs: CRS | None = None
+                    array_transform: Affine | None = None
+
                     # NOTE: skip non-data arrays
                     # TODO: be smarter
                     if array.ndim < 2:
                         continue
 
-                    attributes = cast(dict[str, Any], array.attrs)
-                    variable_name = array.name.replace(f"/{group_name}/", "")
-                    if variable_name not in variables:
-                        variables[variable_name] = []
+                    conventions = array.attrs.get("zarr_conventions", [])
+                    if _has_proj(conventions):
+                        array_crs = _get_proj_crs(array.attrs)
 
-                    transform = attributes.get("spatial:transform")
-                    transform_type = attributes.get("spatial:transform_type") or "affine"
-                    if transform_type == "affine" and transform is not None:
-                        if attributes.get("spatial:registration", "pixel") == "node":
-                            # NOTE: If the registration is "node", we need to adjust the transform to
-                            # account for the fact that the coordinates refer to the center of the pixel rather than the edge.
-                            transform[2] -= transform[0] / 2
-                            transform[5] -= transform[4] / 2
+                    if _has_spatial(conventions):
+                        array_transform = _get_transform(array.attrs)
 
-                    transform = transform or meta["transform"]
-                    assert transform, (
-                        f"`spatial:transform` missing for multiscales layout {group_name} (path: '{array.name}')"
-                    )
+                    array_crs = array_crs or root_crs
+                    array_transform = array_transform or root_transform
 
-                    # TODO: is this always true
+                    # TODO: is this always true ?
                     height, width = array.shape[-2:]
 
-                    variables[variable_name].append(
-                        {
-                            "array": array,
-                            "crs": meta["crs"],
-                            "height": height,
-                            "width": width,
-                            "transform": Affine(*transform),
-                        }
-                    )
+                    if all([array_crs, array_transform]):
+                        array_name = array.name.replace(f"{g.name}/", "")
+                        arrays[array_name] = [
+                            {
+                                "array": array,
+                                "crs": array_crs,
+                                "height": height,
+                                "width": width,
+                                "transform": array_transform,
+                            }
+                        ]
 
-        else:
-            group_name = self.input.name
-            async for array in self.input.array_values():
-                # NOTE: skip non-data arrays
-                # TODO: be smarter
-                if array.ndim < 2:
-                    continue
+            self._groups[group] = {
+                "crs": root_crs,
+                "bbox": root_bbox,
+                "transform": root_transform,
+                "multiscale": group_is_multiscale,
+                "arrays": arrays,
+            }
 
-                attributes = cast(dict[str, Any], array.attrs)
-                variable_name = array.name.replace(f"{group_name}/", "")
-
-                transform = attributes.get("spatial:transform")
-                transform_type = attributes.get("spatial:transform_type") or "affine"
-                if transform_type == "affine" and transform is not None:
-                    if attributes.get("spatial:registration", "pixel") == "node":
-                        # NOTE: If the registration is "node", we need to adjust the transform to
-                        # account for the fact that the coordinates refer to the center of the pixel rather than the edge.
-                        transform[2] -= transform[0] / 2
-                        transform[5] -= transform[4] / 2
-
-                transform = transform or self.transform
-                assert transform, (
-                    f"`spatial:transform` missing for array {variable_name} (path: '{array.name}')"
-                )
-
-                # TODO: is this always true
-                height, width = array.shape[-2:]
-
-                variables[variable_name] = [
-                    {
-                        "array": array,
-                        "crs": self.crs,
-                        "height": height,
-                        "width": width,
-                        "transform": Affine(*transform),
-                    }
-                ]
-
-        if not variables:
-            raise ValueError("No variables (data arrays) found in the dataset.")
-
-        self._variables = variables
-
-        return self._variables
+        return self._groups[group]
 
     def select_variable(
         self,
@@ -1392,7 +1509,7 @@ class GeoZarrReader(AsyncBaseReader):
             GeoZarrInfo: Dataset info.
 
         """
-        availables_variables = await self.variables
+        availables_variables = await self.list_variables()
 
         attrs: dict[str, Any] = self.input.attrs or {}
 
@@ -1400,9 +1517,8 @@ class GeoZarrReader(AsyncBaseReader):
             "bounds": self.bounds,
             "crs": CRS_to_uri(self.crs) or self.crs.to_wkt(),
             # additional info (not in default model)
-            "driver": "GeoZarr",
-            "multiscales": self.multiscales,
-            "variables": list(availables_variables.keys()),
+            "driver": "GeoZARR",
+            "variables": availables_variables,
             "attributes": {
                 k: (v.tolist() if isinstance(v, (numpy.ndarray, numpy.generic)) else v)
                 for k, v in attrs.items()
@@ -1411,10 +1527,10 @@ class GeoZarrReader(AsyncBaseReader):
 
         return GeoZarrInfo.model_validate(meta)
 
-    async def statistics(
+    async def statistics(  # type: ignore[override]
         self,
         *,
-        variables: Sequence[str] | str | None = None,
+        variables: Sequence[str] | str,
         expression: str | None = None,
         categorical: bool = False,
         categories: list[float] | None = None,
@@ -1440,16 +1556,6 @@ class GeoZarrReader(AsyncBaseReader):
             dict[str, rio_tiler.models.BandStatistics]: bands statistics.
 
         """
-        availables_variables = await self.variables
-
-        variables = variables or list(availables_variables.keys())
-
-        variables = cast_to_sequence(variables)
-        if vars := set(variables).difference(availables_variables.keys()):
-            raise ValueError(
-                f"Variables {vars} not found in the dataset. Available variables: {list(availables_variables.keys())}"
-            )
-
         img = await self.preview(
             variables=variables,
             expression=expression,
@@ -1489,6 +1595,7 @@ class GeoZarrReader(AsyncBaseReader):
             rio_tiler.models.ImageData: ImageData instance with data, mask and tile spatial info.
 
         """
+        # NOTE: if the top level bbox doesn't exist this, should always return False
         if not self.tile_exists(tile_x, tile_y, tile_z):
             raise TileOutsideBounds(
                 f"Tile(x={tile_x}, y={tile_y}, z={tile_z}) is outside bounds"
@@ -1539,23 +1646,27 @@ class GeoZarrReader(AsyncBaseReader):
             rio_tiler.models.ImageData: ImageData instance with data, mask and input spatial info.
 
         """
-        availables_variables = await self.variables
-
         variables = cast_to_sequence(variables)
-        if vars := set(variables).difference(availables_variables.keys()):
-            raise ValueError(
-                f"Variables {vars} not found in the dataset. Available variables: {list(availables_variables.keys())}"
-            )
 
         async def _part(variable: str) -> ImageData:
+            group_name = "root"
+            if ":" in variable:
+                group_name, variable = variable.split(":", 1)
+
+            group_metadata = await self.get_group_metadata(group_name)
+            array = group_metadata["arrays"].get(variable)
+            if not array:
+                raise ValueError(
+                    f"Variable '{variable}' not found in '{group_name}' group."
+                )
+
             array_metadata = self.select_variable(
-                availables_variables[variable],
+                array,
                 max_size=max_size,
                 height=height,
                 width=width,
                 dst_crs=dst_crs,
             )
-
             async with Reader(
                 input=array_metadata["array"],
                 transform=array_metadata["transform"],
@@ -1602,23 +1713,27 @@ class GeoZarrReader(AsyncBaseReader):
             rio_tiler.models.ImageData: ImageData instance with data, mask and input spatial info.
 
         """
-        availables_variables = await self.variables
-
         variables = cast_to_sequence(variables)
-        if vars := set(variables).difference(availables_variables.keys()):
-            raise ValueError(
-                f"Variables {vars} not found in the dataset. Available variables: {list(availables_variables.keys())}"
-            )
 
         async def _preview(variable: str) -> ImageData:
+            group_name = "root"
+            if ":" in variable:
+                group_name, variable = variable.split(":", 1)
+
+            group_metadata = await self.get_group_metadata(group_name)
+            array = group_metadata["arrays"].get(variable)
+            if not array:
+                raise ValueError(
+                    f"Variable '{variable}' not found in '{group_name}' group."
+                )
+
             array_metadata = self.select_variable(
-                availables_variables[variable],
+                array,
                 max_size=max_size,
                 height=height,
                 width=width,
                 dst_crs=dst_crs,
             )
-
             async with Reader(
                 input=array_metadata["array"],
                 transform=array_metadata["transform"],
@@ -1666,16 +1781,21 @@ class GeoZarrReader(AsyncBaseReader):
             rio_tiler.models.PointData: PointData instance with data, mask and spatial info.
 
         """
-        availables_variables = await self.variables
-
         variables = cast_to_sequence(variables)
-        if vars := set(variables).difference(availables_variables.keys()):
-            raise ValueError(
-                f"Variables {vars} not found in the dataset. Available variables: {list(availables_variables.keys())}"
-            )
 
         async def _point(variable: str) -> PointData:
-            array_metadata = self.select_variable(availables_variables[variable])
+            group_name = "root"
+            if ":" in variable:
+                group_name, variable = variable.split(":", 1)
+
+            group_metadata = await self.get_group_metadata(group_name)
+            array = group_metadata["arrays"].get(variable)
+            if not array:
+                raise ValueError(
+                    f"Variable '{variable}' not found in '{group_name}' group."
+                )
+
+            array_metadata = self.select_variable(array)
             async with Reader(
                 input=array_metadata["array"],
                 transform=array_metadata["transform"],
@@ -1722,14 +1842,6 @@ class GeoZarrReader(AsyncBaseReader):
             rio_tiler.models.ImageData: ImageData instance with data, mask and input spatial info.
 
         """
-        availables_variables = await self.variables
-
-        variables = cast_to_sequence(variables)
-        if vars := set(variables).difference(availables_variables.keys()):
-            raise ValueError(
-                f"Variables {vars} not found in the dataset. Available variables: {list(availables_variables.keys())}"
-            )
-
         shape = _validate_shape_input(shape)
 
         if not dst_crs:

--- a/rio_tiler/experimental/zarr.py
+++ b/rio_tiler/experimental/zarr.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import math
 import warnings
 from collections.abc import Sequence
-from typing import Any, cast
+from typing import Any, Literal, TypedDict, cast
 
 import attr
 import numpy
@@ -16,7 +17,7 @@ from rasterio.crs import CRS
 from rasterio.errors import NotGeoreferencedWarning
 from rasterio.features import bounds as featureBounds
 from rasterio.features import rasterize
-from rasterio.transform import array_bounds, rowcol
+from rasterio.transform import array_bounds, from_bounds, rowcol
 from rasterio.warp import calculate_default_transform
 from rasterio.warp import transform as transform_coords
 from rasterio.warp import transform_bounds, transform_geom
@@ -41,6 +42,17 @@ from rio_tiler.utils import (
     _validate_shape_input,
     cast_to_sequence,
 )
+
+
+def _has_multiscales(conventions: list[dict]) -> bool:
+    return next(
+        (
+            True
+            for c in conventions
+            if c["uuid"] == "d35379db-88df-4056-af3a-620245f8e347"
+        ),
+        False,
+    )
 
 
 def _has_spatial(conventions: list[dict]) -> bool:
@@ -89,7 +101,6 @@ class Reader(AsyncBaseReader):
         crs: Coordinate reference system.
         transform: Affine transform.
         tms: TileMatrixSet for tile operations.
-        options: Reader options including nodata.
         colormap: Optional colormap dictionary.
 
     Note:
@@ -859,3 +870,638 @@ class Reader(AsyncBaseReader):
             band_descriptions=band_descriptions,
             nodata=nodata,
         )
+
+
+def _get_zoom(
+    tms: TileMatrixSet,
+    crs: CRS,
+    width: int,
+    height: int,
+    bounds: BBox,
+) -> int:
+    """Get MaxZoom for a Group."""
+    tms_crs = tms.rasterio_crs
+    if crs != tms_crs:
+        transform, _, _ = calculate_default_transform(
+            crs,
+            tms_crs,
+            width,
+            height,
+            *bounds,
+        )
+    else:
+        transform = from_bounds(*bounds, width, height)
+
+    resolution = max(abs(transform[0]), abs(transform[4]))
+    return tms.zoom_for_res(resolution)
+
+
+class ArrayMetadata(TypedDict):
+    """Array Metadata."""
+
+    array: zarr.AsyncArray
+    crs: CRS
+    height: int
+    width: int
+    transform: Affine
+
+
+def calculate_output_transform(
+    crs: CRS,
+    bounds: BBox,
+    height: int,
+    width: int,
+    out_crs: CRS,
+    *,
+    out_bounds: BBox | None = None,
+    out_max_size: int | None = None,
+    out_height: int | None = None,
+    out_width: int | None = None,
+) -> Affine:
+    """Calculate Reprojected Dataset transform."""
+    # 1. get the `whole` reprojected dataset transfrom, shape and bounds
+    dst_transform, dst_width, dst_height = calculate_default_transform(
+        crs,
+        out_crs,
+        width,
+        height,
+        *bounds,
+    )
+
+    # If no bounds we assume the full dataset bounds
+    out_bounds = out_bounds or array_bounds(dst_height, dst_width, dst_transform)
+
+    # output Bounds
+    w, s, e, n = out_bounds
+
+    # adjust dataset virtual output shape/transform
+    dst_width = max(1, round((e - w) / dst_transform.a))
+    dst_height = max(1, round((s - n) / dst_transform.e))
+
+    # Output Transform in Output CRS
+    dst_transform = from_bounds(w, s, e, n, dst_width, dst_height)
+
+    # 2. adjust output size based on max_size if
+    # - not input width/height
+    # - max_size < dst_width and dst_height
+    if out_max_size:
+        out_height, out_width = _get_width_height(out_max_size, dst_height, dst_width)
+
+    elif out_height or out_width:
+        if not out_height or not out_width:
+            # get the size's ratio of the reprojected dataset
+            ratio = dst_height / dst_width
+            if out_width:
+                out_height = math.ceil(out_width * ratio)
+            else:
+                out_width = math.ceil(out_height / ratio)
+
+    out_height = out_height or dst_height
+    out_width = out_width or dst_width
+
+    # Get the transform in the Dataset CRS
+    transform, _, _ = calculate_default_transform(
+        out_crs,
+        crs,
+        out_width,
+        out_height,
+        *out_bounds,
+    )
+
+    return transform
+
+
+def get_target_resolution(
+    *,
+    input_crs: CRS,
+    output_crs: CRS,
+    input_height: int,
+    input_width: int,
+    input_transform: Affine,
+    output_bounds: BBox | None = None,
+    output_max_size: int | None = None,
+    output_height: int | None = None,
+    output_width: int | None = None,
+) -> float:
+    """Get Target Resolution."""
+    input_bounds = array_bounds(input_height, input_width, input_transform)
+
+    # Get Target expected resolution in Dataset CRS
+    # 1. Reprojection
+    if output_crs and output_crs != input_crs:
+        dst_transform = calculate_output_transform(
+            input_crs,
+            input_bounds,
+            input_height,
+            input_width,
+            output_crs,
+            # bounds is supposed to be in output_crs
+            out_bounds=output_bounds,
+            out_max_size=output_max_size,
+            out_height=output_height,
+            out_width=output_width,
+        )
+        return dst_transform.a
+
+    # 2. No Reprojection
+    # If no bounds we assume the full dataset bounds
+    bounds = output_bounds or input_bounds
+    window = window_from_bounds(*bounds, transform=input_transform)
+    if output_max_size:
+        output_height, output_width = _get_width_height(
+            output_max_size, round(window.height), round(window.width)
+        )
+
+    elif _missing_size(output_width, output_height):
+        ratio = window.height / window.width
+        if output_width:
+            output_height = math.ceil(output_width * ratio)
+        else:
+            output_width = math.ceil(output_height / ratio)
+
+    height = output_height or max(1, round(window.height))
+    width = output_width or max(1, round(window.width))
+    return from_bounds(*bounds, height=height, width=width).a
+
+
+def get_multiscale_level(
+    variable_metadata: list[ArrayMetadata],
+    target_res: float,
+    zoom_level_strategy: Literal["AUTO", "LOWER", "UPPER"] = "AUTO",
+) -> ArrayMetadata:
+    """Return the multiscale level corresponding to the desired resolution."""
+    ms_resolutions: list[tuple[float, ArrayMetadata]] = [
+        (min(abs(ms["transform"][0]), abs(ms["transform"][4])), ms)
+        for ms in variable_metadata
+    ]
+
+    # Based on aiocogeo:
+    # https://github.com/geospatial-jeff/aiocogeo/blob/5a1d32c3f22c883354804168a87abb0a2ea1c328/aiocogeo/partial_reads.py#L113-L147
+    percentage = {"AUTO": 50, "LOWER": 100, "UPPER": 0}.get(zoom_level_strategy, 50)
+
+    # Iterate over zoom levels from lowest/coarsest to highest/finest. If the `target_res` is more than `percentage`
+    # percent of the way from the zoom level below to the zoom level above, then upsample the zoom level below, else
+    # downsample the zoom level above.
+    available_resolutions = sorted(ms_resolutions, key=lambda x: x[0], reverse=True)
+    if len(available_resolutions) == 1:
+        return available_resolutions[0][1]
+
+    for i in range(0, len(available_resolutions) - 1):
+        res_current, _ = available_resolutions[i]
+        res_higher, _ = available_resolutions[i + 1]
+        threshold = res_higher - (res_higher - res_current) * (percentage / 100.0)
+        if target_res > threshold or target_res == res_current:
+            return available_resolutions[i][1]
+
+    # Default level is the first ms level
+    return ms_resolutions[0][1]
+
+
+@attr.s
+class GeoZarrReader(AsyncBaseReader):
+    """Rio-tiler GeoZarr Reader.
+
+    A pure zarr-python async reader that accepts a zarr AsyncGroup (GeoZarr)
+
+    Attributes:
+        input: zarr AsyncGroup
+        tms: TileMatrixSet for tile operations.
+        colormap: Optional colormap dictionary.
+
+    """
+
+    input: zarr.AsyncGroup = attr.ib()
+
+    tms: TileMatrixSet = attr.ib(default=WEB_MERCATOR_TMS)
+
+    crs: CRS = attr.ib(init=False)
+    transform: Affine = attr.ib(init=False)
+
+    # Group shape
+    height: int = attr.ib(init=False)
+    width: int = attr.ib(init=False)
+
+    # Group bounds (calculated from shape + transform)
+    bounds: BBox = attr.ib(init=False)
+
+    multiscales: bool = attr.ib(init=False)
+
+    colormap: dict | None = attr.ib(default=None)
+
+    # list of availables arrays in the group
+    _variables: dict[str, list[ArrayMetadata]] = attr.ib(init=False, default=None)
+
+    async def __aenter__(self):
+        """Support using with Context Managers."""
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        """Support using with Context Managers."""
+        pass
+
+    def __attrs_post_init__(self) -> None:
+        """Post init: derive height, width, count from array shape."""
+        spatial_dims = ["y", "x", "latitude", "longitude", "lat", "lon"]
+        spatial_shape: tuple[int, int] | None = None
+        transform: Affine | None = None
+
+        # NOTE: zarr-python says attrs is of type dict[str, JSON]
+        attributes = cast(dict[str, Any], self.input.attrs)
+        conventions: list[dict] = attributes.get("zarr_conventions", [])
+
+        self.multiscales = _has_multiscales(conventions)
+        # assert self.multiscales, "GeoZarr convention requires 'multiscales' convention to be present in zarr_conventions"
+
+        self.spatial = _has_spatial(conventions)
+        assert self.spatial, (
+            "GeoZarr convention requires 'spatial' convention to be present in zarr_conventions"
+        )
+
+        self.proj = _has_proj(conventions)
+        assert self.proj, (
+            "GeoZarr convention requires 'geo-proj' convention to be present in zarr_conventions"
+        )
+
+        # CRS
+        self.crs = _get_proj_crs(attributes)
+
+        # NOTE: `spatial:dimensions` is the only required attribute for the `spatial` convention
+        # but if this ever change we default to list of common spatial dimension names
+        spatial_dims = attributes.get("spatial:dimensions", spatial_dims)
+        spatial_shape = attributes.get("spatial:shape")
+
+        # Transform
+        # Case 1: Transform at group level
+        tr = attributes.get("spatial:transform")
+        transform_type = attributes.get("spatial:transform_type", "affine")
+        if transform_type == "affine" and tr is not None:
+            if attributes.get("spatial:registration", "pixel") == "node":
+                # NOTE: If the registration is "node", we need to adjust the transform to
+                # account for the fact that the coordinates refer to the center of the pixel rather than the edge.
+                tr[2] -= tr[0] / 2
+                tr[5] -= tr[4] / 2
+
+            transform = Affine(*tr)
+
+        # Case 2: No transform at group level, check multiscales for transform and shape
+        if not transform and self.multiscales:
+            # assume the first layout is the highest resolution
+            first_res = attributes["multiscales"]["layout"][0]
+            spatial_shape = first_res.get("spatial:shape")
+
+            tr = first_res.get("spatial:transform")
+            transform_type = attributes.get("spatial:transform_type", "affine")
+            if transform_type == "affine" and tr is not None:
+                if attributes.get("spatial:registration", "pixel") == "node":
+                    # NOTE: If the registration is "node", we need to adjust the transform to
+                    # account for the fact that the coordinates refer to the center of the pixel rather than the edge.
+                    tr[2] -= tr[0] / 2
+                    tr[5] -= tr[4] / 2
+
+                transform = Affine(*tr)
+
+        assert transform, (
+            "spatial:transform is required either at group level or in the first layout of multiscales convention"
+        )
+        self.transform = transform
+
+        # NOTE: we could potentially check for spatial:bbox and derive shape from it
+        assert spatial_shape, (
+            "spatial:shape is required either at group level or in the first layout of multiscales convention"
+        )
+        self.height = spatial_shape[0]
+        self.width = spatial_shape[1]
+
+        self.bounds = array_bounds(self.height, self.width, self.transform)
+
+    @property
+    def minzoom(self):
+        """Return dataset minzoom."""
+        if self.multiscales:
+            attributes = cast(dict[str, Any], self.input.attrs)
+            # assume the last layout is the lowest resolution
+            last_res = attributes["multiscales"]["layout"][-1]
+            shape = last_res.get("spatial:shape")
+            transform = last_res.get("spatial:transform")
+            if all([transform, shape]):
+                return _get_zoom(
+                    tms=self.tms,
+                    crs=self.crs,
+                    width=shape[1],
+                    height=shape[0],
+                    bounds=array_bounds(shape[0], shape[1], Affine(*transform)),
+                )
+
+        return self.maxzoom
+
+    @property
+    def maxzoom(self):
+        """Return dataset maxzoom."""
+        if self.multiscales:
+            attributes = cast(dict[str, Any], self.input.attrs)
+            # assume the last layout is the highest resolution
+            first_res = attributes["multiscales"]["layout"][0]
+            shape = first_res.get("spatial:shape")
+            transform = first_res.get("spatial:transform")
+            if all([transform, shape]):
+                return _get_zoom(
+                    tms=self.tms,
+                    crs=self.crs,
+                    width=shape[1],
+                    height=shape[0],
+                    bounds=array_bounds(shape[0], shape[1], Affine(*transform)),
+                )
+
+        return self._maxzoom
+
+    @property
+    async def variables(self) -> dict[str, list[ArrayMetadata]]:  # noqa: C901
+        """Return list of variables (arrays) with their geospatial metadata."""
+        if self._variables:
+            return self._variables
+
+        variables: dict[str, list[ArrayMetadata]] = {}
+        if self.multiscales:
+            attributes = cast(dict[str, Any], self.input.attrs)
+            conventions: list[dict] = attributes.get("zarr_conventions", [])
+
+            crs = _get_proj_crs(attributes) if _has_proj(conventions) else self.crs
+
+            # 1. Get MS groups + geospatial metadata (crs, transform)
+            ms_group: dict[str, dict[str, Any]] = {}
+            for layout in attributes["multiscales"]["layout"]:
+                transform_type = layout.get("spatial:transform_type") or "affine"
+                tr = layout.get("spatial:transform")
+                if transform_type == "affine" and tr is not None:
+                    if layout.get("spatial:registration", "pixel") == "node":
+                        # NOTE: If the registration is "node", we need to adjust the transform to
+                        # account for the fact that the coordinates refer to the center of the pixel rather than the edge.
+                        tr[2] -= tr[0] / 2
+                        tr[5] -= tr[4] / 2
+
+                ms_group[layout["asset"]] = {
+                    "crs": crs,
+                    "transform": tr,
+                }
+
+            # 2. list all arrays for each layout
+            for g, meta in ms_group.items():
+                group = await self.input.getitem(g)
+                async for array in group.array_values():
+                    # NOTE: skip non-data arrays
+                    # TODO: be smarter
+                    if array.ndim < 2:
+                        continue
+
+                    variable_name = array.name.replace(f"/{g}/", "")
+                    if variable_name not in variables:
+                        variables[variable_name] = []
+
+                    attributes = cast(dict[str, Any], array.attrs)
+                    transform = attributes.get("spatial:transform")
+                    transform_type = attributes.get("spatial:transform_type") or "affine"
+                    if transform_type == "affine" and transform is not None:
+                        if attributes.get("spatial:registration", "pixel") == "node":
+                            # NOTE: If the registration is "node", we need to adjust the transform to
+                            # account for the fact that the coordinates refer to the center of the pixel rather than the edge.
+                            transform[2] -= transform[0] / 2
+                            transform[5] -= transform[4] / 2
+
+                    transform = transform or meta["transform"]
+                    assert transform, (
+                        f"`spatial:transform` missing for multiscales layout {g} (path: '{array.name}')"
+                    )
+
+                    # TODO: is this always true
+                    height, width = array.shape[-2:]
+
+                    variables[variable_name].append(
+                        {
+                            "array": array,
+                            "crs": meta["crs"],
+                            "height": height,
+                            "width": width,
+                            "transform": Affine(*transform),
+                        }
+                    )
+
+        else:
+            async for array in self.input.array_values():
+                # NOTE: skip non-data arrays
+                # TODO: be smarter
+                if array.ndim < 2:
+                    continue
+
+                attributes = cast(dict[str, Any], array.attrs)
+                variable_name = array.name.replace(f"/{self.input.name}/", "")
+
+                transform = attributes.get("spatial:transform")
+                transform_type = attributes.get("spatial:transform_type") or "affine"
+                if transform_type == "affine" and transform is not None:
+                    if attributes.get("spatial:registration", "pixel") == "node":
+                        # NOTE: If the registration is "node", we need to adjust the transform to
+                        # account for the fact that the coordinates refer to the center of the pixel rather than the edge.
+                        transform[2] -= transform[0] / 2
+                        transform[5] -= transform[4] / 2
+
+                transform = transform or self.transform
+                assert transform, (
+                    f"`spatial:transform` missing for array {variable_name} (path: '{array.name}')"
+                )
+
+                # TODO: is this always true
+                height, width = array.shape[-2:]
+
+                variables[variable_name] = [
+                    {
+                        "array": array,
+                        "crs": self.crs,
+                        "height": height,
+                        "width": width,
+                        "transform": Affine(*transform),
+                    }
+                ]
+
+        self._variables = variables
+
+        return self._variables
+
+    def select_variable(
+        self,
+        variable_metadata: list[ArrayMetadata],
+        *,
+        # MultiScale Selection
+        bounds: BBox | None = None,
+        height: int | None = None,
+        width: int | None = None,
+        max_size: int | None = None,
+        dst_crs: CRS | None = None,
+    ) -> ArrayMetadata:
+        """Get DataArray from xarray Dataset."""
+        if max_size and (width or height):
+            warnings.warn(
+                "'max_size' will be ignored with with 'height' and 'width' set.",
+                UserWarning,
+                stacklevel=2,
+            )
+            max_size = None
+
+        # Default variable is the first one (hihhest resolution)
+        variable = variable_metadata[0]
+        if len(variable_metadata) == 1:
+            # NOTE: Only one variable, return it
+            return variable
+
+        # NOTE: Select a Multiscale Layer based on output resolution
+        if any([height, width, max_size]):
+            transform = variable["transform"]
+            layout_height = variable["height"]
+            layout_width = variable["width"]
+            crs = variable["crs"]
+
+            target_res = get_target_resolution(
+                input_crs=crs,
+                output_crs=dst_crs,
+                input_height=layout_height,
+                input_width=layout_width,
+                input_transform=transform,
+                output_bounds=bounds,
+                output_max_size=max_size,
+                output_height=height,
+                output_width=width,
+            )
+
+            variable = get_multiscale_level(variable_metadata, target_res)
+
+        return variable
+
+    async def info(self) -> Info:
+        """Return Dataset's info.
+
+        Returns:
+            rio_tile.models.Info: Dataset info.
+
+        """
+        raise NotImplementedError
+
+    async def statistics(self) -> dict[str, BandStatistics]:
+        """Return bands statistics from a dataset.
+
+        Returns:
+            dict[str, rio_tiler.models.BandStatistics]: bands statistics.
+
+        """
+        raise NotImplementedError
+
+    async def tile(self, tile_x: int, tile_y: int, tile_z: int) -> ImageData:
+        """Read a Map tile from the Dataset.
+
+        Args:
+            tile_x (int): Tile's horizontal index.
+            tile_y (int): Tile's vertical index.
+            tile_z (int): Tile's zoom level index.
+
+        Returns:
+            rio_tiler.models.ImageData: ImageData instance with data, mask and tile spatial info.
+
+        """
+        raise NotImplementedError
+
+    async def part(self, bbox: BBox) -> ImageData:
+        """Read a Part of a Dataset.
+
+        Args:
+            bbox (tuple): Output bounds (left, bottom, right, top) in target crs.
+
+        Returns:
+            rio_tiler.models.ImageData: ImageData instance with data, mask and input spatial info.
+
+        """
+        raise NotImplementedError
+
+    async def preview(
+        self,
+        variables: list[str] | str,
+        expression: str | None = None,
+        dst_crs: CRS | None = None,
+        max_size: int | None = 1024,
+        height: int | None = None,
+        width: int | None = None,
+        nodata: NoData | None = None,
+        resampling_method: RIOResampling = "nearest",
+        reproject_method: WarpResampling = "nearest",
+        **kwargs: Any,
+    ) -> ImageData:
+        """Read a preview of a Dataset.
+
+        Returns:
+            rio_tiler.models.ImageData: ImageData instance with data, mask and input spatial info.
+
+        """
+        availables_variables = await self.variables
+
+        variables = cast_to_sequence(variables)
+        if vars := set(variables).difference(availables_variables.keys()):
+            raise ValueError(
+                f"Variables {vars} not found in the dataset. Available variables: {list(availables_variables.keys())}"
+            )
+
+        async def _preview(variable: str) -> ImageData:
+            array_metadata = self.select_variable(
+                availables_variables[variable],
+                max_size=max_size,
+                height=height,
+                width=width,
+                dst_crs=dst_crs,
+            )
+
+            async with Reader(
+                input=array_metadata["array"],
+                transform=array_metadata["transform"],
+                crs=array_metadata["crs"],
+                tms=self.tms,
+            ) as src:
+                return await src.preview(
+                    max_size=max_size,
+                    height=height,
+                    width=width,
+                    dst_crs=dst_crs,
+                    nodata=nodata,
+                    resampling_method=resampling_method,
+                    reproject_method=reproject_method,
+                    **kwargs,
+                )
+
+        img_stack = await asyncio.gather(*(_preview(variable) for variable in variables))
+
+        img = ImageData.create_from_list(img_stack)
+        img.band_names = [f"b{ix + 1}" for ix in range(img.count)]
+        if expression:
+            return img.apply_expression(expression)
+
+        return img
+
+    async def point(self, lon: float, lat: float) -> PointData:
+        """Read a value from a Dataset.
+
+        Args:
+            lon (float): Longitude.
+            lat (float): Latitude.
+
+        Returns:
+            rio_tiler.models.PointData: PointData instance with data, mask and spatial info.
+
+        """
+        raise NotImplementedError
+
+    async def feature(self, shape: dict) -> ImageData:
+        """Read a Dataset for a GeoJSON feature.
+
+        Args:
+            shape (dict): Valid GeoJSON feature.
+
+        Returns:
+            rio_tiler.models.ImageData: ImageData instance with data, mask and input spatial info.
+
+        """
+        raise NotImplementedError

--- a/rio_tiler/experimental/zarr.py
+++ b/rio_tiler/experimental/zarr.py
@@ -1235,6 +1235,9 @@ class GeoZarrReader(AsyncBaseReader):
             # 2. list all arrays for each layout
             for group_name, meta in ms_group.items():
                 group = await self.input.getitem(group_name)
+
+                # NOTE: `ms_group` reference group names so we know `getitem` return a group
+                group = cast(zarr.AsyncGroup, group)
                 async for array in group.array_values():
                     # NOTE: skip non-data arrays
                     # TODO: be smarter

--- a/rio_tiler/experimental/zarr.py
+++ b/rio_tiler/experimental/zarr.py
@@ -1106,8 +1106,9 @@ class GeoZarrReader(AsyncBaseReader):
 
     def __attrs_post_init__(self) -> None:
         """Post init: derive height, width, count from array shape."""
-        # NOTE: zarr-python says attrs is of type dict[str, JSON]
-        attributes = cast(dict[str, Any], self.input.attrs)
+        assert isinstance(self.input, zarr.AsyncGroup), "Input must be a zarr AsyncGroup"
+
+        attributes = self.input.attrs
         conventions: list[dict] = attributes.get("zarr_conventions", [])
 
         # Default CRS/Bounds for a Zarr Store
@@ -1138,22 +1139,23 @@ class GeoZarrReader(AsyncBaseReader):
                 # assume the first layout is the highest resolution
                 first_res = attributes["multiscales"]["layout"][0]
 
-                if bbox := attributes.get("spatial:bbox"):
+                if bbox := first_res.get("spatial:bbox"):
                     bounds = bounds or bbox
 
                 transform = transform or _get_transform(first_res)
 
-                if spatial_shape := attributes.get("spatial:shape"):
+                if spatial_shape := first_res.get("spatial:shape"):
                     height = height or spatial_shape[0]
                     width = width or spatial_shape[1]
 
             if not bounds and all([width, height, transform]):
                 bounds = array_bounds(height, width, transform)
 
-            if all([transform, bounds]):
+            if bounds:
                 self.crs = crs
-                self.transform = transform
                 self.bounds = bounds
+                if transform:
+                    self.transform = transform
 
             if all([height, width]):
                 self.height = height
@@ -1162,15 +1164,16 @@ class GeoZarrReader(AsyncBaseReader):
     @property
     def minzoom(self) -> int:
         """Return dataset minzoom."""
-        attributes = cast(dict[str, Any], self.input.attrs)
-        conventions: list[dict] = attributes.get("zarr_conventions", [])
-
+        conventions: list[dict] = self.input.attrs.get("zarr_conventions", [])
         if _has_multiscales(conventions):
-            attributes = cast(dict[str, Any], self.input.attrs)
-            # assume the last layout is the lowest resolution
-            last_res = attributes["multiscales"]["layout"][-1]
+            # NOTE: assume the last layout is the lowest resolution
+            last_res = self.input.attrs["multiscales"]["layout"][-1]
+
+            # NOTE: assume `spatial:shape` and `spatial:transform` are provided
+            # at the layout level (if not present at group level)
             shape = last_res.get("spatial:shape")
             transform = _get_transform(last_res)
+
             if all([transform, shape]):
                 return _get_zoom(
                     tms=self.tms,
@@ -1185,15 +1188,16 @@ class GeoZarrReader(AsyncBaseReader):
     @property
     def maxzoom(self) -> int:
         """Return dataset maxzoom."""
-        attributes = cast(dict[str, Any], self.input.attrs)
-        conventions: list[dict] = attributes.get("zarr_conventions", [])
-
+        conventions: list[dict] = self.input.attrs.get("zarr_conventions", [])
         if _has_multiscales(conventions):
-            attributes = cast(dict[str, Any], self.input.attrs)
-            # assume the last layout is the highest resolution
-            first_res = attributes["multiscales"]["layout"][0]
+            # NOTE: assume the last layout is the highest resolution
+            first_res = self.input.attrs["multiscales"]["layout"][0]
+
+            # NOTE: assume `spatial:shape` and `spatial:transform` are provided
+            # at the layout level (if not present at group level)
             shape = first_res.get("spatial:shape")
             transform = _get_transform(first_res)
+
             if all([transform, shape]):
                 return _get_zoom(
                     tms=self.tms,
@@ -1382,6 +1386,9 @@ class GeoZarrReader(AsyncBaseReader):
             return self._groups[group]
 
         g = self.input if group == "root" else await self.input.getitem(group)
+        assert isinstance(g, zarr.AsyncGroup), (
+            f"Group '{group}' not found in the Zarr store."
+        )
 
         arrays: dict[str, list[ArrayMetadata]] = {}
 
@@ -1389,135 +1396,101 @@ class GeoZarrReader(AsyncBaseReader):
         root_transform: Affine | None = None
         root_bbox: BBox | None = None
 
-        # NOTE: root is an Array
-        if isinstance(g, zarr.AsyncArray):
-            attributes = cast(dict[str, Any], g.attrs)
-            conventions = attributes.get("zarr_conventions", [])
-            if _has_proj(conventions):
-                root_crs = _get_proj_crs(attributes)
+        conventions = g.attrs.get("zarr_conventions", [])
+        # Top Level spatial/geo metadata
+        # 1. Group level metadata (crs, transform)
+        if _has_proj(conventions):
+            root_crs = _get_proj_crs(g.attrs)
 
-            if _has_spatial(conventions):
-                root_transform = _get_transform(attributes)
-                root_bbox = attributes.get("spatial:bbox")
+        if _has_spatial(conventions):
+            root_transform = _get_transform(g.attrs)
+            root_bbox = g.attrs.get("spatial:bbox")
 
-            # TODO: is this always true ?
-            height, width = g.shape[-2:]
+        group_is_multiscale = _has_multiscales(conventions)
+        if group_is_multiscale:
+            # NOTE: We assume a group with multiscale should have geo-proj convention
+            assert root_crs, (
+                f"`proj:code` missing for multiscales group '{g.name}' metadata"
+            )
 
-            if all([root_crs, root_transform]):
-                arrays["/"] = [
-                    {
-                        "array": g,
-                        "crs": root_crs,
-                        "height": height,
-                        "width": width,
-                        "transform": root_transform,
-                    }
-                ]
+            # 1. Multiscales metadata
+            ms_group: dict[str, dict[str, Any]] = {}
+            for layout in g.attrs["multiscales"]["layout"]:
+                ms_group[layout["asset"]] = {
+                    "transform": _get_transform(layout),
+                }
 
-            self._groups[group] = {
-                "crs": root_crs,
-                "bbox": root_bbox,
-                "transform": root_transform,
-                "arrays": arrays,
-                "multiscale": False,
-            }
+            # 2. list all arrays for each layout
+            for group_name, meta in ms_group.items():
+                msgroup = await g.getitem(group_name)
 
-        else:
-            conventions = g.attrs.get("zarr_conventions", [])
-            # Top Level spatial/geo metadata
-            # 1. Group level metadata (crs, transform)
-            if _has_proj(conventions):
-                root_crs = _get_proj_crs(g.attrs)
-
-            if _has_spatial(conventions):
-                root_transform = _get_transform(g.attrs)
-                root_bbox = g.attrs.get("spatial:bbox")
-
-            group_is_multiscale = _has_multiscales(conventions)
-            if group_is_multiscale:
-                # NOTE: We assume a group with multiscale should have geo-proj convention
-                assert root_crs, (
-                    f"`proj:code` missing for multiscales group '{g.name}' metadata"
-                )
-
-                # 1. Multiscales metadata
-                ms_group: dict[str, dict[str, Any]] = {}
-                for layout in g.attrs["multiscales"]["layout"]:
-                    ms_group[layout["asset"]] = {
-                        "transform": _get_transform(layout),
-                    }
-
-                # 2. list all arrays for each layout
-                for group_name, meta in ms_group.items():
-                    msgroup = await g.getitem(group_name)
-
-                    # NOTE: `ms_group` reference group names so we know `getitem` return a group
-                    msgroup = cast(zarr.AsyncGroup, msgroup)
-                    async for array in msgroup.array_values():
-                        # NOTE: skip non-data arrays
-                        # TODO: be smarter
-                        if array.ndim < 2:
-                            continue
-
-                        variable_name = array.name.split("/")[-1]
-                        if variable_name not in arrays:
-                            arrays[variable_name] = []
-
-                        # NOTE: Transform from the array or the multiscale layout
-                        transform = _get_transform(array.attrs) or meta["transform"]
-                        assert transform, (
-                            f"`spatial:transform` missing for multiscales layout {group_name} (path: '{array.name}')"
-                        )
-
-                        # TODO: is this always true ?
-                        height, width = array.shape[-2:]
-
-                        arrays[variable_name].append(
-                            {
-                                "array": array,
-                                "crs": root_crs,
-                                "height": height,
-                                "width": width,
-                                "transform": transform,
-                            }
-                        )
-
-            else:
-                # List arrays in group
-                async for array in g.array_values():
-                    array_crs: CRS | None = None
-                    array_transform: Affine | None = None
-
+                # NOTE: `ms_group` reference group names so we know `getitem` return a group
+                msgroup = cast(zarr.AsyncGroup, msgroup)
+                async for array in msgroup.array_values():
                     # NOTE: skip non-data arrays
                     # TODO: be smarter
                     if array.ndim < 2:
                         continue
 
-                    attributes = cast(dict[str, Any], array.attrs)
-                    conventions = attributes.get("zarr_conventions", [])
-                    if _has_proj(conventions):
-                        array_crs = _get_proj_crs(attributes)
+                    variable_name = array.name.split("/")[-1]
+                    if variable_name not in arrays:
+                        arrays[variable_name] = []
 
-                    if _has_spatial(conventions):
-                        array_transform = _get_transform(attributes)
-
-                    array_crs = array_crs or root_crs
-                    array_transform = array_transform or root_transform
+                    # NOTE: Transform from the array or the multiscale layout
+                    transform = _get_transform(array.attrs) or meta["transform"]
+                    assert transform, (
+                        f"`spatial:transform` missing for multiscales layout {group_name} (path: '{array.name}')"
+                    )
 
                     # TODO: is this always true ?
                     height, width = array.shape[-2:]
 
-                    if all([array_crs, array_transform]):
-                        array_name = array.name.replace(f"{g.name}/", "")
-                        arrays[array_name] = [
-                            {
-                                "array": array,
-                                "crs": array_crs,
-                                "height": height,
-                                "width": width,
-                                "transform": array_transform,
-                            }
-                        ]
+                    arrays[variable_name].append(
+                        {
+                            "array": array,
+                            "crs": root_crs,
+                            "height": height,
+                            "width": width,
+                            "transform": transform,
+                        }
+                    )
+
+        else:
+            # List arrays in group
+            async for array in g.array_values():
+                array_crs: CRS | None = None
+                array_transform: Affine | None = None
+
+                # NOTE: skip non-data arrays
+                # TODO: be smarter
+                if array.ndim < 2:
+                    continue
+
+                attributes = cast(dict[str, Any], array.attrs)
+                conventions = attributes.get("zarr_conventions", [])
+                if _has_proj(conventions):
+                    array_crs = _get_proj_crs(attributes)
+
+                if _has_spatial(conventions):
+                    array_transform = _get_transform(attributes)
+
+                array_crs = array_crs or root_crs
+                array_transform = array_transform or root_transform
+
+                # TODO: is this always true ?
+                height, width = array.shape[-2:]
+
+                if all([array_crs, array_transform]):
+                    array_name = array.name.replace(f"{g.name}/", "")
+                    arrays[array_name] = [
+                        {
+                            "array": array,
+                            "crs": array_crs,
+                            "height": height,
+                            "width": width,
+                            "transform": array_transform,
+                        }
+                    ]
 
             self._groups[group] = {
                 "crs": root_crs,

--- a/rio_tiler/experimental/zarr.py
+++ b/rio_tiler/experimental/zarr.py
@@ -1379,13 +1379,14 @@ class GeoZarrReader(AsyncBaseReader):
 
     async def statistics(
         self,
+        *,
         variables: Sequence[str] | str | None = None,
+        expression: str | None = None,
         categorical: bool = False,
         categories: list[float] | None = None,
         percentiles: list[int] | None = None,
         hist_options: dict | None = None,
         max_size: int | None = 1024,
-        expression: str | None = None,
         nodata: NoData | None = None,
         **kwargs: Any,
     ) -> dict[str, BandStatistics]:
@@ -1437,8 +1438,8 @@ class GeoZarrReader(AsyncBaseReader):
         tile_z: int,
         *,
         variables: Sequence[str] | str,
-        tilesize: int | None = None,
         expression: str | None = None,
+        tilesize: int | None = None,
         nodata: NoData | None = None,
         reproject_method: WarpResampling = "nearest",
         **kwargs: Any,
@@ -1610,7 +1611,17 @@ class GeoZarrReader(AsyncBaseReader):
 
         return img
 
-    async def point(self, lon: float, lat: float) -> PointData:
+    async def point(  # type: ignore[override]
+        self,
+        lon: float,
+        lat: float,
+        *,
+        variables: Sequence[str] | str,
+        expression: str | None = None,
+        coord_crs: CRS = WGS84_CRS,
+        nodata: NoData | None = None,
+        **kwargs: Any,
+    ) -> PointData:
         """Read a value from a Dataset.
 
         Args:
@@ -1621,9 +1632,53 @@ class GeoZarrReader(AsyncBaseReader):
             rio_tiler.models.PointData: PointData instance with data, mask and spatial info.
 
         """
-        raise NotImplementedError
+        availables_variables = await self.variables
 
-    async def feature(self, shape: dict) -> ImageData:
+        variables = cast_to_sequence(variables)
+        if vars := set(variables).difference(availables_variables.keys()):
+            raise ValueError(
+                f"Variables {vars} not found in the dataset. Available variables: {list(availables_variables.keys())}"
+            )
+
+        async def _point(variable: str) -> PointData:
+            array_metadata = self.select_variable(availables_variables[variable])
+            async with Reader(
+                input=array_metadata["array"],
+                transform=array_metadata["transform"],
+                crs=array_metadata["crs"],
+                tms=self.tms,
+            ) as src:
+                return await src.point(
+                    lon,
+                    lat,
+                    coord_crs=coord_crs,
+                    nodata=nodata,
+                )
+
+        point_stack = await asyncio.gather(*(_point(variable) for variable in variables))
+
+        pt = PointData.create_from_list(point_stack)
+        pt.band_names = [f"b{ix + 1}" for ix in range(pt.count)]
+        if expression:
+            return pt.apply_expression(expression)
+
+        return pt
+
+    async def feature(  # type: ignore[override]
+        self,
+        shape: dict,
+        *,
+        variables: Sequence[str] | str,
+        dst_crs: CRS | None = None,
+        shape_crs: CRS = WGS84_CRS,
+        expression: str | None = None,
+        max_size: int | None = None,
+        height: int | None = None,
+        width: int | None = None,
+        nodata: NoData | None = None,
+        reproject_method: WarpResampling = "nearest",
+        **kwargs: Any,
+    ) -> ImageData:
         """Read a Dataset for a GeoJSON feature.
 
         Args:
@@ -1633,4 +1688,55 @@ class GeoZarrReader(AsyncBaseReader):
             rio_tiler.models.ImageData: ImageData instance with data, mask and input spatial info.
 
         """
-        raise NotImplementedError
+        availables_variables = await self.variables
+
+        variables = cast_to_sequence(variables)
+        if vars := set(variables).difference(availables_variables.keys()):
+            raise ValueError(
+                f"Variables {vars} not found in the dataset. Available variables: {list(availables_variables.keys())}"
+            )
+
+        shape = _validate_shape_input(shape)
+
+        if not dst_crs:
+            dst_crs = shape_crs
+
+        # Get BBOX of the polygon
+        bbox = featureBounds(shape)
+
+        img = await self.part(
+            bbox,
+            variables=variables,
+            dst_crs=dst_crs,
+            bounds_crs=shape_crs,
+            expression=expression,
+            max_size=max_size,
+            height=height,
+            width=width,
+            nodata=nodata,
+            reproject_method=reproject_method,
+        )
+
+        if dst_crs != shape_crs:
+            shape = transform_geom(shape_crs, dst_crs, shape)
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                category=NotGeoreferencedWarning,
+                module="rasterio",
+            )
+            cutline_mask = rasterize(
+                [shape],
+                out_shape=(img.height, img.width),
+                transform=img.transform,
+                all_touched=True,  # Mandatory for matching masks at different resolutions
+                default_value=0,
+                fill=1,
+                dtype="uint8",
+            ).astype("bool")
+
+        img.cutline_mask = cutline_mask
+        img.array.mask = numpy.where(~cutline_mask, img.array.mask, True)
+
+        return img

--- a/rio_tiler/experimental/zarr.py
+++ b/rio_tiler/experimental/zarr.py
@@ -1198,8 +1198,12 @@ class GeoZarrReader(AsyncBaseReader):
         # NOTE: By construction we know that if `self.transform` is set
         # self.bounds and self.crs are also comming from the zarr attributes.
         if self.transform:
-            w = self.width or 1
-            h = self.height or 1
+            w = self.width
+            h = self.height
+            if not self.width or not self.height:
+                w = round((self.bounds[2] - self.bounds[0]) / abs(self.transform.a))
+                h = round((self.bounds[3] - self.bounds[1]) / abs(self.transform.e))
+
             dst_affine = self.transform
             tms_crs = self.tms.rasterio_crs
             if self.crs != tms_crs:
@@ -1473,7 +1477,7 @@ class GeoZarrReader(AsyncBaseReader):
                 height, width = array.shape[-2:]
 
                 if all([array_crs, array_transform]):
-                    array_name = array.name.replace(f"{g.name}/", "")
+                    array_name = array.name.replace(f"{g.name}/", "").lstrip("/")
                     arrays[array_name] = [
                         {
                             "array": array,

--- a/rio_tiler/experimental/zarr.py
+++ b/rio_tiler/experimental/zarr.py
@@ -1193,21 +1193,25 @@ class GeoZarrReader(AsyncBaseReader):
                     bounds=array_bounds(shape[0], shape[1], transform),
                 )
 
-        if not all([self.bounds, self.width, self.height]):
+        # NOTE: By construction we know that if `self.transform` is set
+        # self.bounds and self.crs are also comming from the zarr attributes.
+        if self.transform:
+            w = self.width or 1
+            h = self.height or 1
             dst_affine = self.transform
             tms_crs = self.tms.rasterio_crs
             if self.crs != tms_crs:
                 dst_affine, _, _ = calculate_default_transform(
                     self.crs,
                     self.tms.rasterio_crs,
-                    1,
-                    1,
+                    w,
+                    h,
                     *self.bounds,
                 )
             resolution = max(abs(dst_affine[0]), abs(dst_affine[4]))
             return self.tms.zoom_for_res(resolution)
 
-        return self._maxzoom
+        return self.tms.maxzoom
 
     def parse_variable(self, variable: str) -> tuple[str, str, Any | None]:
         """Parse variable name into group, variable and options."""

--- a/rio_tiler/experimental/zarr.py
+++ b/rio_tiler/experimental/zarr.py
@@ -240,7 +240,7 @@ class Reader(AsyncBaseReader):
             "nodata_type": nodata_type,
             "colorinterp": None,
             # additional info (not in default model)
-            "driver": "Zarr",
+            "driver": "Zarr-Python",
             "count": self.nbands,
             "width": self.width,
             "height": self.height,
@@ -1048,6 +1048,7 @@ def get_multiscale_level(
 class GeoZarrInfo(Bounds):
     """GeoZarr Info."""
 
+    driver: str
     variables: list[str]
     attributes: dict[str, Any]
 
@@ -1110,15 +1111,14 @@ class GeoZarrReader(AsyncBaseReader):
             crs = _get_proj_crs(attributes)
 
             if bbox := attributes.get("spatial:bbox"):
-                bounds = bbox
+                bounds = tuple(bbox)
 
             # Transform
             # Case 1: Transform at group level
             transform = _get_transform(attributes)
 
             if spatial_shape := attributes.get("spatial:shape"):
-                height = spatial_shape[0]
-                width = spatial_shape[1]
+                height, width = spatial_shape[-2:]
 
             # Case 2: check multiscales for transform and shape
             if _has_multiscales(conventions):
@@ -1131,8 +1131,9 @@ class GeoZarrReader(AsyncBaseReader):
                 transform = transform or _get_transform(first_res)
 
                 if spatial_shape := first_res.get("spatial:shape"):
-                    height = height or spatial_shape[0]
-                    width = width or spatial_shape[1]
+                    h, w = spatial_shape[-2:]
+                    height = height or h
+                    width = width or w
 
             if not bounds and all([width, height, transform]):
                 bounds = array_bounds(height, width, transform)
@@ -1157,17 +1158,19 @@ class GeoZarrReader(AsyncBaseReader):
 
             # NOTE: assume `spatial:shape` and `spatial:transform` are provided
             # at the layout level (if not present at group level)
-            shape = last_res.get("spatial:shape")
             transform = _get_transform(last_res)
-
-            if all([transform, shape]):
+            if transform and (spatial_shape := last_res.get("spatial:shape")):
+                height, width = spatial_shape[-2:]
                 return _get_zoom(
                     tms=self.tms,
                     crs=self.crs,
-                    width=shape[1],
-                    height=shape[0],
-                    bounds=array_bounds(shape[0], shape[1], transform),
+                    width=width,
+                    height=height,
+                    bounds=array_bounds(height, width, transform),
                 )
+
+        if not self.transform:
+            return self.tms.minzoom
 
         return self.maxzoom
 
@@ -1181,16 +1184,15 @@ class GeoZarrReader(AsyncBaseReader):
 
             # NOTE: assume `spatial:shape` and `spatial:transform` are provided
             # at the layout level (if not present at group level)
-            shape = first_res.get("spatial:shape")
             transform = _get_transform(first_res)
-
-            if all([transform, shape]):
+            if transform and (spatial_shape := first_res.get("spatial:shape")):
+                height, width = spatial_shape[-2:]
                 return _get_zoom(
                     tms=self.tms,
                     crs=self.crs,
-                    width=shape[1],
-                    height=shape[0],
-                    bounds=array_bounds(shape[0], shape[1], transform),
+                    width=width,
+                    height=height,
+                    bounds=array_bounds(height, width, transform),
                 )
 
         # NOTE: By construction we know that if `self.transform` is set
@@ -1482,13 +1484,13 @@ class GeoZarrReader(AsyncBaseReader):
                         }
                     ]
 
-            self._groups[group] = {
-                "crs": root_crs,
-                "bbox": root_bbox,
-                "transform": root_transform,
-                "multiscale": group_is_multiscale,
-                "arrays": arrays,
-            }
+        self._groups[group] = {
+            "crs": root_crs,
+            "bbox": root_bbox,
+            "transform": root_transform,
+            "multiscale": group_is_multiscale,
+            "arrays": arrays,
+        }
 
         return self._groups[group]
 
@@ -1556,7 +1558,7 @@ class GeoZarrReader(AsyncBaseReader):
             "bounds": self.bounds,
             "crs": CRS_to_uri(self.crs) or self.crs.to_wkt(),
             # additional info (not in default model)
-            "driver": "GeoZARR",
+            "driver": "Zarr-Python",
             "variables": availables_variables,
             "attributes": {
                 k: (v.tolist() if isinstance(v, (numpy.ndarray, numpy.generic)) else v)

--- a/rio_tiler/experimental/zarr.py
+++ b/rio_tiler/experimental/zarr.py
@@ -1084,8 +1084,8 @@ class GeoZarrReader(AsyncBaseReader):
     transform: Affine = attr.ib(init=False)
 
     # Group shape
-    height: int = attr.ib(init=False)
-    width: int = attr.ib(init=False)
+    height: int = attr.ib(init=False, default=None)
+    width: int = attr.ib(init=False, default=None)
 
     # Group bounds (calculated from shape + transform)
     bounds: BBox = attr.ib(init=False)

--- a/rio_tiler/experimental/zarr.py
+++ b/rio_tiler/experimental/zarr.py
@@ -44,36 +44,28 @@ from rio_tiler.utils import (
     cast_to_sequence,
 )
 
+MULTISCALE_CONVENTION_UUID = "d35379db-88df-4056-af3a-620245f8e347"
+SPATIAL_CONVENTION_UUID = "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4"
+PROJ_CONVENTION_UUID = "f17cb550-5864-4468-aeb7-f3180cfb622f"
+
 
 def _has_multiscales(conventions: list[dict]) -> bool:
     return next(
-        (
-            True
-            for c in conventions
-            if c["uuid"] == "d35379db-88df-4056-af3a-620245f8e347"
-        ),
+        (True for c in conventions if c["uuid"] == MULTISCALE_CONVENTION_UUID),
         False,
     )
 
 
 def _has_spatial(conventions: list[dict]) -> bool:
     return next(
-        (
-            True
-            for c in conventions
-            if c["uuid"] == "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4"
-        ),
+        (True for c in conventions if c["uuid"] == SPATIAL_CONVENTION_UUID),
         False,
     )
 
 
 def _has_proj(conventions: list[dict]) -> bool:
     return next(
-        (
-            True
-            for c in conventions
-            if c["uuid"] == "f17cb550-5864-4468-aeb7-f3180cfb622f"
-        ),
+        (True for c in conventions if c["uuid"] == PROJ_CONVENTION_UUID),
         False,
     )
 
@@ -117,7 +109,6 @@ class Reader(AsyncBaseReader):
         crs: Coordinate reference system.
         transform: Affine transform.
         tms: TileMatrixSet for tile operations.
-        colormap: Optional colormap dictionary.
 
     Note:
         For 3D arrays, expects bands-first layout (bands, height, width).
@@ -142,8 +133,6 @@ class Reader(AsyncBaseReader):
 
     # List of names for the first dimension (e.g time, bands, etc)
     band_names: list[str] | None = attr.ib(default=None)
-
-    colormap: dict | None = attr.ib(default=None)
 
     async def __aenter__(self):
         """Support using with Context Managers."""
@@ -1072,7 +1061,6 @@ class GeoZarrReader(AsyncBaseReader):
     Attributes:
         input: zarr AsyncGroup
         tms: TileMatrixSet for tile operations.
-        colormap: Optional colormap dictionary.
 
     """
 
@@ -1089,8 +1077,6 @@ class GeoZarrReader(AsyncBaseReader):
 
     # Group bounds (calculated from shape + transform)
     bounds: BBox = attr.ib(init=False)
-
-    colormap: dict | None = attr.ib(default=None)
 
     # list of availables the groups with variables (used for cache)
     _groups: dict[str, GroupMetadata] = attr.ib(init=False, factory=dict)
@@ -1190,7 +1176,7 @@ class GeoZarrReader(AsyncBaseReader):
         """Return dataset maxzoom."""
         conventions: list[dict] = self.input.attrs.get("zarr_conventions", [])
         if _has_multiscales(conventions):
-            # NOTE: assume the last layout is the highest resolution
+            # NOTE: assume the first layout is the highest resolution
             first_res = self.input.attrs["multiscales"]["layout"][0]
 
             # NOTE: assume `spatial:shape` and `spatial:transform` are provided
@@ -1223,6 +1209,14 @@ class GeoZarrReader(AsyncBaseReader):
 
         return self._maxzoom
 
+    def parse_variable(self, variable: str) -> tuple[str, str, Any | None]:
+        """Parse variable name into group, variable and options."""
+        group_name = "root"
+        if ":" in variable:
+            group_name, variable = variable.split(":")[0:2]
+
+        return group_name, variable, None
+
     async def get_bounds(
         self,
         *,
@@ -1233,9 +1227,7 @@ class GeoZarrReader(AsyncBaseReader):
         variables = cast_to_sequence(variables)
 
         async def _get_bounds(variable: str) -> BBox:
-            group_name = "root"
-            if ":" in variable:
-                group_name, variable = variable.split(":", 1)
+            group_name, variable, _ = self.parse_variable(variable)
 
             group_metadata = await self.get_group_metadata(group_name)
             array = group_metadata["arrays"].get(variable)
@@ -1275,10 +1267,7 @@ class GeoZarrReader(AsyncBaseReader):
         variables = cast_to_sequence(variables)
 
         async def _get_minzoom(variable: str) -> int:
-            group_name = "root"
-            if ":" in variable:
-                group_name, variable = variable.split(":", 1)
-
+            group_name, variable, _ = self.parse_variable(variable)
             group_metadata = await self.get_group_metadata(group_name)
             array = group_metadata["arrays"].get(variable)
             if not array:
@@ -1312,10 +1301,7 @@ class GeoZarrReader(AsyncBaseReader):
         variables = cast_to_sequence(variables)
 
         async def _get_maxzoom(variable: str) -> int:
-            group_name = "root"
-            if ":" in variable:
-                group_name, variable = variable.split(":", 1)
-
+            group_name, variable, _ = self.parse_variable(variable)
             group_metadata = await self.get_group_metadata(group_name)
             array = group_metadata["arrays"].get(variable)
             if not array:
@@ -1698,10 +1684,7 @@ class GeoZarrReader(AsyncBaseReader):
         variables = cast_to_sequence(variables)
 
         async def _part(variable: str) -> ImageData:
-            group_name = "root"
-            if ":" in variable:
-                group_name, variable = variable.split(":", 1)
-
+            group_name, variable, _ = self.parse_variable(variable)
             group_metadata = await self.get_group_metadata(group_name)
             array = group_metadata["arrays"].get(variable)
             if not array:
@@ -1765,10 +1748,7 @@ class GeoZarrReader(AsyncBaseReader):
         variables = cast_to_sequence(variables)
 
         async def _preview(variable: str) -> ImageData:
-            group_name = "root"
-            if ":" in variable:
-                group_name, variable = variable.split(":", 1)
-
+            group_name, variable, _ = self.parse_variable(variable)
             group_metadata = await self.get_group_metadata(group_name)
             array = group_metadata["arrays"].get(variable)
             if not array:
@@ -1833,10 +1813,7 @@ class GeoZarrReader(AsyncBaseReader):
         variables = cast_to_sequence(variables)
 
         async def _point(variable: str) -> PointData:
-            group_name = "root"
-            if ":" in variable:
-                group_name, variable = variable.split(":", 1)
-
+            group_name, variable, _ = self.parse_variable(variable)
             group_metadata = await self.get_group_metadata(group_name)
             array = group_metadata["arrays"].get(variable)
             if not array:

--- a/rio_tiler/experimental/zarr.py
+++ b/rio_tiler/experimental/zarr.py
@@ -1233,19 +1233,19 @@ class GeoZarrReader(AsyncBaseReader):
                 }
 
             # 2. list all arrays for each layout
-            for g, meta in ms_group.items():
-                group = await self.input.getitem(g)
+            for group_name, meta in ms_group.items():
+                group = await self.input.getitem(group_name)
                 async for array in group.array_values():
                     # NOTE: skip non-data arrays
                     # TODO: be smarter
                     if array.ndim < 2:
                         continue
 
-                    variable_name = array.name.replace(f"/{g}/", "")
+                    attributes = cast(dict[str, Any], array.attrs)
+                    variable_name = array.name.replace(f"/{group_name}/", "")
                     if variable_name not in variables:
                         variables[variable_name] = []
 
-                    attributes = cast(dict[str, Any], array.attrs)
                     transform = attributes.get("spatial:transform")
                     transform_type = attributes.get("spatial:transform_type") or "affine"
                     if transform_type == "affine" and transform is not None:
@@ -1257,7 +1257,7 @@ class GeoZarrReader(AsyncBaseReader):
 
                     transform = transform or meta["transform"]
                     assert transform, (
-                        f"`spatial:transform` missing for multiscales layout {g} (path: '{array.name}')"
+                        f"`spatial:transform` missing for multiscales layout {group_name} (path: '{array.name}')"
                     )
 
                     # TODO: is this always true
@@ -1275,13 +1275,15 @@ class GeoZarrReader(AsyncBaseReader):
 
         else:
             async for array in self.input.array_values():
+                group_name = self.input.name
+
                 # NOTE: skip non-data arrays
                 # TODO: be smarter
                 if array.ndim < 2:
                     continue
 
                 attributes = cast(dict[str, Any], array.attrs)
-                variable_name = array.name.replace(f"/{self.input.name}/", "")
+                variable_name = array.name.replace(f"/{group_name}/", "")
 
                 transform = attributes.get("spatial:transform")
                 transform_type = attributes.get("spatial:transform_type") or "affine"
@@ -1309,6 +1311,9 @@ class GeoZarrReader(AsyncBaseReader):
                         "transform": Affine(*transform),
                     }
                 ]
+
+        if not variables:
+            raise ValueError("No variables (data arrays) found in the dataset.")
 
         self._variables = variables
 
@@ -1372,16 +1377,72 @@ class GeoZarrReader(AsyncBaseReader):
         """
         raise NotImplementedError
 
-    async def statistics(self) -> dict[str, BandStatistics]:
+    async def statistics(
+        self,
+        variables: Sequence[str] | str | None = None,
+        categorical: bool = False,
+        categories: list[float] | None = None,
+        percentiles: list[int] | None = None,
+        hist_options: dict | None = None,
+        max_size: int | None = 1024,
+        expression: str | None = None,
+        nodata: NoData | None = None,
+        **kwargs: Any,
+    ) -> dict[str, BandStatistics]:
         """Return bands statistics from a dataset.
+
+        Args:
+            variables (list of str or str, optional): list of variables to return value for. Defaults to all variables.
+            categorical (bool): treat input data as categorical data. Defaults to False.
+            categories (list of numbers, optional): list of categories to return value for.
+            percentiles (list of numbers, optional): list of percentile values to calculate. Defaults to `[2, 98]`.
+            hist_options (dict, optional): Options to forward to numpy.histogram function.
+            max_size (int, optional): Limit the size of the longest dimension of the dataset read, respecting bounds X/Y aspect ratio. Defaults to 1024.
+            expression (str, optional): rio-tiler expression (e.g. b1/b2+b3).
+            kwargs (optional): Options to forward to `self.preview`.
 
         Returns:
             dict[str, rio_tiler.models.BandStatistics]: bands statistics.
 
         """
-        raise NotImplementedError
+        availables_variables = await self.variables
 
-    async def tile(self, tile_x: int, tile_y: int, tile_z: int) -> ImageData:
+        variables = variables or list(availables_variables.keys())
+
+        variables = cast_to_sequence(variables)
+        if vars := set(variables).difference(availables_variables.keys()):
+            raise ValueError(
+                f"Variables {vars} not found in the dataset. Available variables: {list(availables_variables.keys())}"
+            )
+
+        img = await self.preview(
+            variables=variables,
+            expression=expression,
+            max_size=max_size,
+            nodata=nodata,
+            **kwargs,
+        )
+
+        return img.statistics(
+            categorical=categorical,
+            categories=categories,
+            percentiles=percentiles,
+            hist_options=hist_options,
+        )
+
+    async def tile(  # type: ignore[override]
+        self,
+        tile_x: int,
+        tile_y: int,
+        tile_z: int,
+        *,
+        variables: Sequence[str] | str,
+        tilesize: int | None = None,
+        expression: str | None = None,
+        nodata: NoData | None = None,
+        reproject_method: WarpResampling = "nearest",
+        **kwargs: Any,
+    ) -> ImageData:
         """Read a Map tile from the Dataset.
 
         Args:
@@ -1393,23 +1454,103 @@ class GeoZarrReader(AsyncBaseReader):
             rio_tiler.models.ImageData: ImageData instance with data, mask and tile spatial info.
 
         """
-        raise NotImplementedError
+        if not self.tile_exists(tile_x, tile_y, tile_z):
+            raise TileOutsideBounds(
+                f"Tile(x={tile_x}, y={tile_y}, z={tile_z}) is outside bounds"
+            )
 
-    async def part(self, bbox: BBox) -> ImageData:
+        matrix = self.tms.matrix(tile_z)
+        bbox = cast(
+            BBox,
+            self.tms.xy_bounds(Tile(x=tile_x, y=tile_y, z=tile_z)),
+        )
+
+        return await self.part(
+            bbox,
+            variables=variables,
+            expression=expression,
+            dst_crs=self.tms.rasterio_crs,
+            bounds_crs=self.tms.rasterio_crs,
+            max_size=None,
+            height=tilesize or matrix.tileHeight,
+            width=tilesize or matrix.tileWidth,
+            nodata=nodata,
+            reproject_method=reproject_method,
+            **kwargs,
+        )
+
+    async def part(  # type: ignore[override]
+        self,
+        bbox: BBox,
+        *,
+        variables: Sequence[str] | str,
+        expression: str | None = None,
+        dst_crs: CRS | None = None,
+        bounds_crs: CRS = WGS84_CRS,
+        max_size: int | None = None,
+        height: int | None = None,
+        width: int | None = None,
+        nodata: NoData | None = None,
+        reproject_method: WarpResampling = "nearest",
+        **kwargs: Any,
+    ) -> ImageData:
         """Read a Part of a Dataset.
 
         Args:
             bbox (tuple): Output bounds (left, bottom, right, top) in target crs.
+            variables (list of str or str): list of variables to return value for.
 
         Returns:
             rio_tiler.models.ImageData: ImageData instance with data, mask and input spatial info.
 
         """
-        raise NotImplementedError
+        availables_variables = await self.variables
 
-    async def preview(
+        variables = cast_to_sequence(variables)
+        if vars := set(variables).difference(availables_variables.keys()):
+            raise ValueError(
+                f"Variables {vars} not found in the dataset. Available variables: {list(availables_variables.keys())}"
+            )
+
+        async def _part(variable: str) -> ImageData:
+            array_metadata = self.select_variable(
+                availables_variables[variable],
+                max_size=max_size,
+                height=height,
+                width=width,
+                dst_crs=dst_crs,
+            )
+
+            async with Reader(
+                input=array_metadata["array"],
+                transform=array_metadata["transform"],
+                crs=array_metadata["crs"],
+                tms=self.tms,
+            ) as src:
+                return await src.part(
+                    bbox,
+                    dst_crs=dst_crs,
+                    bounds_crs=bounds_crs,
+                    max_size=max_size,
+                    height=height,
+                    width=width,
+                    nodata=nodata,
+                    reproject_method=reproject_method,
+                )
+
+        img_stack = await asyncio.gather(*(_part(variable) for variable in variables))
+
+        img = ImageData.create_from_list(img_stack)
+        img.band_names = [f"b{ix + 1}" for ix in range(img.count)]
+        if expression:
+            return img.apply_expression(expression)
+
+        return img
+
+    async def preview(  # type: ignore[override]
         self,
-        variables: list[str] | str,
+        *,
+        variables: Sequence[str] | str,
         expression: str | None = None,
         dst_crs: CRS | None = None,
         max_size: int | None = 1024,

--- a/rio_tiler/experimental/zarr.py
+++ b/rio_tiler/experimental/zarr.py
@@ -1317,13 +1317,14 @@ class GeoZarrReader(AsyncBaseReader):
 
         # NOTE: root is an Array
         if isinstance(g, zarr.AsyncArray):
-            conventions = g.attrs.get("zarr_conventions", [])
+            attributes = cast(dict[str, Any], g.attrs)
+            conventions = attributes.get("zarr_conventions", [])
             if _has_proj(conventions):
-                root_crs = _get_proj_crs(g.attrs)
+                root_crs = _get_proj_crs(attributes)
 
             if _has_spatial(conventions):
-                root_transform = _get_transform(g.attrs)
-                root_bbox = g.attrs.get("spatial:bbox")
+                root_transform = _get_transform(attributes)
+                root_bbox = attributes.get("spatial:bbox")
 
             # TODO: is this always true ?
             height, width = g.shape[-2:]
@@ -1418,12 +1419,13 @@ class GeoZarrReader(AsyncBaseReader):
                     if array.ndim < 2:
                         continue
 
-                    conventions = array.attrs.get("zarr_conventions", [])
+                    attributes = cast(dict[str, Any], array.attrs)
+                    conventions = attributes.get("zarr_conventions", [])
                     if _has_proj(conventions):
-                        array_crs = _get_proj_crs(array.attrs)
+                        array_crs = _get_proj_crs(attributes)
 
                     if _has_spatial(conventions):
-                        array_transform = _get_transform(array.attrs)
+                        array_transform = _get_transform(attributes)
 
                     array_crs = array_crs or root_crs
                     array_transform = array_transform or root_transform

--- a/rio_tiler/experimental/zarr.py
+++ b/rio_tiler/experimental/zarr.py
@@ -1262,6 +1262,80 @@ class GeoZarrReader(AsyncBaseReader):
         minx, miny, maxx, maxy = zip(*bounds)
         return (min(minx), min(miny), max(maxx), max(maxy))
 
+    async def get_minzoom(
+        self,
+        *,
+        variables: Sequence[str] | str,
+    ) -> int:
+        """Get minzoom for variables."""
+        variables = cast_to_sequence(variables)
+
+        async def _get_minzoom(variable: str) -> int:
+            group_name = "root"
+            if ":" in variable:
+                group_name, variable = variable.split(":", 1)
+
+            group_metadata = await self.get_group_metadata(group_name)
+            array = group_metadata["arrays"].get(variable)
+            if not array:
+                raise ValueError(
+                    f"Variable '{variable}' not found in '{group_name}' group."
+                )
+
+            # Assume the last array is the lowest resolution
+            array_metadata = array[-1]
+            return _get_zoom(
+                tms=self.tms,
+                crs=array_metadata["crs"],
+                width=array_metadata["width"],
+                height=array_metadata["height"],
+                bounds=array_bounds(
+                    array_metadata["height"],
+                    array_metadata["width"],
+                    array_metadata["transform"],
+                ),
+            )
+
+        zooms = await asyncio.gather(*(_get_minzoom(variable) for variable in variables))
+        return min(zooms)
+
+    async def get_maxzoom(
+        self,
+        *,
+        variables: Sequence[str] | str,
+    ) -> int:
+        """Get maxzoom for variables."""
+        variables = cast_to_sequence(variables)
+
+        async def _get_maxzoom(variable: str) -> int:
+            group_name = "root"
+            if ":" in variable:
+                group_name, variable = variable.split(":", 1)
+
+            group_metadata = await self.get_group_metadata(group_name)
+            array = group_metadata["arrays"].get(variable)
+            if not array:
+                raise ValueError(
+                    f"Variable '{variable}' not found in '{group_name}' group."
+                )
+
+            # Assume the first array is the highest resolution
+            array_metadata = array[0]
+            return _get_zoom(
+                tms=self.tms,
+                crs=array_metadata["crs"],
+                width=array_metadata["width"],
+                height=array_metadata["height"],
+                bounds=array_bounds(
+                    array_metadata["height"],
+                    array_metadata["width"],
+                    array_metadata["transform"],
+                ),
+            )
+
+        zooms = await asyncio.gather(*(_get_maxzoom(variable) for variable in variables))
+        return max(zooms)
+
     async def list_variables(self) -> list[str]:
         """List variables in the Zarr store."""
         if self._variables is not None:

--- a/rio_tiler/experimental/zarr.py
+++ b/rio_tiler/experimental/zarr.py
@@ -293,12 +293,6 @@ class Reader(AsyncBaseReader):
             dict[str, rio_tiler.models.BandStatistics]: bands statistics.
 
         """
-        nbytes = await self.input.nbytes_stored()
-        if nbytes > MAX_ARRAY_SIZE:
-            raise MaxArraySizeError(
-                f"Maximum array limit {MAX_ARRAY_SIZE} reached, trying to put Array of {self.input.shape} in memory."
-            )
-
         if indexes and expression:
             warnings.warn(
                 "Both expression and indexes passed; expression will overwrite indexes parameter.",
@@ -544,12 +538,6 @@ class Reader(AsyncBaseReader):
             rio_tiler.models.ImageData: ImageData instance with data, mask and input spatial info.
 
         """
-        nbytes = await self.input.nbytes_stored()
-        if nbytes > MAX_ARRAY_SIZE:
-            raise MaxArraySizeError(
-                f"Maximum array limit {MAX_ARRAY_SIZE} reached, trying to put Array of {self.input.shape} in memory."
-            )
-
         if indexes and expression:
             warnings.warn(
                 "Both expression and indexes passed; expression will overwrite indexes parameter.",

--- a/rio_tiler/experimental/zarr.py
+++ b/rio_tiler/experimental/zarr.py
@@ -33,7 +33,7 @@ from rio_tiler.errors import (
 )
 from rio_tiler.expression import parse_expression
 from rio_tiler.io import AsyncBaseReader
-from rio_tiler.models import BandStatistics, ImageData, Info, PointData
+from rio_tiler.models import BandStatistics, Bounds, ImageData, Info, PointData
 from rio_tiler.types import BBox, Indexes, NoData, RIOResampling, WarpResampling
 from rio_tiler.utils import (
     CRS_to_uri,
@@ -144,18 +144,12 @@ class Reader(AsyncBaseReader):
                 f"Expected 2D or 3D array, got {self.input.ndim}D with shape {self.input.shape}"
             )
 
-        spatial_dims = ["y", "x", "latitude", "longitude", "lat", "lon"]
-
         # NOTE: zarr-python says attrs is of type dict[str, JSON]
         attributes = cast(dict[str, Any], self.input.attrs)
         conventions: list[dict] = attributes.get("zarr_conventions", [])
 
         # Transform
         if not self.transform and _has_spatial(conventions):
-            # NOTE: `spatial:dimensions` is the only required attribute for the `spatial` convention
-            # but if this ever change we default to list of common spatial dimension names
-            spatial_dims = attributes.get("spatial:dimensions", spatial_dims)
-
             transform_type = attributes.get("spatial:transform_type") or "affine"
             tr = attributes.get("spatial:transform")
             if transform_type == "affine" and tr is not None:
@@ -191,8 +185,7 @@ class Reader(AsyncBaseReader):
 
         self.bounds = array_bounds(self.height, self.width, self.transform)
 
-        dimensions = getattr(self.input.metadata, "dimension_names", [])
-        self._dims = [d for d in dimensions if d.lower() not in spatial_dims]
+        self._dims = list(getattr(self.input.metadata, "dimension_names", []))
 
         if self.band_names:
             assert len(self.band_names) == self.nbands, (
@@ -1045,6 +1038,14 @@ def get_multiscale_level(
     return ms_resolutions[0][1]
 
 
+class GeoZarrInfo(Bounds):
+    """GeoZarr Info."""
+
+    multiscales: bool
+    variables: list[str]
+    attributes: dict[str, Any]
+
+
 @attr.s
 class GeoZarrReader(AsyncBaseReader):
     """Rio-tiler GeoZarr Reader.
@@ -1089,16 +1090,11 @@ class GeoZarrReader(AsyncBaseReader):
 
     def __attrs_post_init__(self) -> None:
         """Post init: derive height, width, count from array shape."""
-        spatial_dims = ["y", "x", "latitude", "longitude", "lat", "lon"]
-        spatial_shape: tuple[int, int] | None = None
-        transform: Affine | None = None
-
         # NOTE: zarr-python says attrs is of type dict[str, JSON]
         attributes = cast(dict[str, Any], self.input.attrs)
         conventions: list[dict] = attributes.get("zarr_conventions", [])
 
         self.multiscales = _has_multiscales(conventions)
-        # assert self.multiscales, "GeoZarr convention requires 'multiscales' convention to be present in zarr_conventions"
 
         self.spatial = _has_spatial(conventions)
         assert self.spatial, (
@@ -1113,54 +1109,59 @@ class GeoZarrReader(AsyncBaseReader):
         # CRS
         self.crs = _get_proj_crs(attributes)
 
-        # NOTE: `spatial:dimensions` is the only required attribute for the `spatial` convention
-        # but if this ever change we default to list of common spatial dimension names
-        spatial_dims = attributes.get("spatial:dimensions", spatial_dims)
-        spatial_shape = attributes.get("spatial:shape")
+        if spatial_shape := attributes.get("spatial:shape"):
+            self.height = spatial_shape[0]
+            self.width = spatial_shape[1]
+
+        if bbox := attributes.get("spatial:bbox"):
+            self.bounds = bbox
 
         # Transform
         # Case 1: Transform at group level
         tr = attributes.get("spatial:transform")
         transform_type = attributes.get("spatial:transform_type", "affine")
-        if transform_type == "affine" and tr is not None:
+        if tr is not None and transform_type == "affine":
             if attributes.get("spatial:registration", "pixel") == "node":
                 # NOTE: If the registration is "node", we need to adjust the transform to
                 # account for the fact that the coordinates refer to the center of the pixel rather than the edge.
                 tr[2] -= tr[0] / 2
                 tr[5] -= tr[4] / 2
 
-            transform = Affine(*tr)
+            self.transform = Affine(*tr)
 
-        # Case 2: No transform at group level, check multiscales for transform and shape
-        if not transform and self.multiscales:
+        # Case 2: check multiscales for transform and shape
+        if self.multiscales:
             # assume the first layout is the highest resolution
             first_res = attributes["multiscales"]["layout"][0]
-            spatial_shape = first_res.get("spatial:shape")
+
+            if spatial_shape := attributes.get("spatial:shape"):
+                self.height = self.height or spatial_shape[0]
+                self.width = self.width or spatial_shape[1]
+
+            if bbox := attributes.get("spatial:bbox"):
+                self.bounds = self.bounds or bbox
 
             tr = first_res.get("spatial:transform")
-            transform_type = attributes.get("spatial:transform_type", "affine")
-            if transform_type == "affine" and tr is not None:
-                if attributes.get("spatial:registration", "pixel") == "node":
+            transform_type = first_res.get("spatial:transform_type", "affine")
+            if tr is not None and transform_type == "affine":
+                if first_res.get("spatial:registration", "pixel") == "node":
                     # NOTE: If the registration is "node", we need to adjust the transform to
                     # account for the fact that the coordinates refer to the center of the pixel rather than the edge.
                     tr[2] -= tr[0] / 2
                     tr[5] -= tr[4] / 2
 
-                transform = Affine(*tr)
+            self.transform = self.transform or Affine(*tr)
 
-        assert transform, (
+        assert self.transform, (
             "spatial:transform is required either at group level or in the first layout of multiscales convention"
         )
-        self.transform = transform
 
-        # NOTE: we could potentially check for spatial:bbox and derive shape from it
-        assert spatial_shape, (
-            "spatial:shape is required either at group level or in the first layout of multiscales convention"
+        if not self.bounds and all([self.width, self.height]):
+            self.bounds = array_bounds(self.height, self.width, self.transform)
+
+        assert self.bounds, (
+            "spatial:bbox or spatial:shape is required either at group level or in the first layout of multiscales convention"
         )
-        self.height = spatial_shape[0]
-        self.width = spatial_shape[1]
-
-        self.bounds = array_bounds(self.height, self.width, self.transform)
 
     @property
     def minzoom(self):
@@ -1199,6 +1200,20 @@ class GeoZarrReader(AsyncBaseReader):
                     height=shape[0],
                     bounds=array_bounds(shape[0], shape[1], Affine(*transform)),
                 )
+
+        if not all([self.bounds, self.width, self.height]):
+            dst_affine = self.transform
+            tms_crs = self.tms.rasterio_crs
+            if self.crs != tms_crs:
+                dst_affine, _, _ = calculate_default_transform(
+                    self.crs,
+                    self.tms.rasterio_crs,
+                    1,
+                    1,
+                    *self.bounds,
+                )
+            resolution = max(abs(dst_affine[0]), abs(dst_affine[4]))
+            return self.tms.zoom_for_res(resolution)
 
         return self._maxzoom
 
@@ -1277,16 +1292,15 @@ class GeoZarrReader(AsyncBaseReader):
                     )
 
         else:
+            group_name = self.input.name
             async for array in self.input.array_values():
-                group_name = self.input.name
-
                 # NOTE: skip non-data arrays
                 # TODO: be smarter
                 if array.ndim < 2:
                     continue
 
                 attributes = cast(dict[str, Any], array.attrs)
-                variable_name = array.name.replace(f"/{group_name}/", "")
+                variable_name = array.name.replace(f"{group_name}/", "")
 
                 transform = attributes.get("spatial:transform")
                 transform_type = attributes.get("spatial:transform_type") or "affine"
@@ -1371,14 +1385,31 @@ class GeoZarrReader(AsyncBaseReader):
 
         return variable
 
-    async def info(self) -> Info:
+    async def info(self) -> GeoZarrInfo:  # type: ignore[override]
         """Return Dataset's info.
 
         Returns:
-            rio_tile.models.Info: Dataset info.
+            GeoZarrInfo: Dataset info.
 
         """
-        raise NotImplementedError
+        availables_variables = await self.variables
+
+        attrs: dict[str, Any] = self.input.attrs or {}
+
+        meta: dict[str, Any] = {
+            "bounds": self.bounds,
+            "crs": CRS_to_uri(self.crs) or self.crs.to_wkt(),
+            # additional info (not in default model)
+            "driver": "GeoZarr",
+            "multiscales": self.multiscales,
+            "variables": list(availables_variables.keys()),
+            "attributes": {
+                k: (v.tolist() if isinstance(v, (numpy.ndarray, numpy.generic)) else v)
+                for k, v in attrs.items()
+            },
+        }
+
+        return GeoZarrInfo.model_validate(meta)
 
     async def statistics(
         self,

--- a/rio_tiler/experimental/zarr.py
+++ b/rio_tiler/experimental/zarr.py
@@ -1081,7 +1081,7 @@ class GeoZarrReader(AsyncBaseReader):
     tms: TileMatrixSet = attr.ib(default=WEB_MERCATOR_TMS)
 
     crs: CRS = attr.ib(init=False)
-    transform: Affine = attr.ib(init=False)
+    transform: Affine = attr.ib(init=False, default=None)
 
     # Group shape
     height: int = attr.ib(init=False, default=None)

--- a/tests/test_async_geozarr.py
+++ b/tests/test_async_geozarr.py
@@ -1,0 +1,306 @@
+"""test rio_tiler.experimental.zarr.GeoZarrReader."""
+
+from typing import Any
+
+import numpy
+import pytest
+import zarr
+from affine import Affine
+from rasterio.crs import CRS
+
+from rio_tiler.experimental.zarr import GeoZarrReader
+
+from .utils import multiscale_conventions, proj_conventions, spatial_conventions
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_geozarr_reader():
+    """Test XarrayReader and AsyncZarrReader compatibility."""
+    store = zarr.storage.MemoryStore()
+
+    # Create zarr dataset
+    attributes: dict[str, Any] = {}
+    attributes["zarr_conventions"] = [
+        spatial_conventions,
+        proj_conventions,
+        multiscale_conventions,
+    ]
+    attributes.update(
+        {
+            "spatial:dimensions": ["y", "x"],
+            "spatial:bbox": [500000, 4190000, 510000, 4200000],
+            "proj:code": "EPSG:32633",
+            "multiscales": {
+                "layout": [
+                    {
+                        "asset": "0",
+                        "spatial:dimensions": ["y", "x"],
+                        "spatial:shape": [1000, 1000],
+                        "spatial:transform": list(
+                            Affine.translation(500000, 4200000) * Affine.scale(10, -10)
+                        ),
+                    },
+                    {
+                        "asset": "1",
+                        "spatial:dimensions": ["y", "x"],
+                        "spatial:shape": [100, 100],
+                        "spatial:transform": list(
+                            Affine.translation(500000, 4200000) * Affine.scale(100, -100)
+                        ),
+                    },
+                ]
+            },
+        }
+    )
+
+    root = zarr.open_group(store, mode="w", zarr_format=3, attributes=attributes)
+
+    highres_group = root.create_group(
+        name="0",
+        attributes={
+            "zarr_conventions": [
+                spatial_conventions,
+                proj_conventions,
+            ],
+            "spatial:dimensions": ["y", "x"],
+            "spatial:bbox": [500000, 4190000, 510000, 4200000],
+            "proj:code": "EPSG:32633",
+            "spatial:transform": list(
+                Affine.translation(500000, 4200000) * Affine.scale(10, -10)
+            ),
+        },
+    )
+
+    # Layout 0
+    arr = numpy.arange(0.0, 1000 * 1000, dtype="float32").reshape(1000, 1000)
+    arr[0:50, 0:50] = 0
+
+    highres_b01 = highres_group.create_array(
+        "b01",
+        shape=arr.shape,
+        chunks=(64, 64),
+        dtype="float32",
+        fill_value=0,
+        dimension_names=["y", "x"],
+        attributes={},
+    )
+    highres_b01[:] = arr
+
+    highres_b02 = highres_group.create_array(
+        "b02",
+        shape=arr.shape,
+        chunks=(64, 64),
+        dtype="float32",
+        fill_value=0,
+        dimension_names=["y", "x"],
+        attributes={},
+    )
+    highres_b02[:] = arr
+
+    # Layout 1
+    arr = numpy.arange(0.0, 100 * 100, dtype="float32").reshape(100, 100)
+    arr[0:5, 0:5] = 0
+
+    lowres_group = root.create_group(
+        name="1",
+        attributes={
+            "zarr_conventions": [
+                spatial_conventions,
+                proj_conventions,
+            ],
+            "spatial:dimensions": ["y", "x"],
+            "spatial:bbox": [500000, 4190000, 510000, 4200000],
+            "proj:code": "EPSG:32633",
+            "spatial:transform": list(
+                Affine.translation(500000, 4200000) * Affine.scale(100, -100)
+            ),
+        },
+    )
+
+    lowres_b02 = lowres_group.create_array(
+        "b02",
+        shape=arr.shape,
+        chunks=(64, 64),
+        dtype="float32",
+        fill_value=0,
+        dimension_names=["y", "x"],
+        attributes={},
+    )
+    lowres_b02[:] = arr
+
+    # Write consolidated metadata
+    zarr.consolidate_metadata(root.store)
+
+    ###########################################################################
+    group = await zarr.api.asynchronous.open_group(store=store, mode="r")
+
+    geozarrds = GeoZarrReader(input=group)
+    assert geozarrds.crs == CRS.from_epsg(32633)
+    assert geozarrds.bounds == (500000, 4190000, 510000, 4200000)
+    assert geozarrds.transform
+    assert geozarrds.minzoom == 10
+    assert geozarrds.maxzoom == 14
+
+    info = await geozarrds.info()
+    assert info.driver == "Zarr-Python"
+    assert info.variables == ["b01", "b02"]
+
+    vars = await geozarrds.list_variables()
+    assert vars == ["b01", "b02"]
+
+    # B01 has only one layout to minzoom 14, while b02 has two layouts with minzoom 10 and maxzoom 14
+    z = await geozarrds.get_minzoom(variables="b01")
+    assert z == 14
+    z = await geozarrds.get_maxzoom(variables="b01")
+    assert z == 14
+
+    z = await geozarrds.get_minzoom(variables="b02")
+    assert z == 10
+    z = await geozarrds.get_maxzoom(variables="b02")
+    assert z == 14
+
+    meta = await geozarrds.get_group_metadata("root")
+    assert meta["multiscale"]
+    assert len(meta["arrays"]["b01"]) == 1
+    assert len(meta["arrays"]["b02"]) == 2
+    assert meta["arrays"]["b01"][0]["width"] == 1000
+    assert meta["arrays"]["b02"][0]["width"] == 1000
+    assert meta["arrays"]["b02"][1]["width"] == 100
+
+    array = meta["arrays"].get("b02")
+    selected = geozarrds.select_variable(array)
+    assert selected["width"] == 1000
+
+    selected = geozarrds.select_variable(array, max_size=900)
+    assert selected["width"] == 1000
+
+    selected = geozarrds.select_variable(array, max_size=150)
+    assert selected["width"] == 100
+
+    selected = geozarrds.select_variable(array, max_size=50)
+    assert selected["width"] == 100
+
+    array = meta["arrays"].get("b01")
+    selected = geozarrds.select_variable(array)
+    assert selected["width"] == 1000
+
+    selected = geozarrds.select_variable(array, max_size=50)
+    assert selected["width"] == 1000
+
+
+async def test_geozarr_root():
+    """Test GeoZarrReader
+
+    - root zarr store without any attribute:
+        - bounds should be (-180, -90, 180, 90)
+        - CRS should be EPSG:4326
+        - minzoom should be 0 (TMS)
+        - maxzoom should be 24 (TMS)
+
+    """
+    store = zarr.storage.MemoryStore()
+
+    attributes: dict[str, Any] = {}
+    root = zarr.open_group(store, mode="w", zarr_format=3, attributes=attributes)
+
+    group = root.create_group(
+        name="data",
+        attributes={
+            "zarr_conventions": [
+                spatial_conventions,
+                proj_conventions,
+            ],
+            "spatial:dimensions": ["y", "x"],
+            "spatial:bbox": [500000, 4190000, 510000, 4200000],
+            "proj:code": "EPSG:32633",
+            "spatial:transform": list(
+                Affine.translation(500000, 4200000) * Affine.scale(10, -10)
+            ),
+        },
+    )
+
+    # Layout 0
+    arr = numpy.arange(0.0, 1000 * 1000, dtype="float32").reshape(1000, 1000)
+    arr[0:50, 0:50] = 0
+
+    b01 = group.create_array(
+        "b01",
+        shape=arr.shape,
+        chunks=(64, 64),
+        dtype="float32",
+        fill_value=0,
+        dimension_names=["y", "x"],
+        attributes={},
+    )
+    b01[:] = arr
+
+    b02 = group.create_array(
+        "b02",
+        shape=arr.shape,
+        chunks=(64, 64),
+        dtype="float32",
+        fill_value=0,
+        dimension_names=["y", "x"],
+        attributes={},
+    )
+    b02[:] = arr
+
+    # Write consolidated metadata
+    zarr.consolidate_metadata(root.store)
+
+    ###########################################################################
+    group = await zarr.api.asynchronous.open_group(store=store, mode="r")
+
+    geozarrds = GeoZarrReader(input=group)
+    assert geozarrds.crs == CRS.from_epsg(4326)
+    assert geozarrds.bounds == (-180, -90, 180, 90)
+    assert not geozarrds.transform
+    assert geozarrds.minzoom == 0
+    assert geozarrds.maxzoom == 24
+
+    info = await geozarrds.info()
+    assert info.driver == "Zarr-Python"
+    assert info.variables == ["data:b01", "data:b02"]
+
+    vars = await geozarrds.list_variables()
+    assert vars == ["data:b01", "data:b02"]
+
+    # No arrays/metadata at root level
+    meta = await geozarrds.get_group_metadata("root")
+    assert meta == {
+        "crs": None,
+        "bbox": None,
+        "transform": None,
+        "multiscale": False,
+        "arrays": {},
+    }
+
+    meta = await geozarrds.get_group_metadata("data")
+    assert meta["crs"] == CRS.from_epsg(32633)
+    assert meta["bbox"] == [500000, 4190000, 510000, 4200000]
+    assert len(meta["arrays"]["b01"]) == 1
+    assert len(meta["arrays"]["b02"]) == 1
+    assert meta["arrays"]["b01"][0]["width"] == 1000
+    assert meta["arrays"]["b02"][0]["width"] == 1000
+
+    # No Multiscale
+    z = await geozarrds.get_minzoom(variables="data:b01")
+    assert z == 14
+    z = await geozarrds.get_maxzoom(variables="data:b01")
+    assert z == 14
+
+    array = meta["arrays"].get("b01")
+    selected = geozarrds.select_variable(array)
+    assert selected["width"] == 1000
+
+    bbox = await geozarrds.get_bounds(variables="data:b01")
+    assert bbox == (
+        14.999999999999982,
+        37.857404200399316,
+        15.113817624024337,
+        37.94758957178317,
+    )
+
+    bbox = await geozarrds.get_bounds(variables="data:b01", crs=CRS.from_epsg(32633))
+    assert bbox == (500000, 4190000, 510000, 4200000)

--- a/tests/test_async_geozarr.py
+++ b/tests/test_async_geozarr.py
@@ -304,3 +304,105 @@ async def test_geozarr_root():
 
     bbox = await geozarrds.get_bounds(variables="data:b01", crs=CRS.from_epsg(32633))
     assert bbox == (500000, 4190000, 510000, 4200000)
+
+
+async def test_geozarr_root_with_arrays():
+    """Test GeoZarrReader
+
+    - root zarr store without any attribute:
+        - bounds should be (-180, -90, 180, 90)
+        - CRS should be EPSG:4326
+        - minzoom should be 0 (TMS)
+        - maxzoom should be 24 (TMS)
+
+    """
+    store = zarr.storage.MemoryStore()
+
+    attributes = {
+        "zarr_conventions": [
+            spatial_conventions,
+            proj_conventions,
+        ],
+        "spatial:dimensions": ["y", "x"],
+        "spatial:bbox": [500000, 4190000, 510000, 4200000],
+        "proj:code": "EPSG:32633",
+        "spatial:transform": list(
+            Affine.translation(500000, 4200000) * Affine.scale(10, -10)
+        ),
+    }
+    root = zarr.open_group(store, mode="w", zarr_format=3, attributes=attributes)
+
+    # Layout 0
+    arr = numpy.arange(0.0, 1000 * 1000, dtype="float32").reshape(1000, 1000)
+    arr[0:50, 0:50] = 0
+
+    b01 = root.create_array(
+        "b01",
+        shape=arr.shape,
+        chunks=(64, 64),
+        dtype="float32",
+        fill_value=0,
+        dimension_names=["y", "x"],
+        attributes={},
+    )
+    b01[:] = arr
+
+    b02 = root.create_array(
+        "b02",
+        shape=arr.shape,
+        chunks=(64, 64),
+        dtype="float32",
+        fill_value=0,
+        dimension_names=["y", "x"],
+        attributes={},
+    )
+    b02[:] = arr
+
+    # Write consolidated metadata
+    zarr.consolidate_metadata(root.store)
+
+    ###########################################################################
+    group = await zarr.api.asynchronous.open_group(store=store, mode="r")
+
+    geozarrds = GeoZarrReader(input=group)
+    assert geozarrds.crs == CRS.from_epsg(32633)
+    assert geozarrds.bounds == (500000, 4190000, 510000, 4200000)
+    assert geozarrds.transform
+    assert geozarrds.minzoom == 14
+    assert geozarrds.maxzoom == 14
+
+    info = await geozarrds.info()
+    assert info.driver == "Zarr-Python"
+    assert info.variables == ["b01", "b02"]
+
+    vars = await geozarrds.list_variables()
+    assert vars == ["b01", "b02"]
+
+    meta = await geozarrds.get_group_metadata("root")
+    assert meta["crs"] == CRS.from_epsg(32633)
+    assert meta["bbox"] == [500000, 4190000, 510000, 4200000]
+    assert len(meta["arrays"]["b01"]) == 1
+    assert len(meta["arrays"]["b02"]) == 1
+    assert meta["arrays"]["b01"][0]["width"] == 1000
+    assert meta["arrays"]["b02"][0]["width"] == 1000
+
+    # No Multiscale
+    z = await geozarrds.get_minzoom(variables="b01")
+    assert z == 14
+    z = await geozarrds.get_maxzoom(variables="b01")
+    assert z == 14
+
+    array = meta["arrays"].get("b01")
+    selected = geozarrds.select_variable(array)
+    assert selected["width"] == 1000
+
+    bbox = await geozarrds.get_bounds(variables="b01")
+    assert bbox == (
+        14.999999999999982,
+        37.857404200399316,
+        15.113817624024337,
+        37.94758957178317,
+    )
+
+    bbox = await geozarrds.get_bounds(variables="b01", crs=CRS.from_epsg(32633))
+    assert bbox == (500000, 4190000, 510000, 4200000)

--- a/tests/test_async_zarr.py
+++ b/tests/test_async_zarr.py
@@ -97,7 +97,7 @@ async def test_async_zarr_reader(zarr_store):
         transform=transform,
     )
     assert reader.bounds == (500000.0, 4000000.0, 500100.0, 4000100.0)
-    assert reader._dims == ["band"]
+    assert reader._dims == ["band", "y", "x"]
 
     # Test _read (full array)
     img = await reader._read()
@@ -138,7 +138,7 @@ async def test_2d_array(zarr_store_2d):
         transform=transform,
     )
     assert reader.bounds == (500000.0, 4000000.0, 500050.0, 4000050.0)
-    assert reader._dims == []
+    assert reader._dims == ["y", "x"]
 
     img = await reader._read()
     assert img.array.shape == (1, 50, 50), f"Expected (1, 50, 50), got {img.array.shape}"

--- a/tests/test_async_zarr.py
+++ b/tests/test_async_zarr.py
@@ -123,7 +123,7 @@ async def test_async_zarr_reader(zarr_store):
     # Test info method
     info = await reader.info()
     assert info.bounds == (500000.0, 4000000.0, 500100.0, 4000100.0)
-    assert info.driver == "Zarr"
+    assert info.driver == "Zarr-Python"
     assert info.count == 3
     assert info.model_dump()
 
@@ -147,7 +147,7 @@ async def test_2d_array(zarr_store_2d):
     # Test info method
     info = await reader.info()
     assert info.bounds == (500000.0, 4000000.0, 500050.0, 4000050.0)
-    assert info.driver == "Zarr"
+    assert info.driver == "Zarr-Python"
     assert info.count == 1
     assert info.model_dump()
 

--- a/tests/test_async_zarr.py
+++ b/tests/test_async_zarr.py
@@ -16,6 +16,7 @@ from zarr.storage import ObjectStore
 
 from rio_tiler.errors import (
     ExpressionMixingWarning,
+    InvalidBounds,
     PointOutsideBounds,
     TileOutsideBounds,
 )
@@ -317,6 +318,10 @@ async def test_tile_outside_bounds(zarr_store):
     # Tile that doesn't intersect the dataset
     with pytest.raises(TileOutsideBounds):
         await reader.tile(tile_x=1000, tile_y=1000, tile_z=10)
+
+    with pytest.raises(InvalidBounds):
+        bounds = reader.tms.xy_bounds(1000, 1000, 10)
+        await reader.part(bounds, bounds_crs=reader.tms.rasterio_crs)
 
 
 async def test_preview(zarr_store):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,6 +7,28 @@ import zarr
 from affine import Affine
 from zarr.codecs import BloscCodec
 
+spatial_conventions = {
+    "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/refs/tags/v1/schema.json",
+    "spec_url": "https://github.com/zarr-conventions/spatial/blob/v1/README.md",
+    "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
+    "name": "spatial:",
+    "description": "Spatial coordinate information",
+}
+proj_conventions = {
+    "schema_url": "https://raw.githubusercontent.com/zarr-experimental/geo-proj/refs/tags/v1/schema.json",
+    "spec_url": "https://github.com/zarr-experimental/geo-proj/blob/v1/README.md",
+    "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
+    "name": "proj:",
+    "description": "Coordinate reference system information for geospatial data",
+}
+multiscale_conventions = {
+    "schema_url": "https://raw.githubusercontent.com/zarr-conventions/multiscales/refs/tags/v1/schema.json",
+    "spec_url": "https://github.com/zarr-conventions/multiscales/blob/v1/README.md",
+    "uuid": "d35379db-88df-4056-af3a-620245f8e347",
+    "name": "multiscales",
+    "description": "Multiscale layout of zarr datasets",
+}
+
 
 def create_zarr(path: str, geozarr: bool = False) -> None:
     """Create a zarr archive."""
@@ -16,28 +38,12 @@ def create_zarr(path: str, geozarr: bool = False) -> None:
     compressor = BloscCodec(cname="zstd", clevel=3, shuffle="shuffle", blocksize=0)
 
     # Create zarr group
-    root = zarr.open_group(path, mode="w", zarr_format=3)
-
-    attributes: dict[str, Any] = {
-        "valid_min": float(arr.min()),
-        "valid_max": float(arr.max()),
-    }
+    attributes: dict[str, Any] = {}
     if geozarr:
         attributes["zarr_conventions"] = [
-            {
-                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/spatial/refs/tags/v1/schema.json",
-                "spec_url": "https://github.com/zarr-conventions/spatial/blob/v1/README.md",
-                "uuid": "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4",
-                "name": "spatial:",
-                "description": "Spatial coordinate information",
-            },
-            {
-                "schema_url": "https://raw.githubusercontent.com/zarr-experimental/geo-proj/refs/tags/v1/schema.json",
-                "spec_url": "https://github.com/zarr-experimental/geo-proj/blob/v1/README.md",
-                "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
-                "name": "proj:",
-                "description": "Coordinate reference system information for geospatial data",
-            },
+            spatial_conventions,
+            proj_conventions,
+            multiscale_conventions,
         ]
         attributes.update(
             {
@@ -45,9 +51,20 @@ def create_zarr(path: str, geozarr: bool = False) -> None:
                 "spatial:transform": list(
                     Affine.translation(-180, 90) * Affine.scale(0.1, -0.1)
                 ),
+                "spatial:bbox": [-180.0, -90.0, 180.0, 90.0],
                 "proj:code": "EPSG:4326",
             }
         )
+
+    root = zarr.open_group(path, mode="w", zarr_format=3, attributes=attributes)
+
+    array_attributes = attributes.copy()
+    array_attributes.update(
+        {
+            "valid_min": float(arr.min()),
+            "valid_max": float(arr.max()),
+        }
+    )
 
     # Create the main dataset array
     dataset = root.create_array(
@@ -58,7 +75,7 @@ def create_zarr(path: str, geozarr: bool = False) -> None:
         fill_value=0,
         compressors=[compressor],
         dimension_names=["time", "y", "x"],
-        attributes=attributes,
+        attributes=array_attributes,
     )
     dataset[:] = arr
 

--- a/uv.lock
+++ b/uv.lock
@@ -13,6 +13,10 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
+[options]
+exclude-newer = "2026-04-10T14:55:57.46947Z"
+exclude-newer-span = "P3D"
+
 [[package]]
 name = "affine"
 version = "2.4.0"


### PR DESCRIPTION
```python
from obstore.store import HTTPStore
import zarr
from zarr.storage import ObjectStore

from rio_tiler.experimental.zarr import GeoZarrReader

store = HTTPStore("https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2B_MSIL2A_20260216T142149_N0512_R096_T25WFV_20260216T165051.zarr/measurements/reflectance")
zarr_store = ObjectStore(store=store, read_only=True)

group = await zarr.api.asynchronous.open_group(store=zarr_store, mode="r")
ds = GeoZarrReader(input=group)

vars = await ds.variables
vars["b02"]

>> [{'array': <AsyncArray object_store://HTTPStore("https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2B_MSIL2A_20260216T142149_N0512_R096_T25WFV_20260216T165051.zarr/measurements/reflectance")/r10m/b02 shape=(10980, 10980) dtype=float32>,
  'crs': CRS.from_epsg(32625),
  'height': 10980,
  'width': 10980,
  'transform': Affine(10.0, 0.0, 600000.0,
         0.0, -10.0, 8000040.0)},
 {'array': <AsyncArray object_store://HTTPStore("https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2B_MSIL2A_20260216T142149_N0512_R096_T25WFV_20260216T165051.zarr/measurements/reflectance")/r20m/b02 shape=(5490, 5490) dtype=float32>,
  'crs': CRS.from_epsg(32625),
  'height': 5490,
  'width': 5490,
  'transform': Affine(20.0, 0.0, 600000.0,
         0.0, -20.0, 8000040.0)},
 {'array': <AsyncArray object_store://HTTPStore("https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2B_MSIL2A_20260216T142149_N0512_R096_T25WFV_20260216T165051.zarr/measurements/reflectance")/r60m/b02 shape=(1830, 1830) dtype=float32>,
  'crs': CRS.from_epsg(32625),
  'height': 1830,
  'width': 1830,
  'transform': Affine(60.0, 0.0, 600000.0,
         0.0, -60.0, 8000040.0)},
 {'array': <AsyncArray object_store://HTTPStore("https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2B_MSIL2A_20260216T142149_N0512_R096_T25WFV_20260216T165051.zarr/measurements/reflectance")/r120m/b02 shape=(915, 915) dtype=float32>,
  'crs': CRS.from_epsg(32625),
  'height': 915,
  'width': 915,
  'transform': Affine(120.0, 0.0, 600000.0,
         0.0, -120.0, 8000040.0)},
 {'array': <AsyncArray object_store://HTTPStore("https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2B_MSIL2A_20260216T142149_N0512_R096_T25WFV_20260216T165051.zarr/measurements/reflectance")/r360m/b02 shape=(305, 305) dtype=float32>,
  'crs': CRS.from_epsg(32625),
  'height': 305,
  'width': 305,
  'transform': Affine(360.0, 0.0, 600000.0,
         0.0, -360.0, 8000040.0)},
 {'array': <AsyncArray object_store://HTTPStore("https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2B_MSIL2A_20260216T142149_N0512_R096_T25WFV_20260216T165051.zarr/measurements/reflectance")/r720m/b02 shape=(152, 152) dtype=float32>,
  'crs': CRS.from_epsg(32625),
  'height': 152,
  'width': 152,
  'transform': Affine(720.0, 0.0, 600000.0,
         0.0, -720.0, 8000040.0)}]

img = await ds.preview(variables="b02", max_size=128)
img 

ImageData(array=masked_array(
  data=[[[0.853752076625824, 0.7639507055282593, 0.7750680446624756,
          ..., 0.2121896743774414, -0.08321993798017502,
          -0.0998888909816742],
         [0.7293742895126343, 0.7273194789886475, 0.8645895719528198,
          ..., 0.919400691986084, 0.642178475856781, 0.2491092085838318],
         [0.8349562287330627, 0.893208384513855, 0.9366021156311035,
          ..., 0.7356111407279968, 0.6698201894760132,
          0.7265465259552002],
         ...,
         [0.9428333044052124, 0.9167847633361816, 0.9088020920753479,
          ..., --, --, --],
         [1.042079210281372, 0.9973312616348267, 0.9550909996032715,
          ..., --, --, --],
         [0.9809249639511108, 1.0116347074508667, 1.052645206451416,
          ..., --, --, --]]],
  mask=[[[False, False, False, ..., False, False, False],
         [False, False, False, ..., False, False, False],
         [False, False, False, ..., False, False, False],
         ...,
         [False, False, False, ...,  True,  True,  True],
         [False, False, False, ...,  True,  True,  True],
         [False, False, False, ...,  True,  True,  True]]],
  fill_value=np.float64(1e+20),
  dtype=float32), assets=[], bounds=BoundingBox(left=600000.0, bottom=7890600.0, right=709440.0, top=8000040.0), crs=CRS.from_epsg(32625), metadata={}, nodata=None, scales=[1.0], offsets=[0.0], band_names=['b1'], band_descriptions=['b1'], dataset_statistics=None, cutline_mask=None, alpha_mask=None)
``