### PR TITLE
fix: improve performance in async_mosaic_reader

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 
 # Unreleased
 
+## 9.2.2 (2026-06-18)
+
+* fix: improve performance in `mosaic.async_mosaic_reader`
+* change: deprecate `chunk_size` parameter in `mosaic.async_mosaic_reader` function
+
 ## 9.2.1 (2026-06-12)
 
 * fix: `GeoZarrReader.info()` returns `GeoZarr` driver instead of `Zarr-Python` driver

--- a/rio_tiler/mosaic/reader.py
+++ b/rio_tiler/mosaic/reader.py
@@ -379,7 +379,7 @@ async def async_mosaic_reader(  # noqa: C901
             pixel_selection.feed(
                 numpy.ma.MaskedArray(
                     resize_array(img.array.data, h, w),
-                    mask=resize_array(img.array.mask * 1, h, w).astype("bool"),
+                    mask=resize_array(img.array.mask * 1, h, w).astype("bool"),  # type: ignore
                 )
             )
 

--- a/rio_tiler/mosaic/reader.py
+++ b/rio_tiler/mosaic/reader.py
@@ -302,7 +302,6 @@ async def async_mosaic_reader(  # noqa: C901
         reader (callable): Reader function. The function MUST take `(asset, *args, **kwargs)` as arguments, and MUST return an ImageData.
         args (Any): Argument to forward to the reader function.
         pixel_selection (MosaicMethod, optional): Instance of MosaicMethodBase class. Defaults to `rio_tiler.mosaic.methods.defaults.FirstMethod`.
-        chunk_size (int, optional): Control the number of asset to process per loop.
         allowed_exceptions (tuple, optional): List of exceptions which will be ignored. Note: `TileOutsideBounds` is likely to be raised and should be included in the allowed_exceptions. Defaults to `(TileOutsideBounds, )`.
         kwargs (optional): Reader callable's keywords options.
 
@@ -318,6 +317,13 @@ async def async_mosaic_reader(  # noqa: C901
             img = await async_mosaic_reader(["cog.tif", "cog2.tif"], reader, x, y, z)
 
     """
+    # TODO: Remove `chunk_size` parameter in v10.0
+    if chunk_size:
+        warnings.warn(
+            "`chunk_size` parameter is deprecated. All assets will be processed at once.",
+            DeprecationWarning,
+        )
+
     if isclass(pixel_selection):
         pixel_selection = cast(type[MosaicMethodBase], pixel_selection)
 
@@ -330,78 +336,79 @@ async def async_mosaic_reader(  # noqa: C901
             "'rio_tiler.mosaic.methods.base.MosaicMethodBase'"
         )
 
-    chunk_size = chunk_size or len(mosaic_assets)
-
     assets_used: list = []
     crs: CRS | None
     bounds: BBox | None
     band_names: list[str]
 
-    for chunks in _chunks(mosaic_assets, chunk_size):
-        futures = await asyncio.gather(
-            *[reader(asset, *args, **kwargs) for asset in chunks],
-            return_exceptions=True,
+    tasks = [
+        asyncio.create_task(reader(asset, *args, **kwargs)) for asset in mosaic_assets
+    ]
+    for task, asset in zip(tasks, mosaic_assets):
+        try:
+            img = await task
+        except allowed_exceptions:
+            continue
+
+        # On the first Image we set the properties
+        if len(assets_used) == 0:
+            crs = img.crs
+            bounds = img.bounds
+            band_names = img.band_names
+            band_descriptions = img.band_descriptions
+            pixel_selection.cutline_mask = img.cutline_mask
+            pixel_selection.width = img.width
+            pixel_selection.height = img.height
+            pixel_selection.count = img.count
+
+        assert img.count == pixel_selection.count, (
+            "Assets HAVE TO have the same number of bands"
         )
-        tasks = [(v, chunks[ix]) for ix, v in enumerate(futures)]
-        for img, asset in filter_tasks(
-            tasks,
-            allowed_exceptions=allowed_exceptions,
+        if any(
+            [
+                img.width != pixel_selection.width,
+                img.height != pixel_selection.height,
+            ]
         ):
-            # On the first Image we set the properties
-            if len(assets_used) == 0:
-                crs = img.crs
-                bounds = img.bounds
-                band_names = img.band_names
-                band_descriptions = img.band_descriptions
-                pixel_selection.cutline_mask = img.cutline_mask
-                pixel_selection.width = img.width
-                pixel_selection.height = img.height
-                pixel_selection.count = img.count
-
-            assert img.count == pixel_selection.count, (
-                "Assets HAVE TO have the same number of bands"
+            warnings.warn(
+                "Cannot concatenate images with different sizes. Will resize using first asset's width/height.",
+                UserWarning,
             )
-            if any(
-                [
-                    img.width != pixel_selection.width,
-                    img.height != pixel_selection.height,
-                ]
-            ):
-                warnings.warn(
-                    "Cannot concatenate images with different sizes. Will resize using first asset's width/height.",
-                    UserWarning,
+            h = pixel_selection.height
+            w = pixel_selection.width
+            pixel_selection.feed(
+                numpy.ma.MaskedArray(
+                    resize_array(img.array.data, h, w),
+                    mask=resize_array(img.array.mask * 1, h, w).astype("bool"),
                 )
-                h = pixel_selection.height
-                w = pixel_selection.width
-                pixel_selection.feed(
-                    numpy.ma.MaskedArray(
-                        resize_array(img.array.data, h, w),
-                        mask=resize_array(img.array.mask * 1, h, w).astype("bool"),
-                    )
-                )
+            )
 
-            else:
-                pixel_selection.feed(img.array)
+        else:
+            pixel_selection.feed(img.array)
 
-            assets_used.append(asset)
+        assets_used.append(asset)
 
-            if pixel_selection.is_done and pixel_selection.data is not None:
-                return (
-                    ImageData(
-                        pixel_selection.data,
-                        assets=assets_used,
-                        crs=crs,
-                        bounds=bounds,
-                        band_names=band_names,
-                        band_descriptions=band_descriptions,
-                        metadata={
-                            "mosaic_method": pixel_selection.__class__.__name__,
-                            "mosaic_assets_count": len(mosaic_assets),
-                            "mosaic_assets_used": len(assets_used),
-                        },
-                    ),
-                    assets_used,
-                )
+        if pixel_selection.is_done and pixel_selection.data is not None:
+            # Cancel remaining tasks
+            for remaining in tasks:
+                remaining.cancel()
+
+            return (
+                ImageData(
+                    pixel_selection.data,
+                    assets=assets_used,
+                    crs=crs,
+                    bounds=bounds,
+                    band_names=band_names,
+                    band_descriptions=band_descriptions,
+                    metadata={
+                        "mosaic_method": pixel_selection.__class__.__name__,
+                        "mosaic_assets_count": len(mosaic_assets),
+                        "mosaic_assets_used": len(assets_used),
+                    },
+                ),
+                assets_used,
+            )
 
     if pixel_selection.data is None:
         raise EmptyMosaicError("Method returned an empty array")


### PR DESCRIPTION
> With gather you must wait for all tasks to complete before you can check is_done and exit early; with task handles you can cancel() the remaining in-flight requests the moment the mosaic is full.