### PR TITLE
feat: add experimental geoxarray reader

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
 * add: `rio_tiler.mosaic.reader.async_mosaic_reader`
 * add: `rio_tiler.mosaic.backend.AsyncBaseBackend`
 * add: `SumMethod` to `rio_tiler.mosaic.methods.defaults`
+* add: `rio_tiler.experimental.xarray.GeoArrayReader` reader for geospatial xarray DataArray with Zarr conventions
 
 ## 9.0.6 (2026-04-08)
 

--- a/docs/src/experimental.md
+++ b/docs/src/experimental.md
@@ -226,7 +226,7 @@ print(variables)
 # Get the preview for a specific variable
 img = await reader.preview(variables=["b02"], max_size=128)
 
-bounds = 
+bounds = reader.get_geographic_bounds("epsg:4326")
 # Get Time image
 tile = reader.tms.tile(bounds[0], bounds[1], reader.minzoom)
 img = await reader.tile(tile.x, tile.y, tile.z, variables=("b04", "b03", "b02"))
@@ -278,4 +278,64 @@ async with AsyncSTACReader(input=item, reader=reader) as stac:
     img = await stac.preview(assets={"name": "red", "indexes": [0]})
     print(img.statistics())                      
     >>> {'b1': BandStatistics(min=5.0, max=10664.0, mean=3308.9022180896536, count=66679.0, sum=220634291.0, std=2403.0317223160237, median=2767.0, majority=441.0, minority=5.0, unique=9456.0, histogram=[[14203, 12648, 10254, 8267, 6805, 5550, 4288, 2724, 1573, 367], [5.0, 1070.9, 2136.8, 3202.7000000000003, 4268.6, 5334.5, 6400.400000000001, 7466.300000000001, 8532.2, 9598.1, 10664.0]], valid_percent=6.36, masked_pixels=981897.0, valid_pixels=66679.0, description='red_b0', percentile_2=294.0, percentile_98=8826.0)}
