### PR TITLE
Chore/: Stricter-statictics-checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,5 @@ tests/fixtures/mask*
 .vscode/settings.json
 
 dev_notebooks/*
+
+.DS_Store

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -71,7 +71,7 @@ def _weighted_quantiles(
     i = numpy.argsort(values)
     c = numpy.cumsum(weights[i])
     q = numpy.atleast_1d(quantiles) * c[-1]
-    return values[i[numpy.searchsorted(c, q)]].tolist()
+    return [float(value) for value in values[i[numpy.searchsorted(c, q)]]]
 
 
 # Ref: https://stackoverflow.com/questions/2413522
@@ -145,9 +145,7 @@ def get_array_statistics(
         assert coverage.shape == (
             data.shape[1],
             data.shape[2],
-        ), (
-            f"Invalid shape ({coverage.shape}) for Coverage, expected {(data.shape[1], data.shape[2])}"
-        )
+        ), f"Invalid shape ({coverage.shape}) for Coverage, expected {(data.shape[1], data.shape[2])}"
 
     else:
         coverage = numpy.ones((data.shape[1], data.shape[2]))

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -145,7 +145,9 @@ def get_array_statistics(
         assert coverage.shape == (
             data.shape[1],
             data.shape[2],
-        ), f"Invalid shape ({coverage.shape}) for Coverage, expected {(data.shape[1], data.shape[2])}"
+        ), (
+            f"Invalid shape ({coverage.shape}) for Coverage, expected {(data.shape[1], data.shape[2])}"
+        )
 
     else:
         coverage = numpy.ones((data.shape[1], data.shape[2]))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -686,14 +686,17 @@ def test_get_array_statistics_coverage():
     assert len(stats) == 1
     assert stats[0]["count"] == 4
     assert stats[0]["mean"] == 5
-    assert stats[0]["median"] == 5
+    assert stats[0]["median"] == 5.0
+    assert isinstance(stats[0]["median"], float)
     assert stats[0]["min"] == 1
     assert stats[0]["max"] == 9
     # exactextract takes coverage into account, we don't
     assert stats[0]["minority"] == 1  # 1 in exactextract
     assert stats[0]["majority"] == 1  # 5 in exactextract
-    assert stats[0]["percentile_25"] == 3
-    assert stats[0]["percentile_75"] == 6
+    assert stats[0]["percentile_25"] == 3.0
+    assert stats[0]["percentile_75"] == 6.0
+    assert isinstance(stats[0]["percentile_25"], float)
+    assert isinstance(stats[0]["percentile_75"], float)
     assert stats[0]["std"] == math.sqrt(5)
 
     # test correct calculation of valid percent with masked array and coverage array


### PR DESCRIPTION
Explicitly cast weighted quantile results to float so statistics for integer rasters retain their previous output types. Add regression assertions for median and percentile values.