+```
+
+## GeoArrayReader
+
+An experimental *Reader* built on top the `XarrayReader` but remove the usage of rioxarray and instead rely on the Geo/Spatial conventions (or user input CRS/Transform) for geospatial operations (e.g coordinates selection). This reader differs from the regular XarrayReader with:
+
+    - allows`crs` and `transform` input parameters or relies on Zarr Geo/Spatial conventions attributes
+    - do not read coordinates arrays
+    - allows `band_names` input parameter to specify the 3d dimension names
+
+
+```python
+from obstore.store import HTTPStore
+import zarr
+from zarr.storage import ObjectStore
+import xarray
+from rasterio.crs import CRS
+from affine import Affine
+from rio_tiler.experimental.xarray import GeoArrayReader
+
+# Create Obstore Store
+store = HTTPStore("https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2B_MSIL2A_20260216T142149_N0512_R096_T25WFV_20260216T165051.zarr")
+zarr_store = ObjectStore(store=store, read_only=True)
+
+ds = xarray.open_datatree(
+    zarr_store,  # type: ignore
+    decode_times=True,
+    decode_coords="all",
+    create_default_indexes=False,
+    consolidated=True,
+    engine="zarr",
+)
+group = ds["/measurements/reflectance/r720m"]
+
+crs = CRS.from_user_input(group.attrs["proj:code"])
+transform = Affine(*group.attrs["spatial:transform"])
+
+# Select an array ("b02")
+dataarray = group["b02"]
+
+# Initiate the reader
+reader = GeoArrayReader(
+    input=dataarray,
+    crs=crs,
+    transform=transform,
+)
+
+# The `/measurements/reflectance` group has spatial/geo conventions
+print(reader.bounds)
+>> (600000.0, 7890600.0, 709440.0, 8000040.0
+
+print(reader.crs)
+>> CRS.from_epsg(32625)
+
+# info
+print(reader.info())
+>> bounds=(600000.0, 7890600.0, 709440.0, 8000040.0) crs='http://www.opengis.net/def/crs/EPSG/0/32625' band_metadata=[('b1', {})] band_descriptions=[('b1', 'b1')] dtype='float32' nodata_type='None' colorinterp=None scales=None offsets=None colormap=None name='b02' count=1 width=152 height=152 dimensions=('y', 'x') attrs={'_eopf_attrs': {'add_offset': -0.1, 'coordinates': ['y', 'x'], 'dimensions': ['y', 'x'], 'dtype': '<u2', 'eopf_is_masked': True, 'eopf_target_dtype': '<f8', 'fill_value': 0, 'long_name': 'BOA reflectance from MSI acquisition at spectral band 02 490 nm', 'scale_factor': 0.0001, 'short_name': 'b02_60m', 'units': 'digital_counts', 'valid_max': 65535, 'valid_min': 1}, 'dtype': '<u2', 'long_name': 'BOA reflectance from MSI acquisition at spectral band 02 490 nm', 'units': 'digital_counts'}
+
+# Get the preview for a specific variable
+img = reader.preview()
 ```

--- a/rio_tiler/experimental/xarray.py
+++ b/rio_tiler/experimental/xarray.py
@@ -138,7 +138,7 @@ class GeoArrayReader(XarrayReader):
     # List of names for the first dimension (e.g time, bands, etc)
     band_names: list[str] | None = attr.ib(default=None)
 
-    _dims: list = attr.ib(init=False)
+    _dims: list = attr.ib(init=False, factory=list)
 
     @options.default
     def _options_default(self):
@@ -178,24 +178,25 @@ class GeoArrayReader(XarrayReader):
             "CRS is required, either as an argument or in `geo-proj` zarr_conventions"
         )
 
-        self._dims = [
-            d
-            for d in self.input.dims
-            if d not in ["x", "y", "spatial_ref", "crs_wkt", "grid_mapping"]
-        ]
-        assert len(self._dims) in [0, 1], "Can't handle >=4D DataArray"
+        if len(self.input.shape) > 2:
+            self._dims = [
+                d
+                for d in self.input.dims
+                if d not in ["x", "y", "spatial_ref", "crs_wkt", "grid_mapping"]
+            ]
 
         # NOTE: Assume shape of array is (bands, height, width) or (height, width)
         # and get height/width from the last 2 dimensions of the shape.
         shape = attributes.get("spatial:shape", self.input.shape)
         self.height, self.width = shape[-2], shape[-1]
 
+        assert len(self.input.shape) in [2, 3], "Can't handle 1D or >=4D DataArray"
         if len(self.input.shape) == 3:
             self.nbands = self.input.shape[0]
         else:
             self.nbands = 1
 
-        self.bounds = self.input.attrs.get("spatial:bounds")
+        self.bounds = attributes.get("spatial:bounds")
         if not self.bounds:
             self.bounds = array_bounds(self.height, self.width, self.transform)
 
@@ -224,7 +225,25 @@ class GeoArrayReader(XarrayReader):
         if self.band_names:
             return self.band_names
 
-        return [f"b{ix + 1}" for ix in range(self.nbands)]
+        if not self._dims:
+            coords_name = [
+                d
+                for d in self.input.coords
+                if d
+                not in [
+                    self.input.rio.x_dim,
+                    self.input.rio.y_dim,
+                    "spatial_ref",
+                    "crs_wkt",
+                    "grid_mapping",
+                ]
+            ]
+            if coords_name:
+                return [str(self.input.coords[coords_name[0]].data)]
+
+            return [self.input.name or "b1"]  # type: ignore
+
+        return [str(band) for d in self._dims for band in self.input[d].values]
 
     @property
     def minzoom(self):

--- a/rio_tiler/experimental/xarray.py
+++ b/rio_tiler/experimental/xarray.py
@@ -1,0 +1,750 @@
+"""Xarray experimental reader."""
+
+from __future__ import annotations
+
+import math
+import warnings
+from typing import Any, cast
+
+import attr
+import numpy
+from affine import Affine
+from morecantile import Tile, TileMatrixSet
+from rasterio.crs import CRS
+from rasterio.transform import array_bounds, rowcol
+from rasterio.warp import calculate_default_transform
+from rasterio.warp import transform as transform_coords
+from rasterio.warp import transform_bounds
+from rasterio.windows import from_bounds as window_from_bounds
+
+from rio_tiler._warp import warp
+from rio_tiler.constants import (
+    MAX_ARRAY_SIZE,
+    WEB_MERCATOR_CRS,
+    WEB_MERCATOR_TMS,
+    WGS84_CRS,
+)
+from rio_tiler.errors import (
+    InvalidGeographicBounds,
+    MaxArraySizeError,
+    PointOutsideBounds,
+    TileOutsideBounds,
+)
+from rio_tiler.io.xarray import Options, XarrayReader
+from rio_tiler.models import BandStatistics, ImageData, Info, PointData
+from rio_tiler.types import BBox, Indexes, NoData, RIOResampling, WarpResampling
+from rio_tiler.utils import (
+    CRS_to_uri,
+    _get_width_height,
+    _missing_size,
+    cast_to_sequence,
+)
+
+try:
+    import xarray
+except ImportError:  # pragma: nocover
+    xarray = None  # type: ignore
+
+
+MULTISCALE_CONVENTION_UUID = "d35379db-88df-4056-af3a-620245f8e347"
+SPATIAL_CONVENTION_UUID = "689b58e2-cf7b-45e0-9fff-9cfc0883d6b4"
+PROJ_CONVENTION_UUID = "f17cb550-5864-4468-aeb7-f3180cfb622f"
+
+
+def _has_multiscales(conventions: list[dict]) -> bool:
+    return next(
+        (True for c in conventions if c["uuid"] == MULTISCALE_CONVENTION_UUID),
+        False,
+    )
+
+
+def _has_spatial(conventions: list[dict]) -> bool:
+    return next(
+        (True for c in conventions if c["uuid"] == SPATIAL_CONVENTION_UUID),
+        False,
+    )
+
+
+def _has_proj(conventions: list[dict]) -> bool:
+    return next(
+        (True for c in conventions if c["uuid"] == PROJ_CONVENTION_UUID),
+        False,
+    )
+
+
+def _get_proj_crs(attributes: dict) -> CRS:
+    """Get CRS defined by PROJ conventions."""
+    proj_string = next(
+        (  # type: ignore
+            attributes.get(key)
+            for key in ["proj:code", "proj:wkt2", "proj:projjson"]
+            if key in attributes
+        )
+    )
+    return CRS.from_user_input(proj_string)
+
+
+@attr.s
+class GeoArrayReader(XarrayReader):
+    """GeoZarr Array Reader.
+    A Xarray based reader for geospatial arrays following Zarr Conventions.
+
+    Attributes:
+        input (xarray.DataArray): Xarray DataArray.
+        tms (morecantile.TileMatrixSet, optional): TileMatrixSet grid definition. Defaults to `WebMercatorQuad`.
+
+    Examples:
+        >>> import xarray
+            from obstore.store import HTTPStore
+            from zarr.storage import ObjectStore
+            from affine import Affine
+            from rasterio.crs import CRS
+            from matplotlib.pyplot import imshow
+
+            # Create Obstore Store
+            store = HTTPStore("https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2B_MSIL2A_20260216T142149_N0512_R096_T25WFV_20260216T165051.zarr")
+            zarr_store = ObjectStore(store=store, read_only=True)
+            dt = xarray.open_datatree(
+                zarr_store,
+                engine="zarr",
+                create_default_indexes=False,
+                consolidated=True,
+            )
+
+            ds = dt["/measurements/reflectance/r720m"]
+
+            attributes = ds.attrs
+
+            tr = attributes["spatial:transform"]
+            transform = Affine(*tr)
+            crs = CRS.from_user_input(attributes["proj:code"])
+
+            with GeoArrayReader(ds["b02"], transform=transform, crs=crs) as dst:
+                img = dst.preview()
+
+    """
+
+    input: xarray.DataArray = attr.ib()
+
+    crs: CRS | None = attr.ib(default=None)
+    transform: Affine | None = attr.ib(default=None)
+
+    tms: TileMatrixSet = attr.ib(default=WEB_MERCATOR_TMS)
+
+    options: Options = attr.ib()
+
+    nbands: int = attr.ib(init=False)
+
+    # List of names for the first dimension (e.g time, bands, etc)
+    band_names: list[str] | None = attr.ib(default=None)
+
+    _dims: list = attr.ib(init=False)
+
+    @options.default
+    def _options_default(self):
+        return {}
+
+    def __attrs_post_init__(self) -> None:
+        """Set bounds and CRS."""
+        assert xarray is not None, "xarray must be installed to use XarrayReader"
+
+        attributes = self.input.attrs
+
+        # Zarr Conventions
+        conventions: list[dict] = attributes.get("zarr_conventions", [])
+
+        # Transform
+        if not self.transform and _has_spatial(conventions):
+            transform_type = attributes.get("spatial:transform_type") or "affine"
+            tr = attributes.get("spatial:transform")
+            if transform_type == "affine" and tr is not None:
+                if attributes.get("spatial:registration", "pixel") == "node":
+                    # NOTE: If the registration is "node", we need to adjust the transform to
+                    # account for the fact that the coordinates refer to the center of the pixel rather than the edge.
+                    tr[2] -= tr[0] / 2
+                    tr[5] -= tr[4] / 2
+
+                self.transform = Affine(*tr)
+
+        assert self.transform, (
+            "Affine transform is required, either as an argument or in `spatial` zarr_conventions"
+        )
+
+        # CRS
+        if not self.crs and _has_proj(conventions):
+            self.crs = _get_proj_crs(attributes)
+
+        assert self.crs, (
+            "CRS is required, either as an argument or in `geo-proj` zarr_conventions"
+        )
+
+        self._dims = [
+            d
+            for d in self.input.dims
+            if d not in ["x", "y", "spatial_ref", "crs_wkt", "grid_mapping"]
+        ]
+        assert len(self._dims) in [0, 1], "Can't handle >=4D DataArray"
+
+        # NOTE: Assume shape of array is (bands, height, width) or (height, width)
+        # and get height/width from the last 2 dimensions of the shape.
+        shape = attributes.get("spatial:shape", self.input.shape)
+        self.height, self.width = shape[-2], shape[-1]
+
+        if len(self.input.shape) == 3:
+            self.nbands = self.input.shape[0]
+        else:
+            self.nbands = 1
+
+        self.bounds = self.input.attrs.get("spatial:bounds")
+        if not self.bounds:
+            self.bounds = array_bounds(self.height, self.width, self.transform)
+
+        if self.crs == WGS84_CRS and (
+            self.bounds[0] < -180
+            or self.bounds[1] < -90
+            or self.bounds[2] > 180
+            or self.bounds[3] > 90
+        ):
+            raise InvalidGeographicBounds(
+                f"Invalid geographic bounds: {self.bounds}. Must be within (-180, -90, 180, 90)."
+            )
+
+        if self.band_names:
+            assert len(self.band_names) == self.nbands, (
+                "Length of band_names must match number of bands in the array"
+            )
+
+    @property
+    def band_descriptions(self) -> list[str]:
+        """
+        Return list of `band descriptions` in DataArray.
+
+        `Bands` are all dimensions not defined as spatial dims by rioxarray.
+        """
+        if self.band_names:
+            return self.band_names
+
+        return [f"b{ix + 1}" for ix in range(self.nbands)]
+
+    @property
+    def minzoom(self):
+        """Return dataset minzoom.
+
+        A dataarray doesn't have overviews so minzoom==maxzoom
+        """
+        return self.maxzoom
+
+    @property
+    def maxzoom(self):
+        """Return dataset maxzoom."""
+        return self._maxzoom
+
+    @property
+    def _nodata_value(self) -> NoData | None:
+        return self.input.attrs.get(
+            "_FillValue",
+            self.input.attrs.get(
+                "missing_value",
+                self.input.attrs.get("fill_value", self.input.attrs.get("nodata")),
+            ),
+        )
+
+    def info(self) -> Info:
+        """Return xarray.DataArray info."""
+        metadata = [band.attrs for d in self._dims for band in self.input[d]] or [{}]
+
+        nodata_type = "None"
+        if self.options.get("nodata", self._nodata_value) is not None:
+            nodata_type = "Nodata"
+
+        meta = {
+            "bounds": self.bounds,
+            "crs": CRS_to_uri(self.crs) or self.crs.to_wkt(),
+            "band_metadata": [(f"b{ix}", v) for ix, v in enumerate(metadata, 1)],
+            "band_descriptions": [
+                (f"b{ix}", v or f"b{ix}")
+                for ix, v in enumerate(self.band_descriptions, 1)
+            ],
+            "dtype": str(self.input.dtype),
+            "nodata_type": nodata_type,
+            "name": self.input.name,
+            "count": self.nbands,
+            "width": self.width,
+            "height": self.height,
+            "dimensions": self.input.dims,
+            "attrs": {
+                k: (v.tolist() if isinstance(v, (numpy.ndarray, numpy.generic)) else v)
+                for k, v in self.input.attrs.items()
+            },
+        }
+
+        return Info.model_validate(meta)
+
+    def statistics(  # type: ignore[override]
+        self,
+        categorical: bool = False,
+        categories: list[float] | None = None,
+        percentiles: list[int] | None = None,
+        hist_options: dict | None = None,
+        indexes: Indexes | None = None,
+        nodata: NoData | None = None,
+        **kwargs: Any,
+    ) -> dict[str, BandStatistics]:
+        """Return statistics from a dataset."""
+        img = self._read(indexes=indexes, nodata=nodata)
+
+        return img.statistics(
+            categorical=categorical,
+            categories=categories,
+            percentiles=percentiles,
+            hist_options=hist_options,
+        )
+
+    def tile(  # type: ignore[override]
+        self,
+        tile_x: int,
+        tile_y: int,
+        tile_z: int,
+        tilesize: int | None = None,
+        indexes: Indexes | None = None,
+        nodata: NoData | None = None,
+        reproject_method: WarpResampling = "nearest",
+        resampling_method: RIOResampling = "nearest",
+        **kwargs: Any,
+    ) -> ImageData:
+        """Read a Web Map tile from a dataset.
+
+        Args:
+            tile_x (int): Tile's horizontal index.
+            tile_y (int): Tile's vertical index.
+            tile_z (int): Tile's zoom level index.
+            tilesize (int, optional): Output tile size. Defaults to TMS tilesize.
+            indexes (sequence of int or int, optional): Band indexes.
+            nodata (int or float, optional): Overwrite dataset internal nodata value.
+            reproject_method (WarpResampling, optional): WarpKernel resampling algorithm. Defaults to `nearest`.
+            resampling_method (RIOResampling, optional): GDAL Resampling method to use when resizing. Defaults to "nearest".
+        Returns:
+            rio_tiler.models.ImageData: ImageData instance with data, mask and tile spatial info.
+
+        """
+        if not self.tile_exists(tile_x, tile_y, tile_z):
+            raise TileOutsideBounds(
+                f"Tile(x={tile_x}, y={tile_y}, z={tile_z}) is outside bounds"
+            )
+
+        matrix = self.tms.matrix(tile_z)
+        bbox = cast(
+            BBox,
+            self.tms.xy_bounds(Tile(x=tile_x, y=tile_y, z=tile_z)),
+        )
+
+        return self.part(
+            bbox,
+            dst_crs=self.tms.rasterio_crs,
+            bounds_crs=self.tms.rasterio_crs,
+            indexes=indexes,
+            max_size=None,
+            height=tilesize or matrix.tileHeight,
+            width=tilesize or matrix.tileWidth,
+            nodata=nodata,
+            reproject_method=reproject_method,
+            resampling_method=resampling_method,
+            **kwargs,
+        )
+
+    def part(  # type: ignore[override]
+        self,
+        bbox: BBox,
+        dst_crs: CRS | None = None,
+        bounds_crs: CRS = WGS84_CRS,
+        indexes: Indexes | None = None,
+        max_size: int | None = None,
+        height: int | None = None,
+        width: int | None = None,
+        nodata: NoData | None = None,
+        reproject_method: WarpResampling = "nearest",
+        resampling_method: RIOResampling = "nearest",
+        **kwargs: Any,
+    ) -> ImageData:
+        """Read part of a dataset.
+
+        Args:
+            bbox (tuple): Output bounds (left, bottom, right, top) in target crs.
+            dst_crs (rasterio.crs.CRS, optional): Target coordinate reference system. Defaults to bounds_crs.
+            bounds_crs (rasterio.crs.CRS, optional): CRS of the input bounds. Defaults to WGS84.
+            indexes (sequence of int or int, optional): Band indexes.
+            max_size (int, optional): Limit the size of the longest dimension.
+            height (int, optional): Output height of the array.
+            width (int, optional): Output width of the array.
+            nodata (int or float, optional): Overwrite dataset internal nodata value.
+            reproject_method (WarpResampling, optional): WarpKernel resampling algorithm. Defaults to `nearest`.
+            resampling_method (RIOResampling, optional): GDAL Resampling method to use when resizing. Defaults to "nearest".
+
+        Returns:
+            rio_tiler.models.ImageData: ImageData instance with data, mask and input spatial info.
+
+        """
+        if max_size and (width or height):
+            warnings.warn(
+                "'max_size' will be ignored with with 'height' or 'width' set.",
+                UserWarning,
+            )
+            max_size = None
+
+        dst_crs = dst_crs or bounds_crs
+
+        # Transform bbox from bounds_crs → dst_crs
+        if bounds_crs != dst_crs:
+            bbox = transform_bounds(bounds_crs, dst_crs, *bbox, densify_pts=21)
+
+        # 1. Estimate output dimensions
+        if dst_crs != self.crs:
+            # Case 1: Reprojection needed
+            # - reproject bbox to dataset CRS
+            # - compute native output shape in dataset resolution/CRS
+            # - compute output shape in output CRS
+            dst_bounds = transform_bounds(dst_crs, self.crs, *bbox, densify_pts=21)
+            native_src_w = max(
+                1, round((dst_bounds[2] - dst_bounds[0]) / abs(self.transform.a))
+            )
+            native_src_h = max(
+                1, round((dst_bounds[3] - dst_bounds[1]) / abs(self.transform.e))
+            )
+            _, dst_width, dst_height = calculate_default_transform(
+                self.crs, dst_crs, native_src_w, native_src_h, *dst_bounds
+            )
+        else:
+            # Case 2: No reprojection needed
+            # - keep output dataset bbox as input bbox
+            # - compute output shape in dataset resolution/CRS
+            dst_bounds = bbox
+            dst_width = max(1, round((bbox[2] - bbox[0]) / abs(self.transform.a)))
+            dst_height = max(1, round((bbox[3] - bbox[1]) / abs(self.transform.e)))
+
+        # Case 1: `max_size` is set,
+        # compute output shape based on it,
+        # respecting aspect ratio of the output bbox (dst_width/dst_height)
+        if max_size:
+            height, width = _get_width_height(max_size, dst_height, dst_width)
+
+        # Case 2: One of width/height is missing,
+        # compute it but keep the aspect ratio from the max output bbox (dst_width/dst_height)
+        elif _missing_size(width, height):
+            ratio = dst_height / dst_width
+            if width:
+                height = math.ceil(width * ratio)
+            else:
+                width = math.ceil(height / ratio)
+
+        # 2. Output shape (in the output CRS)
+        height = cast(int, height or dst_height)
+        width = cast(int, width or dst_width)
+
+        # 3. Build pixel window from bounds in dataset CRS
+        rasterio_win = window_from_bounds(*dst_bounds, transform=self.transform)
+        row_off = math.floor(rasterio_win.row_off)
+        col_off = math.floor(rasterio_win.col_off)
+        win_width = math.ceil(rasterio_win.width) + 1
+        win_height = math.ceil(rasterio_win.height) + 1
+
+        # Validate intersection
+        col_end = min(self.width, math.ceil(rasterio_win.col_off + rasterio_win.width))
+        row_end = min(self.height, math.ceil(rasterio_win.row_off + rasterio_win.height))
+        if col_off >= col_end or row_off >= row_end:
+            raise ValueError("Input BBOX and dataset bounds do not intersect")
+
+        # Clamp window to array bounds
+        clipped_col_off = max(0, col_off)
+        clipped_row_off = max(0, row_off)
+        clipped_col_stop = min(self.width, col_off + win_width)
+        clipped_row_stop = min(self.height, row_off + win_height)
+
+        # 3. Read data from zarr array
+        img = self._read(
+            indexes=indexes,
+            row_slice=slice(clipped_row_off, clipped_row_stop),
+            col_slice=slice(clipped_col_off, clipped_col_stop),
+            nodata=nodata,
+        )
+
+        # 4. Reproject/resample to output CRS and dimensions
+        img = warp(
+            img,
+            dst_crs=dst_crs,
+            dst_bounds=bbox,
+            dst_width=width,
+            dst_height=height,
+            reproject_method=reproject_method,
+            resampling_method=resampling_method,
+        )
+        return img
+
+    def preview(  # type: ignore[override]
+        self,
+        indexes: Indexes | None = None,
+        dst_crs: CRS | None = None,
+        max_size: int | None = 1024,
+        height: int | None = None,
+        width: int | None = None,
+        nodata: NoData | None = None,
+        resampling_method: RIOResampling = "nearest",
+        reproject_method: WarpResampling = "nearest",
+        **kwargs: Any,
+    ) -> ImageData:
+        """Read a preview of a Dataset.
+
+        Args:
+            indexes (sequence of int or int, optional): Band indexes.
+            dst_crs (rasterio.crs.CRS, optional): Target coordinate reference system. Defaults to None (same as input).
+            max_size (int, optional): Limit the size of the longest dimension of the dataset read, respecting bounds X/Y aspect ratio. Defaults to 1024.
+            height (int, optional): Output height of the array.
+            width (int, optional): Output width of the array.
+            nodata (int or float, optional): Overwrite dataset internal nodata value.
+            resampling_method (RIOResampling, optional): GDAL Resampling method to use when resizing. Defaults to "nearest".
+            reproject_method (WarpResampling, optional): WarpKernel resampling algorithm. Defaults to `nearest`.
+
+        Returns:
+            rio_tiler.models.ImageData: ImageData instance with data, mask and input spatial info.
+
+        """
+        if max_size and (width or height):
+            warnings.warn(
+                "'max_size' will be ignored with with 'height' or 'width' set.",
+                UserWarning,
+            )
+            max_size = None
+
+        # 1. Determine output shape
+        # get height/width of the dataset in the output CRS
+        dst_width = self.width
+        dst_height = self.height
+        row_slice = None
+        if dst_crs and dst_crs != self.crs:
+            # Get shape of the dataset in the output CRS
+            src_width = self.width
+            src_height = self.height
+            src_bounds = list(self.bounds)
+            if (
+                self.crs == WGS84_CRS
+                and dst_crs == WEB_MERCATOR_CRS
+                and (self.bounds[1] < -85.06 or self.bounds[3] > 85.06)
+            ):
+                warnings.warn(
+                    "Adjusting dataset latitudes to avoid re-projection overflow (EPSG:4326 -> EPSG:3857) for latitudes outside of Web Mercator limits (-85.06, 85.06).",
+                    UserWarning,
+                )
+                src_bounds[1] = max(src_bounds[1], -85.06)
+                src_bounds[3] = min(src_bounds[3], 85.06)
+
+                rasterio_win = window_from_bounds(*src_bounds, transform=self.transform)
+                src_height = round(rasterio_win.height)
+                row_off = math.floor(rasterio_win.row_off)
+                win_height = math.ceil(rasterio_win.height) + 1
+                row_slice = slice(row_off, row_off + win_height)
+
+            _, dst_width, dst_height = calculate_default_transform(
+                self.crs, dst_crs, src_width, src_height, *src_bounds
+            )
+
+        if max_size:
+            height, width = _get_width_height(max_size, dst_height, dst_width)
+
+        elif _missing_size(width, height):
+            ratio = dst_height / dst_width
+            if width:
+                height = math.ceil(width * ratio)
+            else:
+                width = math.ceil(height / ratio)
+
+        # Shape in the output CRS
+        height = height or dst_height
+        width = width or dst_width
+
+        # 2. Read data
+        img = self._read(indexes=indexes, row_slice=row_slice, nodata=nodata)
+
+        # 3. Reproject if needed
+        if dst_crs and dst_crs != self.crs:
+            img = img.reproject(
+                dst_crs=dst_crs,
+                reproject_method=reproject_method,
+            )
+
+        # 4. Resize
+        if width != img.width or height != img.height:
+            img = img.resize(
+                width=width,
+                height=height,
+                resampling_method=resampling_method,
+            )
+
+        return img
+
+    def point(  # type: ignore[override]
+        self,
+        lon: float,
+        lat: float,
+        coord_crs: CRS = WGS84_CRS,
+        indexes: Indexes | None = None,
+        nodata: NoData | None = None,
+        **kwargs: Any,
+    ) -> PointData:
+        """Read a value from a Dataset.
+
+        Args:
+            lon (float): Longitude.
+            lat (float): Latitude.
+            coord_crs (rasterio.crs.CRS, optional): Coordinate Reference System of the input coords. Defaults to `epsg:4326`.
+            indexes (sequence of int or int, optional): Band indexes.
+            nodata: (int or float, optional): Overwrite dataset internal nodata value. Defaults to `None`.
+
+        Returns:
+            PointData: Pixel value per bands/assets.
+
+        """
+        coordinates = (lon, lat)
+        if coord_crs != self.crs:
+            xs, ys = transform_coords(coord_crs, self.crs, [lon], [lat])
+            lon, lat = xs[0], ys[0]
+
+        dataset_min_lon, dataset_min_lat, dataset_max_lon, dataset_max_lat = self.bounds
+        # check if latitude is inverted
+        if dataset_min_lat > dataset_max_lat:
+            warnings.warn(
+                "BoundingBox of the dataset is inverted (minLat > maxLat).",
+                UserWarning,
+            )
+
+        dataset_min_lat, dataset_max_lat = (
+            min(dataset_min_lat, dataset_max_lat),
+            max(dataset_min_lat, dataset_max_lat),
+        )
+        if not (
+            (dataset_min_lon < lon < dataset_max_lon)
+            and (dataset_min_lat < lat < dataset_max_lat)
+        ):
+            raise PointOutsideBounds("Point is outside dataset bounds")
+
+        y, x = rowcol(self.transform, [lon], [lat])
+
+        da, band_descriptions = self._sel_indexes(indexes)
+        arr: numpy.ma.MaskedArray
+        if da.ndim == 2:
+            arr = da[int(y[0]), int(x[0])].to_masked_array()
+            arr = numpy.expand_dims(arr, axis=0)  # type: ignore[assignment]
+        else:
+            arr = da[:, int(y[0]), int(x[0])].to_masked_array()
+
+        nodata = (
+            nodata
+            if nodata is not None
+            else self.options.get("nodata", self._nodata_value)
+        )
+        if nodata is not None:
+            arr.mask |= arr.data == nodata
+
+        indexes = cast_to_sequence(indexes)
+        if not indexes:
+            indexes = list(range(1, arr.shape[0] + 1))
+
+        return PointData(
+            arr,
+            coordinates=coordinates,
+            crs=coord_crs,
+            band_names=[f"b{idx}" for idx in indexes],
+            band_descriptions=band_descriptions,
+            pixel_location=(x.tolist()[0], y.tolist()[0]),
+            nodata=nodata,
+        )
+
+    def _read(
+        self,
+        row_slice: slice | None = None,
+        col_slice: slice | None = None,
+        indexes: Indexes | None = None,
+        nodata: NoData | None = None,
+    ) -> ImageData:
+        """Read data from zarr AsyncArray.
+
+        Args:
+            indexes: Band indexes (1-based). If None, reads all bands.
+            row_slice: Row slice for windowed read.
+            col_slice: Column slice for windowed read.
+            nodata (int or float, optional): Overwrite dataset internal nodata value.
+
+        Returns:
+            ImageData: Image data with mask and spatial info.
+
+        """
+        da, band_descriptions = self._sel_indexes(indexes)
+
+        row_slice = row_slice or slice(0, self.height)
+        col_slice = col_slice or slice(0, self.width)
+
+        arr: numpy.ma.MaskedArray
+        if len(da.shape) == 2:
+            # 2D array: (height, width)
+
+            # Calculate array size in bytes
+            read_height = row_slice.stop - row_slice.start
+            read_width = col_slice.stop - col_slice.start
+            nbytes = read_height * read_width * self.input.dtype.itemsize
+            if nbytes > MAX_ARRAY_SIZE:
+                raise MaxArraySizeError(
+                    f"Maximum array limit {MAX_ARRAY_SIZE} reached, trying to put Array of {(1, read_height, read_width)} in memory."
+                )
+
+            arr = da[row_slice, col_slice].to_masked_array()
+            arr = numpy.expand_dims(arr, axis=0)  # type: ignore[assignment]
+
+        else:
+            # 3D array: (bands, height, width)
+            nbands = da.shape[0]
+
+            # Calculate array size in bytes
+            read_height = row_slice.stop - row_slice.start
+            read_width = col_slice.stop - col_slice.start
+            nbytes = nbands * read_height * read_width * self.input.dtype.itemsize
+            if nbytes > MAX_ARRAY_SIZE:
+                raise MaxArraySizeError(
+                    f"Maximum array limit {MAX_ARRAY_SIZE} reached, trying to put Array of {(nbands, read_height, read_width)} in memory."
+                )
+
+            arr = da[:, row_slice, col_slice].to_masked_array()
+
+        # if data has Nodata then we simply make sure the mask == the nodata
+        nodata = (
+            nodata
+            if nodata is not None
+            else self.options.get("nodata", self._nodata_value)
+        )
+        if nodata is not None:
+            arr.mask |= arr.data == nodata
+
+        # Calculate bounds for the read window
+        read_height = row_slice.stop - row_slice.start
+        read_width = col_slice.stop - col_slice.start
+        read_transform = self.transform * Affine.translation(
+            col_slice.start, row_slice.start
+        )
+        read_bounds = array_bounds(read_height, read_width, read_transform)
+
+        indexes = cast_to_sequence(indexes)
+        if not indexes:
+            indexes = list(range(1, arr.shape[0] + 1))
+
+        # Forward valid_min/valid_max to the ImageData object
+        minv, maxv = da.attrs.get("valid_min"), da.attrs.get("valid_max")
+        stats = None
+        if minv is not None and maxv is not None:
+            stats = ((minv, maxv),) * arr.shape[0]
+
+        return ImageData(
+            arr,
+            bounds=read_bounds,
+            band_names=[f"b{idx}" for idx in indexes],
+            band_descriptions=band_descriptions,
+            crs=self.crs,
+            dataset_statistics=stats,
+            nodata=nodata,
+        )

--- a/rio_tiler/experimental/xarray.py
+++ b/rio_tiler/experimental/xarray.py
@@ -680,14 +680,12 @@ class GeoArrayReader(XarrayReader):
 
         row_slice = row_slice or slice(0, self.height)
         col_slice = col_slice or slice(0, self.width)
+        read_height = row_slice.stop - row_slice.start
+        read_width = col_slice.stop - col_slice.start
 
         arr: numpy.ma.MaskedArray
         if len(da.shape) == 2:
             # 2D array: (height, width)
-
-            # Calculate array size in bytes
-            read_height = row_slice.stop - row_slice.start
-            read_width = col_slice.stop - col_slice.start
             nbytes = read_height * read_width * self.input.dtype.itemsize
             if nbytes > MAX_ARRAY_SIZE:
                 raise MaxArraySizeError(
@@ -699,15 +697,10 @@ class GeoArrayReader(XarrayReader):
 
         else:
             # 3D array: (bands, height, width)
-            nbands = da.shape[0]
-
-            # Calculate array size in bytes
-            read_height = row_slice.stop - row_slice.start
-            read_width = col_slice.stop - col_slice.start
-            nbytes = nbands * read_height * read_width * self.input.dtype.itemsize
+            nbytes = da.shape[0] * read_height * read_width * self.input.dtype.itemsize
             if nbytes > MAX_ARRAY_SIZE:
                 raise MaxArraySizeError(
-                    f"Maximum array limit {MAX_ARRAY_SIZE} reached, trying to put Array of {(nbands, read_height, read_width)} in memory."
+                    f"Maximum array limit {MAX_ARRAY_SIZE} reached, trying to put Array of {(da.shape[0], read_height, read_width)} in memory."
                 )
 
             arr = da[:, row_slice, col_slice].to_masked_array()
@@ -722,8 +715,6 @@ class GeoArrayReader(XarrayReader):
             arr.mask |= arr.data == nodata
 
         # Calculate bounds for the read window
-        read_height = row_slice.stop - row_slice.start
-        read_width = col_slice.stop - col_slice.start
         read_transform = self.transform * Affine.translation(
             col_slice.start, row_slice.start
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """``pytest`` configuration."""
 
+import sys
 from io import BytesIO
 from typing import Sequence
 
@@ -21,6 +22,10 @@ with rasterio.Env() as env:
 
 requires_webp = pytest.mark.skipif(
     "WEBP" not in drivers.keys(), reason="Only relevant if WEBP drivers is supported"
+)
+
+requires_lt314 = pytest.mark.skipif(
+    sys.version_info >= (3, 14), reason="Requires python3.13 or lower"
 )
 
 

--- a/tests/test_geoxarray.py
+++ b/tests/test_geoxarray.py
@@ -1,0 +1,487 @@
+"""tests rio_tiler.io.xarray.XarrayReader"""
+
+from datetime import datetime
+
+import morecantile
+import numpy
+import pytest
+import xarray
+import zarr
+from affine import Affine
+from rasterio.crs import CRS
+from xarray.backends.zarr import FillValueCoder
+
+from rio_tiler.experimental.xarray import GeoArrayReader
+from rio_tiler.io import XarrayReader
+
+
+def test_geoxarray_reader():
+    """test XarrayReader."""
+    arr = numpy.arange(0.0, 3600 * 1800 * 2, dtype="float32").reshape(2, 1800, 3600)
+    data = xarray.DataArray(
+        arr,
+        dims=("time", "y", "x"),
+        coords={
+            "time": [datetime(2022, 1, 1), datetime(2022, 1, 2)],
+        },
+    )
+    data.attrs.update({"valid_min": arr.min(), "valid_max": arr.max()})
+
+    with GeoArrayReader(
+        input=data,
+        crs=CRS.from_epsg(4326),
+        transform=Affine.translation(-180, 90) * Affine.scale(0.1, -0.1),
+    ) as dst:
+        assert dst.crs == CRS.from_epsg(4326)
+        assert dst.bounds == (-180.0, -90.0, 180.0, 90.0)
+        assert dst.minzoom == dst.maxzoom == 0
+        info = dst.info()
+        assert info.band_metadata == [("b1", {}), ("b2", {})]
+        assert info.band_descriptions == [
+            ("b1", "b1"),
+            ("b2", "b2"),
+        ]
+        assert info.height == 1800
+        assert info.width == 3600
+        assert info.count == 2
+        assert info.attrs
+        assert info.dimensions == ("time", "y", "x")
+
+    with GeoArrayReader(
+        input=data,
+        crs=CRS.from_epsg(4326),
+        transform=Affine.translation(-180, 90) * Affine.scale(0.1, -0.1),
+        band_names=["2022-01-01T00:00:00.000000", "2022-01-02T00:00:00.000000"],
+    ) as dst:
+        info = dst.info()
+        assert info.band_descriptions == [
+            ("b1", "2022-01-01T00:00:00.000000"),
+            ("b2", "2022-01-02T00:00:00.000000"),
+        ]
+
+        stats = dst.statistics()
+        assert list(stats) == [
+            "b1",
+            "b2",
+        ]
+        assert stats["b1"].min == 0.0
+
+        stats = dst.statistics(indexes=1)
+        assert list(stats) == ["b1"]
+        assert stats["b1"].description == "2022-01-01T00:00:00.000000"
+
+        stats = dst.statistics(indexes=2)
+        assert list(stats) == ["b2"]
+        assert stats["b2"].description == "2022-01-02T00:00:00.000000"
+
+        stats = dst.statistics(indexes=(1, 2))
+        assert list(stats) == [
+            "b1",
+            "b2",
+        ]
+
+        with pytest.raises(AssertionError):
+            stats = dst.statistics(indexes=0)
+
+        img = dst.tile(0, 0, 0)
+        assert img.count == 2
+        assert img.width == 256
+        assert img.height == 256
+        assert img.array.dtype == numpy.float32
+        assert img.band_descriptions == [
+            "2022-01-01T00:00:00.000000",
+            "2022-01-02T00:00:00.000000",
+        ]
+        assert img.dataset_statistics == ((arr.min(), arr.max()), (arr.min(), arr.max()))
+
+        img = dst.tile(0, 0, 0, indexes=2)
+        assert img.count == 1
+        assert img.band_descriptions == [
+            "2022-01-02T00:00:00.000000",
+        ]
+
+        tms = morecantile.tms.get("WebMercatorQuad")
+        zoom = 10
+        x, y = tms.xy(-170, -80)
+        tile = tms._tile(x, y, zoom)
+        bounds = tms.xy_bounds(tile)
+
+        # Test that a high-zoom tile will succeed
+        img = dst.tile(tile.x, tile.y, zoom, indexes=1)
+        assert img.count == 1
+        assert img.width == 256
+        assert img.height == 256
+        assert img.bounds == bounds
+        assert img.dataset_statistics == ((arr.min(), arr.max()),)
+
+        img = dst.part((-160, -80, 160, 80), indexes=1)
+        assert img.crs == "epsg:4326"
+        assert img.count == 1
+        assert img.band_descriptions == ["2022-01-01T00:00:00.000000"]
+        assert img.array.shape == (1, 1600, 3200)
+        assert img.array.dtype == numpy.float32
+
+        img = dst.part((-160, -80, 160, 80), dst_crs="epsg:3857", indexes=1)
+        assert img.crs == "epsg:3857"
+        assert img.count == 1
+        assert img.band_descriptions == ["2022-01-01T00:00:00.000000"]
+        assert img.array.shape == (1, 2352, 2696)
+
+        img = dst.part(
+            (-160, -80, 160, 80), dst_crs="epsg:3857", indexes=1, max_size=1024
+        )
+        assert img.crs == "epsg:3857"
+        assert img.count == 1
+        assert img.band_descriptions == ["2022-01-01T00:00:00.000000"]
+        assert img.array.shape == (1, 894, 1024)
+
+        img = dst.part((-160, -80, 160, 80), max_size=15, indexes=1)
+        assert img.array.shape == (1, 8, 15)
+
+        img = dst.part((-160, -80, 160, 80), width=40, height=35, indexes=1)
+        assert img.array.shape == (1, 35, 40)
+
+        img = dst.part(
+            (-160, -80, 160, 80), max_size=15, resampling_method="bilinear", indexes=1
+        )
+        assert img.array.shape == (1, 8, 15)
+
+        img = dst.preview()
+        assert img.crs == "epsg:4326"
+        assert img.count == 2
+        assert img.array.dtype == numpy.float32
+        assert img.band_descriptions == [
+            "2022-01-01T00:00:00.000000",
+            "2022-01-02T00:00:00.000000",
+        ]
+        assert img.array.shape == (2, 512, 1024)
+
+        img = dst.preview(indexes=1)
+        assert img.crs == "epsg:4326"
+        assert img.count == 1
+        assert img.band_descriptions == ["2022-01-01T00:00:00.000000"]
+        assert img.array.shape == (1, 512, 1024)
+
+        img = dst.preview(dst_crs="epsg:3857", indexes=2)
+        assert img.crs == "epsg:3857"
+        assert img.count == 1
+        assert img.band_descriptions == ["2022-01-02T00:00:00.000000"]
+        assert img.array.shape == (1, 1024, 1024)
+
+        img = dst.preview(max_size=None, indexes=1)
+        assert img.array.shape == (1, 1800, 3600)
+
+        img = dst.preview(dst_crs="epsg:3857", max_size=15, indexes=1)
+        assert img.array.shape == (1, 15, 15)
+
+        img = dst.preview(max_size=15, indexes=1)
+        assert img.array.shape == (1, 8, 15)
+
+        img = dst.preview(height=25, width=25, max_size=None, indexes=1)
+        assert img.array.shape == (1, 25, 25)
+
+        feat = {
+            "type": "Feature",
+            "properties": {},
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [-92.46093749999999, 72.91963546581484],
+                        [-148.0078125, 33.137551192346145],
+                        [-143.08593749999997, -28.613459424004414],
+                        [43.9453125, -47.04018214480665],
+                        [142.734375, -12.897489183755892],
+                        [157.5, 68.13885164925573],
+                        [58.71093750000001, 74.95939165894974],
+                        [-40.42968749999999, 75.14077784070429],
+                        [-92.46093749999999, 72.91963546581484],
+                    ]
+                ],
+            },
+        }
+        img = dst.feature(feat)
+        assert img.count == 2
+        assert img.array.dtype == numpy.float32
+        assert img.band_descriptions == [
+            "2022-01-01T00:00:00.000000",
+            "2022-01-02T00:00:00.000000",
+        ]
+        assert img.array.shape == (2, 1222, 3055)
+
+        img = dst.feature(feat, indexes=2)
+        assert img.count == 1
+        assert img.band_descriptions == ["2022-01-02T00:00:00.000000"]
+        assert img.array.shape == (1, 1222, 3055)
+
+        img = dst.feature(feat, dst_crs="epsg:3857", indexes=1)
+        assert img.count == 1
+        assert img.band_descriptions == ["2022-01-01T00:00:00.000000"]
+        assert img.crs == "epsg:3857"
+        assert img.array.shape == (1, 1601, 2875)
+
+        img = dst.feature(feat, max_size=15, indexes=1)
+        assert img.array.shape == (1, 6, 15)
+
+        img = dst.feature(feat, width=50, height=45, indexes=1)
+        assert img.array.shape == (1, 45, 50)
+
+
+def test_geoxarray_reader_point():
+    """test XarrayReader."""
+    arr = numpy.arange(0.0, 3600 * 1800 * 2, dtype="float32").reshape(2, 1800, 3600)
+    data = xarray.DataArray(
+        arr,
+        dims=("time", "y", "x"),
+        coords={
+            "x": numpy.arange(-179.9, 180.1, 0.1),
+            "y": numpy.arange(89.9, -90.1, -0.1),
+            "time": [datetime(2022, 1, 1), datetime(2022, 1, 2)],
+        },
+    )
+    data.attrs.update({"valid_min": arr.min(), "valid_max": arr.max()})
+
+    with GeoArrayReader(
+        input=data,
+        crs=CRS.from_epsg(4326),
+        transform=Affine.translation(-180, 90) * Affine.scale(0.1, -0.1),
+        band_names=["2022-01-01T00:00:00.000000", "2022-01-02T00:00:00.000000"],
+    ) as dst:
+        pt = dst.point(0, 0)
+        assert pt.count == 2
+        assert pt.band_descriptions == [
+            "2022-01-01T00:00:00.000000",
+            "2022-01-02T00:00:00.000000",
+        ]
+        assert pt.coordinates
+        assert pt.pixel_location
+        assert pt.array.dtype == numpy.float32
+
+        xys = [[0, 2.499], [0, 2.501], [-4.999, 0], [-5.001, 0], [-170, 80]]
+        for xy in xys:
+            x = xy[0]
+            y = xy[1]
+            pt = dst.point(x, y)
+            coords = pt.pixel_location
+            numpy.testing.assert_array_equal(
+                pt.data,
+                data.values[:, coords[1], coords[0]],
+            )
+
+            # The GeoArray Reader assume coordinates registration to be `pixel` while
+            # the xarray coordinates represent the center of the pixel.
+            # So we need to shift the coordinates by half a pixel to get the correct value.
+            transform = dst.transform
+            x += transform.a / 2
+            y += transform.e / 2
+
+            numpy.testing.assert_array_equal(
+                pt.data, data.sel(x=x, y=y, method="nearest").to_numpy()
+            )
+
+        pt = dst.point(0, 0, indexes=2)
+        assert pt.count == 1
+        assert pt.band_descriptions == ["2022-01-02T00:00:00.000000"]
+        assert pt.coordinates
+        xys = [[0, 2.499], [0, 2.501], [-4.999, 0], [-5.001, 0], [-170, 80]]
+        for xy in xys:
+            x = xy[0]
+            y = xy[1]
+            pt = dst.point(x, y)
+            transform = dst.transform
+            x += transform.a / 2
+            y += transform.e / 2
+            assert pt.data[0] == data.sel(
+                time="2022-01-01T00:00:00.000000", x=x, y=y, method="nearest"
+            )
+
+
+def test_geoxarray_reader_compat():
+    """test XarrayReader."""
+    arr = numpy.arange(0.0, 3600 * 1800 * 2, dtype="float32").reshape(2, 1800, 3600)
+    data = xarray.DataArray(
+        arr,
+        dims=("time", "y", "x"),
+        coords={
+            "x": numpy.arange(-179.9, 180.1, 0.1),
+            "y": numpy.arange(89.9, -90.1, -0.1),
+            "time": [datetime(2022, 1, 1), datetime(2022, 1, 2)],
+        },
+    )
+    data.attrs.update({"valid_min": arr.min(), "valid_max": arr.max()})
+    data.rio.write_crs("epsg:4326", inplace=True)
+
+    geo_dst = GeoArrayReader(
+        input=data,
+        crs=CRS.from_epsg(4326),
+        transform=Affine.translation(-180, 90) * Affine.scale(0.1, -0.1),
+        band_names=["2022-01-01T00:00:00.000000", "2022-01-02T00:00:00.000000"],
+    )
+
+    dst = XarrayReader(data)
+    assert dst.crs == geo_dst.crs
+
+    assert dst.transform != geo_dst.transform
+
+    # The bounds of the XarrayReader are calculated from the coordinates (node registration),
+    # while the bounds of the GeoArrayReader are calculated from the transform.
+    assert dst.bounds != geo_dst.bounds
+
+    info = dst.info()
+    geoinfo = geo_dst.info()
+    assert info.band_descriptions == geoinfo.band_descriptions
+
+    stats = dst.statistics()
+    geostat = geo_dst.statistics()
+    assert list(stats) == list(geostat)
+
+    tms = morecantile.tms.get("WebMercatorQuad")
+    zoom = 10
+    x, y = tms.xy(-170, -80)
+    tile = tms._tile(x, y, zoom)
+
+    img = dst.tile(tile.x, tile.y, zoom, indexes=1)
+    geoimg = geo_dst.tile(tile.x, tile.y, zoom, indexes=1)
+
+    numpy.testing.assert_allclose(img.array, geoimg.array, rtol=0.001)
+
+
+def test_geoxarray_nodata():
+    """test nodata in xarray."""
+    arr = numpy.arange(0.0, 3600 * 1800, dtype="float32").reshape(1800, 3600)
+    arr[0:50, 0:50] = 0.0  # we set the top-left corner to 0
+
+    data = xarray.DataArray(arr, dims=("y", "x"))
+    data.attrs.update(
+        {
+            "valid_min": arr.min(),
+            "valid_max": arr.max(),
+            "_FillValue": 0.0,
+        }
+    )
+
+    with GeoArrayReader(
+        input=data,
+        crs=CRS.from_epsg(4326),
+        transform=Affine.translation(-180, 90) * Affine.scale(0.1, -0.1),
+        options={},
+    ) as dst:
+        info = dst.info()
+        assert info.nodata_type == "Nodata"
+
+        img = dst.preview()
+        assert numpy.ma.is_masked(img.array)
+        assert img.array.mask[0, 0, 0]
+        assert not img.array.mask[0, -1, -1]
+
+    # missing_value
+    data = xarray.DataArray(arr, dims=("y", "x"))
+    data.attrs.update(
+        {
+            "valid_min": arr.min(),
+            "valid_max": arr.max(),
+            "missing_value": 0.0,
+        }
+    )
+    with GeoArrayReader(
+        input=data,
+        crs=CRS.from_epsg(4326),
+        transform=Affine.translation(-180, 90) * Affine.scale(0.1, -0.1),
+        options={},
+    ) as dst:
+        info = dst.info()
+        assert info.nodata_type == "Nodata"
+
+        img = dst.preview()
+        assert numpy.ma.is_masked(img.array)
+        assert img.array.mask[0, 0, 0]
+        assert not img.array.mask[0, -1, -1]
+
+    # fill_value (Xarray specific)
+    data = xarray.DataArray(arr, dims=("y", "x"))
+    data.attrs.update(
+        {
+            "valid_min": arr.min(),
+            "valid_max": arr.max(),
+            "fill_value": 0.0,
+        }
+    )
+    with GeoArrayReader(
+        input=data,
+        crs=CRS.from_epsg(4326),
+        transform=Affine.translation(-180, 90) * Affine.scale(0.1, -0.1),
+        options={},
+    ) as dst:
+        info = dst.info()
+        assert info.nodata_type == "Nodata"
+
+        img = dst.preview()
+        assert numpy.ma.is_masked(img.array)
+        assert img.array.mask[0, 0, 0]
+        assert not img.array.mask[0, -1, -1]
+
+    # nodata - GDAL like
+    data = xarray.DataArray(arr, dims=("y", "x"))
+    data.attrs.update(
+        {
+            "valid_min": arr.min(),
+            "valid_max": arr.max(),
+            "nodata": 0.0,
+        }
+    )
+
+    with GeoArrayReader(
+        input=data,
+        crs=CRS.from_epsg(4326),
+        transform=Affine.translation(-180, 90) * Affine.scale(0.1, -0.1),
+        options={},
+    ) as dst:
+        info = dst.info()
+        assert info.nodata_type == "Nodata"
+
+        img = dst.preview()
+        assert numpy.ma.is_masked(img.array)
+        assert img.array.mask[0, 0, 0]
+        assert not img.array.mask[0, -1, -1]
+
+
+def test_geoxarray_zarr_nodata():
+    """Add Nodata metadata within a Zarr Array."""
+    store = zarr.storage.MemoryStore()
+    dataset = zarr.create_group(store=store)
+    zarrobj = dataset.create_array(
+        "data",
+        shape=(100, 100),
+        chunks=(50, 50),
+        dtype="float32",
+        fill_value=-9999.0,
+        dimension_names=("y", "x"),
+        attributes={
+            "_FillValue": FillValueCoder.encode(-9999.0, numpy.dtype("float32")),
+        },
+    )
+    zarrobj[:] = numpy.arange(0.0, 3600 * 1800, dtype="float32").reshape(1800, 3600)
+    zarrobj[0:50, 0:50] = -9999.0  # Add some nodata
+    zarr.consolidate_metadata(dataset.store)
+
+    ds = xarray.open_dataset(
+        store,  # type: ignore
+        decode_times=False,
+        decode_coords=False,
+        consolidated=True,
+        engine="zarr",
+    )
+
+    xarray_array = ds["data"]
+    geods = GeoArrayReader(
+        input=xarray_array,
+        crs=CRS.from_epsg(4326),
+        transform=Affine.translation(-180, 90) * Affine.scale(0.1, -0.1),
+        options={},
+    )
+    # The FillValue is not a `nodata` value per say in Zarr V3 model
+    assert geods._nodata_value is None
+    img = geods.preview()
+    assert numpy.ma.is_masked(img.array)
+    assert img.array.mask[0, 0, 0]
+    assert not img.array.mask[0, -1, -1]

--- a/tests/test_geoxarray.py
+++ b/tests/test_geoxarray.py
@@ -14,6 +14,8 @@ from xarray.backends.zarr import FillValueCoder
 from rio_tiler.experimental.xarray import GeoArrayReader
 from rio_tiler.io import XarrayReader
 
+from .conftest import requires_lt314
+
 
 def test_geoxarray_reader():
     """test XarrayReader."""
@@ -468,6 +470,7 @@ def zarr_dataset():
     return store
 
 
+@requires_lt314
 def test_geoxarray_zarr_fill_value(zarr_dataset):
     """Interpret fill_value as Nodata within a Zarr Array."""
     ds = xarray.open_zarr(

--- a/tests/test_geoxarray.py
+++ b/tests/test_geoxarray.py
@@ -23,9 +23,6 @@ def test_geoxarray_reader():
     data = xarray.DataArray(
         arr,
         dims=("time", "y", "x"),
-        coords={
-            "time": [datetime(2022, 1, 1), datetime(2022, 1, 2)],
-        },
     )
     data.attrs.update({"valid_min": arr.min(), "valid_max": arr.max()})
 
@@ -33,15 +30,21 @@ def test_geoxarray_reader():
         input=data,
         crs=CRS.from_epsg(4326),
         transform=Affine.translation(-180, 90) * Affine.scale(0.1, -0.1),
+        band_names=["2022-01-01T00:00:00.000000", "2022-01-02T00:00:00.000000"],
     ) as dst:
+        assert dst.band_descriptions == [
+            "2022-01-01T00:00:00.000000",
+            "2022-01-02T00:00:00.000000",
+        ]
+
         assert dst.crs == CRS.from_epsg(4326)
         assert dst.bounds == (-180.0, -90.0, 180.0, 90.0)
         assert dst.minzoom == dst.maxzoom == 0
         info = dst.info()
         assert info.band_metadata == [("b1", {}), ("b2", {})]
         assert info.band_descriptions == [
-            ("b1", "b1"),
-            ("b2", "b2"),
+            ("b1", "2022-01-01T00:00:00.000000"),
+            ("b2", "2022-01-02T00:00:00.000000"),
         ]
         assert info.height == 1800
         assert info.width == 3600
@@ -227,6 +230,79 @@ def test_geoxarray_reader():
 
         img = dst.feature(feat, width=50, height=45, indexes=1)
         assert img.array.shape == (1, 45, 50)
+
+
+def test_geoxarray_reader_coordinates():
+    """test XarrayReader."""
+    # 3D array with time coordinates
+    arr = numpy.arange(0.0, 3600 * 1800 * 2, dtype="float32").reshape(2, 1800, 3600)
+    data = xarray.DataArray(
+        arr,
+        dims=("time", "y", "x"),
+        coords={
+            "time": [datetime(2022, 1, 1), datetime(2022, 1, 2)],
+        },
+    )
+
+    with GeoArrayReader(
+        input=data,
+        crs=CRS.from_epsg(4326),
+        transform=Affine.translation(-180, 90) * Affine.scale(0.1, -0.1),
+    ) as dst:
+        assert dst.band_descriptions == [
+            "2022-01-01T00:00:00.000000",
+            "2022-01-02T00:00:00.000000",
+        ]
+        info = dst.info()
+        assert info.band_descriptions == [
+            ("b1", "2022-01-01T00:00:00.000000"),
+            ("b2", "2022-01-02T00:00:00.000000"),
+        ]
+
+    # 2D array without coordinates
+    arr = numpy.arange(0.0, 3600 * 1800, dtype="float32").reshape(1800, 3600)
+    data = xarray.DataArray(arr, dims=("y", "x"))
+
+    with GeoArrayReader(
+        input=data,
+        crs=CRS.from_epsg(4326),
+        transform=Affine.translation(-180, 90) * Affine.scale(0.1, -0.1),
+    ) as dst:
+        assert dst.band_descriptions == ["b1"]
+        info = dst.info()
+        assert info.band_descriptions == [
+            ("b1", "b1"),
+        ]
+
+    # 2D array with name
+    arr = numpy.arange(0.0, 3600 * 1800, dtype="float32").reshape(1800, 3600)
+    data = xarray.DataArray(arr, dims=("y", "x"), name="data")
+
+    with GeoArrayReader(
+        input=data,
+        crs=CRS.from_epsg(4326),
+        transform=Affine.translation(-180, 90) * Affine.scale(0.1, -0.1),
+    ) as dst:
+        assert dst.band_descriptions == ["data"]
+        info = dst.info()
+        assert info.band_descriptions == [
+            ("b1", "data"),
+        ]
+
+    # 2D array without dims and coordinates
+    arr = numpy.arange(0.0, 3600 * 1800, dtype="float32").reshape(1800, 3600)
+    data = xarray.DataArray(arr)
+
+    with GeoArrayReader(
+        input=data,
+        crs=CRS.from_epsg(4326),
+        transform=Affine.translation(-180, 90) * Affine.scale(0.1, -0.1),
+    ) as dst:
+        assert dst.band_descriptions == ["b1"]
+        info = dst.info()
+        assert info.band_descriptions == [
+            ("b1", "b1"),
+        ]
 
 
 def test_geoxarray_reader_point():

--- a/tests/test_geoxarray.py
+++ b/tests/test_geoxarray.py
@@ -445,14 +445,14 @@ def test_geoxarray_nodata():
         assert not img.array.mask[0, -1, -1]
 
 
-def test_geoxarray_zarr_nodata():
-    """Add Nodata metadata within a Zarr Array."""
+def test_geoxarray_zarr_fill_value():
+    """Interpret fill_value as Nodata within a Zarr Array."""
     store = zarr.storage.MemoryStore()
     dataset = zarr.create_group(store=store)
     zarrobj = dataset.create_array(
         "data",
-        shape=(100, 100),
-        chunks=(50, 50),
+        shape=(1800, 3600),
+        chunks=(100, 100),
         dtype="float32",
         fill_value=-9999.0,
         dimension_names=("y", "x"),
@@ -484,4 +484,52 @@ def test_geoxarray_zarr_nodata():
     img = geods.preview()
     assert numpy.ma.is_masked(img.array)
     assert img.array.mask[0, 0, 0]
+    assert not img.array.mask[0, -1, -1]
+
+
+def test_geoxarray_zarr_nodata():
+    """Merge both fill_value mask and nodata maske."""
+    store = zarr.storage.MemoryStore()
+    dataset = zarr.create_group(store=store)
+    zarrobj = dataset.create_array(
+        "data",
+        shape=(1800, 3600),
+        chunks=(100, 100),
+        dtype="float32",
+        fill_value=-9999.0,
+        dimension_names=("y", "x"),
+        attributes={
+            "_FillValue": FillValueCoder.encode(-9999.0, numpy.dtype("float32")),
+        },
+    )
+    zarrobj[:] = numpy.arange(0.0, 3600 * 1800, dtype="float32").reshape(1800, 3600)
+    zarrobj[0:50, 0:50] = -9999.0  # Add some nodata
+    zarrobj[50:100, 0:50] = 0.0  # Add secondary nodata value
+
+    zarr.consolidate_metadata(dataset.store)
+
+    ds = xarray.open_dataset(
+        store,  # type: ignore
+        decode_times=False,
+        decode_coords=False,
+        consolidated=True,
+        engine="zarr",
+    )
+
+    xarray_array = ds["data"]
+    geods = GeoArrayReader(
+        input=xarray_array,
+        crs=CRS.from_epsg(4326),
+        transform=Affine.translation(-180, 90) * Affine.scale(0.1, -0.1),
+        options={"nodata": 0.0},
+    )
+    # The FillValue is not a `nodata` value per say in Zarr V3 model
+    assert geods._nodata_value is None
+    # use max_size 3600 to return the full array without resampling
+    img = geods.preview(max_size=3600)
+    assert img.array.shape == (1, 1800, 3600)
+    assert numpy.ma.is_masked(img.array)
+    assert img.array.mask[0, 0, 0]
+    assert img.array.mask[0, 50, 0]
+    assert not img.array.mask[0, 100, 0]
     assert not img.array.mask[0, -1, -1]

--- a/tests/test_geoxarray.py
+++ b/tests/test_geoxarray.py
@@ -9,7 +9,6 @@ import xarray
 import zarr
 from affine import Affine
 from rasterio.crs import CRS
-from xarray.backends.zarr import FillValueCoder
 
 from rio_tiler.experimental.xarray import GeoArrayReader
 from rio_tiler.io import XarrayReader
@@ -445,10 +444,11 @@ def test_geoxarray_nodata():
         assert not img.array.mask[0, -1, -1]
 
 
-def test_geoxarray_zarr_fill_value():
-    """Interpret fill_value as Nodata within a Zarr Array."""
+@pytest.fixture
+def zarr_dataset():
+    """Create Zarr fixture."""
     store = zarr.storage.MemoryStore()
-    dataset = zarr.create_group(store=store)
+    dataset = zarr.create_group(store=store, zarr_format=3)
     zarrobj = dataset.create_array(
         "data",
         shape=(1800, 3600),
@@ -456,20 +456,26 @@ def test_geoxarray_zarr_fill_value():
         dtype="float32",
         fill_value=-9999.0,
         dimension_names=("y", "x"),
-        attributes={
-            "_FillValue": FillValueCoder.encode(-9999.0, numpy.dtype("float32")),
-        },
+        # attributes={
+        #     "_FillValue": FillValueCoder.encode(-9999.0, numpy.dtype("float32")),
+        # },
     )
     zarrobj[:] = numpy.arange(0.0, 3600 * 1800, dtype="float32").reshape(1800, 3600)
     zarrobj[0:50, 0:50] = -9999.0  # Add some nodata
+    zarrobj[50:100, 0:50] = 0.0  # Add secondary nodata value
     zarr.consolidate_metadata(dataset.store)
+    return store
 
-    ds = xarray.open_dataset(
-        store,  # type: ignore
+
+def test_geoxarray_zarr_fill_value(zarr_dataset):
+    """Interpret fill_value as Nodata within a Zarr Array."""
+    ds = xarray.open_zarr(
+        zarr_dataset,
         decode_times=False,
         decode_coords=False,
         consolidated=True,
-        engine="zarr",
+        use_zarr_fill_value_as_mask=True,
+        zarr_format=3,
     )
 
     xarray_array = ds["data"]
@@ -486,37 +492,6 @@ def test_geoxarray_zarr_fill_value():
     assert img.array.mask[0, 0, 0]
     assert not img.array.mask[0, -1, -1]
 
-
-def test_geoxarray_zarr_nodata():
-    """Merge both fill_value mask and nodata maske."""
-    store = zarr.storage.MemoryStore()
-    dataset = zarr.create_group(store=store)
-    zarrobj = dataset.create_array(
-        "data",
-        shape=(1800, 3600),
-        chunks=(100, 100),
-        dtype="float32",
-        fill_value=-9999.0,
-        dimension_names=("y", "x"),
-        attributes={
-            "_FillValue": FillValueCoder.encode(-9999.0, numpy.dtype("float32")),
-        },
-    )
-    zarrobj[:] = numpy.arange(0.0, 3600 * 1800, dtype="float32").reshape(1800, 3600)
-    zarrobj[0:50, 0:50] = -9999.0  # Add some nodata
-    zarrobj[50:100, 0:50] = 0.0  # Add secondary nodata value
-
-    zarr.consolidate_metadata(dataset.store)
-
-    ds = xarray.open_dataset(
-        store,  # type: ignore
-        decode_times=False,
-        decode_coords=False,
-        consolidated=True,
-        engine="zarr",
-    )
-
-    xarray_array = ds["data"]
     geods = GeoArrayReader(
         input=xarray_array,
         crs=CRS.from_epsg(4326),

--- a/tests/test_geoxarray.py
+++ b/tests/test_geoxarray.py
@@ -9,6 +9,7 @@ import xarray
 import zarr
 from affine import Affine
 from rasterio.crs import CRS
+from xarray.backends.zarr import FillValueCoder
 
 from rio_tiler.experimental.xarray import GeoArrayReader
 from rio_tiler.io import XarrayReader
@@ -456,9 +457,9 @@ def zarr_dataset():
         dtype="float32",
         fill_value=-9999.0,
         dimension_names=("y", "x"),
-        # attributes={
-        #     "_FillValue": FillValueCoder.encode(-9999.0, numpy.dtype("float32")),
-        # },
+        attributes={
+            "_FillValue": FillValueCoder.encode(-9999.0, numpy.dtype("float32")),
+        },
     )
     zarrobj[:] = numpy.arange(0.0, 3600 * 1800, dtype="float32").reshape(1800, 3600)
     zarrobj[0:50, 0:50] = -9999.0  # Add some nodata


### PR DESCRIPTION
ref #909 

```python
import xarray
from obstore.store import HTTPStore
from zarr.storage import ObjectStore
from affine import Affine
from rasterio.crs import CRS
from matplotlib.pyplot import imshow

from rio_tiler.experimental.xarray import GeoArrayReader

# Create Obstore Store
store = HTTPStore("https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2B_MSIL2A_20260216T142149_N0512_R096_T25WFV_20260216T165051.zarr")
zarr_store = ObjectStore(store=store, read_only=True)
dt = xarray.open_datatree(
    zarr_store,
    engine="zarr",
    create_default_indexes=False,
    consolidated=True,
)

ds = dt["/measurements/reflectance/r720m"]

attributes = ds.attrs

tr = attributes["spatial:transform"]
transform = Affine(*tr)
crs = CRS.from_user_input(attributes["proj:code"])

with GeoArrayReader(ds["b02"], transform=transform, crs=crs) as dst:
    img = dst.preview()
```