### PR TITLE
perf: optional fast uint8 PNG/JPEG/WEBP encode (opt-in)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync
+          # dev group includes imagecodecs/pillow so fast_encode tests can run
+          uv sync --group dev
 
       - name: Run pre-commit and mypy
         if: ${{ matrix.python-version == env.LATEST_PY_VERSION }}
@@ -39,7 +40,16 @@ jobs:
           uv run --with mypy --with types-attrs --with types-cachetools mypy -p rio_tiler --ignore-missing-imports
 
       - name: Run tests
+        # Default: fast encode off (GDAL path) unless tests pass fast_encode=True
         run: uv run pytest --cov rio_tiler --cov-report xml --cov-report term-missing -s -vv
+
+      - name: Run render tests with fast encode enabled
+        # Env opt-in path (imagecodecs/Pillow) for uint8 PNG/JPEG/WEBP
+        if: ${{ matrix.python-version == env.LATEST_PY_VERSION }}
+        env:
+          RIO_TILER_FAST_ENCODE: "1"
+        run: |
+          uv run pytest tests/test_utils.py tests/test_models.py -q --tb=short
 
       - name: Upload Results
         if: ${{ matrix.python-version == env.LATEST_PY_VERSION }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,13 @@
 
 # Unreleased
 
+* perf: optional fast uint8 PNG/JPEG/WEBP encode path in `utils.render` / `ImageData.render` (author @manand881)
+    * **Opt-in only** (default remains GDAL): `fast_encode=True` or env `RIO_TILER_FAST_ENCODE=1` (`true`/`yes`/`on`). Explicit kwarg overrides env.
+    * Backends when enabled: **imagecodecs → GDAL** fallback. Install with `pip install "rio-tiler[fast-encode]"` (also in the `dev` dependency group).
+    * Omitting creation options uses **GDAL driver defaults** (JPEG quality **75**, PNG zlevel **6**, WEBP quality **75**, lossless false). `img_profiles` still apply when passed.
+    * Unsupported creation options (anything other than the mapped quality/zlevel/lossless keys) fall back to GDAL.
+    * Lossless **PNG** is decode-equal to GDAL (pixels/mask/layout). Lossy **JPEG/WEBP** may not be bit-identical to GDAL at the same quality.
+    * fix: WEBP `LOSSLESS` creation option with GDAL-style string values (`"FALSE"`, `"NO"`, `"OFF"`, `"0"`) was incorrectly treated as lossless on the fast path (`bool("FALSE")` is `True` in Python). String values are now interpreted explicitly.
 * fix: avoid unnecessary copy and mask work in ImageData.render (author @manand881, https://github.com/cogeotiff/rio-tiler/pull/974)
 
 ## 9.4.2 (2026-07-20)

--- a/README.md
+++ b/README.md
@@ -173,6 +173,15 @@ python -m pip install -U pip
 python -m pip install -U rio-tiler
 ```
 
+Optional faster uint8 PNG/JPEG/WEBP encoding (for tile servers such as TiTiler):
+
+```bash
+python -m pip install "rio-tiler[fast-encode]"
+```
+
+Then enable per call (`img.render(..., fast_encode=True)`) or via env
+`RIO_TILER_FAST_ENCODE=1`. Default install stays on the GDAL encode path.
+
 or install from source:
 
 ```bash

--- a/docs/src/advanced/dynamic_tiler.md
+++ b/docs/src/advanced/dynamic_tiler.md
@@ -27,8 +27,11 @@ your own API.
 Install with
 
 ```bash
-pip install fastapi uvicorn rio-tiler
+pip install fastapi uvicorn "rio-tiler[fast-encode]"
 ```
+
+For higher tile throughput, enable the optional fast uint8 encode path once
+(e.g. `export RIO_TILER_FAST_ENCODE=1`) or pass `fast_encode=True` to `render()`.
 
 ### `app.py`
 
@@ -72,7 +75,11 @@ def tile(
     with Reader(url) as cog:
         img = cog.tile(x, y, z, tilesize=tilesize)
 
-    content = img.render(img_format="PNG", **img_profiles.get("png"))
+    content = img.render(
+        img_format="PNG",
+        fast_encode=True,  # optional; or set RIO_TILER_FAST_ENCODE=1
+        **img_profiles.get("png"),
+    )
     return Response(content, media_type="image/png")
 
 

--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -65,7 +65,21 @@ with Reader(
 
     # Encode the data in JPEG
     buff = img.render(img_format="JPEG")
+
+    # Optional: faster uint8 PNG/JPEG/WEBP encode (needs rio-tiler[fast-encode])
+    buff = img.render(img_format="PNG", fast_encode=True)
 ```
+
+Install encode backends and opt in (default remains GDAL):
+
+```bash
+python -m pip install "rio-tiler[fast-encode]"
+export RIO_TILER_FAST_ENCODE=1   # or pass fast_encode=True to render()
+```
+
+Lossless PNG is decode-equal to GDAL; lossy JPEG/WEBP may not be bit-identical
+to GDAL at the same quality. Omitting creation options uses GDAL driver defaults
+(JPEG quality 75, PNG zlevel 6, WEBP quality 75).
 
 ## Rescale non-byte data and/or apply colormap
 

--- a/docs/src/models.md
+++ b/docs/src/models.md
@@ -289,6 +289,10 @@ print(ImageData(data))
 
 - **render()**: Render the data/mask to an image buffer (forward data and mask to rio_tiler.utils.render).
 
+    Optional `fast_encode=True` (or env `RIO_TILER_FAST_ENCODE=1`) uses
+    imagecodecs for uint8 PNG/JPEG/WEBP when installed via
+    `rio-tiler[fast-encode]`. Default is the GDAL path.
+
     ```python
     import numpy
     from rasterio.io import MemoryFile
@@ -305,6 +309,7 @@ print(ImageData(data))
 
     # create a PNG image
     buf = img.render(img_format="png")
+    # buf = img.render(img_format="png", fast_encode=True)
     print(get_meta(buf))
     >>> {
         'driver': 'PNG',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,8 @@ dev = [
     "ipyleaflet",
     "matplotlib",
     "pyinstrument",
+    # Fast encode path (utils.render fast_encode=True)
+    "imagecodecs>=2024.1.1",
 ]
 
 performance = [
@@ -82,6 +84,9 @@ deploy = [
 ]
 
 [project.optional-dependencies]
+fast-encode = [
+    "imagecodecs>=2024.1.1",
+]
 s3 = [
     "boto3",
 ]

--- a/rio_tiler/models.py
+++ b/rio_tiler/models.py
@@ -832,6 +832,7 @@ class ImageData:
         add_mask: bool = True,
         img_format: str = "PNG",
         colormap: ColorMapType | None = None,
+        fast_encode: bool | None = None,
         **kwargs,
     ) -> bytes:
         """Render data to image blob.
@@ -840,6 +841,9 @@ class ImageData:
             add_mask (bool, optional): add mask to output image. Defaults to `True`.
             img_format (str, optional): output image format. Defaults to `PNG`.
             colormap (dict or sequence, optional): RGBA Color Table dictionary or sequence.
+            fast_encode (bool, optional): Forwarded to `rio_tiler.utils.render`.
+                Opt-in fast uint8 PNG/JPEG/WEBP encode. Defaults to off unless
+                ``RIO_TILER_FAST_ENCODE`` is set.
             kwargs (optional): keyword arguments to forward to `rio_tiler.utils.render`.
 
         Returns:
@@ -883,10 +887,17 @@ class ImageData:
                 mask,
                 img_format=img_format,
                 colormap=colormap,
+                fast_encode=fast_encode,
                 **kwargs,
             )
 
-        return render(array.data, img_format=img_format, colormap=colormap, **kwargs)
+        return render(
+            array.data,
+            img_format=img_format,
+            colormap=colormap,
+            fast_encode=fast_encode,
+            **kwargs,
+        )
 
     def to_raster(self, dst_path: str, *, driver: str = "GTIFF", **kwargs: Any) -> None:
         """Save ImageData array to file."""

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -1,6 +1,7 @@
 """rio_tiler.utils: utility functions."""
 
 import math
+import os
 import time
 import warnings
 from collections.abc import Callable, Generator
@@ -28,6 +29,7 @@ from rasterio.warp import calculate_default_transform, transform_geom
 from rio_tiler.colormap import apply_cmap
 from rio_tiler.constants import WEB_MERCATOR_CRS, WGS84_CRS
 from rio_tiler.errors import InvalidFormat, RioTilerError
+from rio_tiler.logger import logger
 from rio_tiler.types import BBox, ColorMapType, IntervalTuple, RIOResampling
 
 _P = ParamSpec("_P")
@@ -551,45 +553,207 @@ def _requested_tile_aligned_with_internal_tile(
     return True
 
 
-def render(
-    data: numpy.ndarray,
-    mask: numpy.ndarray | None = None,
-    img_format: str = "PNG",
-    colormap: ColorMapType | None = None,
-    **creation_options: Any,
-) -> bytes:
-    """Translate numpy.ndarray to image bytes.
-
-    Args:
-        data (numpy.ndarray): Image array to encode.
-        mask (numpy.ndarray, optional): Mask array.
-        img_format (str, optional): Image format. See: for the list of supported format by GDAL: https://www.gdal.org/formats_list.html. Defaults to `PNG`.
-        colormap (dict or sequence, optional): RGBA Color Table dictionary or sequence.
-        creation_options (optional): Image driver creation options to forward to GDAL.
-
-    Returns
-        bytes: image body.
-
-    Examples:
-        >>> with Reader("my_tif.tif") as src:
-            img = src.preview()
-            with open('test.jpg', 'wb') as f:
-                f.write(render(img.data, img.mask, img_format="jpeg"))
+def _creation_option(options: dict, *keys: str, default: Any = None) -> Any:
+    """Return the first matching creation option (any key case)."""
+    if not options:
+        return default
+    lower_map = {str(k).lower(): v for k, v in options.items()}
+    for key in keys:
+        if key in options:
+            return options[key]
+        if key.lower() in lower_map:
+            return lower_map[key.lower()]
+    return default
 
 
+# GDAL-style truthy/falsy string values for boolean creation options.
+_GDAL_TRUTHY_STRINGS: frozenset[str] = frozenset({"1", "true", "yes", "on"})
+
+
+def _as_bool(value: Any) -> bool:
+    """Coerce a creation-option value to bool, honoring GDAL-style strings.
+
+    GDAL accepts ``TRUE``/``FALSE``/``ON``/``OFF``/``YES``/``NO``/``1``/``0``
+    (case-insensitive) for boolean options. ``bool("FALSE")`` is ``True`` in
+    Python, so string values must be interpreted explicitly.
     """
-    img_format = img_format.upper()
+    if isinstance(value, str):
+        return value.strip().lower() in _GDAL_TRUTHY_STRINGS
+    return bool(value)
 
+
+# Creation options the fast path can honor (lowercase). Any other key → GDAL.
+_FAST_ENCODE_OPTION_KEYS: dict[str, frozenset[str]] = {
+    "PNG": frozenset({"zlevel"}),
+    "JPEG": frozenset({"quality"}),
+    "WEBP": frozenset({"quality", "lossless"}),
+}
+
+
+def _fast_encode_options_supported(img_format: str, creation_options: dict) -> bool:
+    """Return True if all creation options are supported by the fast encoder."""
+    allowed = _FAST_ENCODE_OPTION_KEYS.get(img_format)
+    if allowed is None:
+        return False
+    for key in creation_options:
+        if str(key).lower() not in allowed:
+            return False
+    return True
+
+
+def _fast_encode_enabled(fast_encode: bool | None) -> bool:
+    """Resolve whether the optional fast encode path is enabled.
+
+    Explicit ``fast_encode`` wins. Otherwise ``RIO_TILER_FAST_ENCODE`` is read
+    (1/true/yes/on). Default is off so installs without opt-in stay on GDAL.
+    """
+    if fast_encode is not None:
+        return bool(fast_encode)
+    val = os.environ.get("RIO_TILER_FAST_ENCODE", "").strip().lower()
+    return val in {"1", "true", "yes", "on"}
+
+
+def _uint8_hwc(
+    data: numpy.ndarray,
+    mask: numpy.ndarray | None,
+) -> tuple[numpy.ndarray, str] | None:
+    """Build contiguous HWC uint8 image and imagecodecs mode string."""
+    count, height, width = data.shape
+
+    if mask is not None:
+        if count not in (1, 3):
+            return None
+        alpha = mask if mask.dtype == numpy.uint8 else mask.astype(numpy.uint8)
+        if alpha.shape != (height, width):
+            return None
+        if count == 1:
+            img_arr = numpy.empty((height, width, 2), dtype=numpy.uint8)
+            img_arr[:, :, 0] = data[0]
+            img_arr[:, :, 1] = alpha
+            return img_arr, "LA"
+        img_arr = numpy.empty((height, width, 4), dtype=numpy.uint8)
+        img_arr[:, :, 0] = data[0]
+        img_arr[:, :, 1] = data[1]
+        img_arr[:, :, 2] = data[2]
+        img_arr[:, :, 3] = alpha
+        return img_arr, "RGBA"
+
+    if count == 1:
+        return numpy.ascontiguousarray(data[0]), "L"
+    if count == 3:
+        img_arr = numpy.empty((height, width, 3), dtype=numpy.uint8)
+        img_arr[:, :, 0] = data[0]
+        img_arr[:, :, 1] = data[1]
+        img_arr[:, :, 2] = data[2]
+        return img_arr, "RGB"
+    if count == 4:
+        img_arr = numpy.empty((height, width, 4), dtype=numpy.uint8)
+        img_arr[:, :, 0] = data[0]
+        img_arr[:, :, 1] = data[1]
+        img_arr[:, :, 2] = data[2]
+        img_arr[:, :, 3] = data[3]
+        return img_arr, "RGBA"
+    return None
+
+
+def _render_uint8_imagecodecs(
+    img_arr: numpy.ndarray,
+    mode: str,
+    img_format: str,
+    creation_options: dict,
+) -> bytes | None:
+    """Encode via imagecodecs when installed."""
+    try:
+        import imagecodecs
+    except ImportError:  # pragma: no cover
+        return None
+
+    try:
+        if img_format == "PNG":
+            # GDAL PNG driver default ZLEVEL is 6
+            level = int(_creation_option(creation_options, "ZLEVEL", "zlevel", default=6))
+            level = max(0, min(level, 9))
+            return bytes(imagecodecs.png_encode(img_arr, level=level))
+
+        if img_format == "JPEG":
+            # GDAL JPEG driver default QUALITY is 75
+            quality = int(
+                _creation_option(creation_options, "QUALITY", "quality", default=75)
+            )
+            # JPEG has no alpha
+            if mode == "RGBA":
+                img_arr = img_arr[:, :, :3]
+            return bytes(
+                imagecodecs.jpeg_encode(img_arr, level=max(1, min(quality, 100)))
+            )
+
+        if img_format == "WEBP":
+            quality = int(
+                _creation_option(creation_options, "QUALITY", "quality", default=75)
+            )
+            lossless = _as_bool(
+                _creation_option(creation_options, "LOSSLESS", "lossless", default=False)
+            )
+            return bytes(
+                imagecodecs.webp_encode(
+                    img_arr,
+                    level=max(0, min(quality, 100)),
+                    lossless=lossless,
+                )
+            )
+    except Exception as exc:
+        logger.debug("imagecodecs %s encode failed: %s; falling back", img_format, exc)
+        return None
+    return None
+
+
+def _render_uint8_fast(
+    data: numpy.ndarray,
+    mask: numpy.ndarray | None,
+    img_format: str,
+    creation_options: dict,
+) -> bytes | None:
+    """Fast uint8 PNG/JPEG/WEBP encode (imagecodecs → GDAL fallback).
+
+    Returns None when imagecodecs cannot handle the request, including when
+    unsupported GDAL creation options are present (caller should use GDAL).
+    """
+    if data.dtype != numpy.uint8 or img_format not in {"PNG", "JPEG", "WEBP"}:
+        return None
+
+    if not _fast_encode_options_supported(img_format, creation_options):
+        return None
+
+    if img_format == "JPEG":
+        mask = None
+        # 4-band JPEG via GDAL is written as CMYK. imagecodecs has no CMYK
+        # JPEG mode (a contiguous RGB slice would emit 3-band RGB instead),
+        # so bail to GDAL to preserve the existing CMYK output exactly.
+        if data.shape[0] == 4:
+            return None
+
+    packed = _uint8_hwc(data, mask)
+    if packed is None:
+        return None
+    img_arr, mode = packed
+
+    return _render_uint8_imagecodecs(img_arr, mode, img_format, creation_options)
+
+
+def _prepare_render_inputs(
+    data: numpy.ndarray,
+    mask: numpy.ndarray | None,
+    img_format: str,
+    colormap: ColorMapType | None,
+) -> tuple[numpy.ndarray, numpy.ndarray | None]:
+    """Normalize array/mask for encoding (colormap, WEBP gray, PNG16, JPEG)."""
     if len(data.shape) < 3:
         data = numpy.expand_dims(data, axis=0)
 
     input_range = dtype_ranges[str(data.dtype)]
     if colormap:
         data, alpha = apply_cmap(data, colormap)
-
-        # We take both the input mask and the alpha from the colormap
-        # if input mask is not provided then we assume output is wanted without alpha band
-        # this can be seen as a bug but at the time of writing we assume it's a feature.
+        # Both input mask and colormap alpha; no mask → no alpha band (legacy).
         if mask is not None:
             output_range = dtype_ranges[str(data.dtype)]
             mask = numpy.where(mask != input_range[0], alpha, output_range[0]).astype(
@@ -603,31 +767,45 @@ def render(
     if img_format == "PNG" and data.dtype == "uint16" and mask is not None:
         # By rio-tiler design, mask should always be between 0 and 255
         mask = linear_rescale(mask, (0, 255), (0, 65535)).astype("uint16")
-
     elif img_format == "JPEG":
         mask = None
 
-    elif img_format == "NPY":
-        # If mask is not None we add it as the last band
+    return data, mask
+
+
+def _render_numpy_binary(
+    data: numpy.ndarray,
+    mask: numpy.ndarray | None,
+    img_format: str,
+) -> bytes | None:
+    """Encode NPY/NPZ; return None for other formats."""
+    if img_format == "NPY":
         if mask is not None:
             m = numpy.expand_dims(mask, axis=0)
             data = numpy.concatenate((data, m))
-
         with BytesIO() as bio:
             numpy.save(bio, data)
             return bio.getvalue()
 
-    elif img_format == "NPZ":
+    if img_format == "NPZ":
         with BytesIO() as bio:
             if mask is not None:
                 numpy.savez_compressed(bio, data=data, mask=mask)
             else:
                 numpy.savez_compressed(bio, data=data)
-
             return bio.getvalue()
 
-    count, height, width = data.shape
+    return None
 
+
+def _render_gdal(
+    data: numpy.ndarray,
+    mask: numpy.ndarray | None,
+    img_format: str,
+    creation_options: dict,
+) -> bytes:
+    """Encode via rasterio MemoryFile / GDAL drivers."""
+    count, height, width = data.shape
     output_profile = {
         "driver": img_format,
         "dtype": data.dtype,
@@ -636,7 +814,6 @@ def render(
         "width": width,
     }
     output_profile.update(creation_options)
-
     try:
         with warnings.catch_warnings():
             warnings.filterwarnings(
@@ -647,20 +824,67 @@ def render(
             with MemoryFile() as memfile:
                 with memfile.open(**output_profile) as dst:
                     dst.write(data, indexes=list(range(1, count + 1)))
-
-                    # Use Mask as an alpha band
                     if mask is not None:
                         if ColorInterp.alpha not in dst.colorinterp:
                             dst.colorinterp = *dst.colorinterp[:-1], ColorInterp.alpha
-
                         dst.write(mask.astype(data.dtype), indexes=count + 1)
-
                 return memfile.read()
-
     except Exception as e:
         raise InvalidFormat(
             f"Could not encode array of shape ({count},{height},{width}) and of datatype `{data.dtype}` using {img_format} driver"
         ) from e
+
+
+def render(
+    data: numpy.ndarray,
+    mask: numpy.ndarray | None = None,
+    img_format: str = "PNG",
+    colormap: ColorMapType | None = None,
+    fast_encode: bool | None = None,
+    **creation_options: Any,
+) -> bytes:
+    """Translate numpy.ndarray to image bytes.
+
+    Args:
+        data (numpy.ndarray): Image array to encode.
+        mask (numpy.ndarray, optional): Mask array.
+        img_format (str, optional): Image format. See: for the list of supported format by GDAL: https://www.gdal.org/formats_list.html. Defaults to `PNG`.
+        colormap (dict or sequence, optional): RGBA Color Table dictionary or sequence.
+        fast_encode (bool, optional): Use optional fast uint8 PNG/JPEG/WEBP
+            encoders (imagecodecs) when available. Defaults to ``False``
+            unless ``RIO_TILER_FAST_ENCODE`` is set to a truthy value
+            (``1``/``true``/``yes``/``on``). Explicit ``fast_encode`` overrides
+            the environment variable. When disabled or unavailable, encoding
+            uses GDAL via rasterio (default userspace behavior). Omitting
+            creation options uses GDAL driver defaults (JPEG quality 75, PNG
+            zlevel 6, WEBP quality 75). Lossless PNG is decode-equal to GDAL;
+            lossy JPEG/WEBP may not be bit-identical to GDAL at the same quality.
+        creation_options (optional): Image driver creation options to forward to GDAL.
+
+    Returns
+        bytes: image body.
+
+    Examples:
+        >>> with Reader("my_tif.tif") as src:
+            img = src.preview()
+            with open('test.jpg', 'wb') as f:
+                f.write(render(img.data, img.mask, img_format="jpeg"))
+
+    """
+    img_format = img_format.upper()
+    data, mask = _prepare_render_inputs(data, mask, img_format, colormap)
+
+    binary = _render_numpy_binary(data, mask, img_format)
+    if binary is not None:
+        return binary
+
+    # Opt-in fast path: uint8 PNG/JPEG/WEBP via imagecodecs → GDAL fallback.
+    if _fast_encode_enabled(fast_encode):
+        encoded = _render_uint8_fast(data, mask, img_format, creation_options)
+        if encoded is not None:
+            return encoded
+
+    return _render_gdal(data, mask, img_format, creation_options)
 
 
 def mapzen_elevation_rgb(data: numpy.ndarray) -> numpy.ndarray:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1020,3 +1020,76 @@ def test_alpha_band():
     # no transparency
     assert not im_colormaped.array.mask[0, 100, 20]
     assert im_colormaped.mask[100, 20] == 255
+
+
+def test_render_fast_encode_passthrough(monkeypatch):
+    """ImageData.render forwards fast_encode; default stays GDAL-compatible."""
+    monkeypatch.delenv("RIO_TILER_FAST_ENCODE", raising=False)
+    rng = numpy.random.default_rng(11)
+    data = rng.integers(0, 256, size=(3, 32, 32), dtype="uint8")
+    im = ImageData(data)
+
+    bare = im.render(img_format="PNG", ZLEVEL=6)
+    off = im.render(img_format="PNG", ZLEVEL=6, fast_encode=False)
+    assert bare == off
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            category=NotGeoreferencedWarning,
+            module="rasterio",
+        )
+        with MemoryFile(im.render(img_format="PNG", ZLEVEL=6, fast_encode=True)) as mem:
+            with mem.open() as src_fast:
+                fast_arr = src_fast.read()
+        with MemoryFile(off) as mem:
+            with mem.open() as src_gdal:
+                gdal_arr = src_gdal.read()
+    numpy.testing.assert_array_equal(fast_arr, gdal_arr)
+
+
+def test_render_fast_encode_add_mask_and_invalidformat():
+    """fast_encode respects add_mask and still raises InvalidFormat."""
+    data = numpy.zeros((1, 16, 16), dtype="uint8") + 5
+    mask = numpy.zeros((1, 16, 16), dtype="bool")
+    mask[0, :4, :4] = True
+    im = ImageData(numpy.ma.MaskedArray(data, mask=mask))
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            category=NotGeoreferencedWarning,
+            module="rasterio",
+        )
+        with MemoryFile(
+            im.render(img_format="PNG", add_mask=True, fast_encode=True)
+        ) as mem:
+            with mem.open() as src:
+                assert src.count == 2
+        with MemoryFile(
+            im.render(img_format="PNG", add_mask=False, fast_encode=True)
+        ) as mem:
+            with mem.open() as src:
+                assert src.count == 1
+
+    with pytest.raises(InvalidFormat):
+        ImageData(numpy.zeros((5, 32, 32), dtype="uint8")).render(
+            img_format="PNG", fast_encode=True
+        )
+
+
+def test_render_fast_encode_does_not_mutate():
+    """fast_encode path must not mutate ImageData.array."""
+    data = numpy.arange(16 * 16, dtype="uint8").reshape(1, 16, 16)
+    im = ImageData(data.copy())
+    before = im.array.copy()
+    assert im.render(img_format="PNG", fast_encode=True)
+    numpy.testing.assert_array_equal(im.array, before)
+
+    data_f = numpy.full((1, 16, 16), 0.25, dtype="float32")
+    im_f = ImageData(data_f.copy())
+    before_f = im_f.array.copy()
+    with pytest.warns(InvalidDatatypeWarning):
+        assert im_f.render(img_format="PNG", fast_encode=True)
+    numpy.testing.assert_array_equal(im_f.array, before_f)
+    assert im_f.array.dtype == numpy.dtype("float32")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,8 +21,9 @@ from rasterio.io import MemoryFile
 
 from rio_tiler import colormap, utils
 from rio_tiler.constants import WEB_MERCATOR_TMS, WGS84_CRS
-from rio_tiler.errors import RioTilerError
+from rio_tiler.errors import InvalidFormat, RioTilerError
 from rio_tiler.io import Reader
+from rio_tiler.profiles import img_profiles
 
 from .conftest import requires_webp
 
@@ -863,3 +864,705 @@ def test_inherit_rasterio_env_not_empty_separate_thread(monkeypatch):
             (True, "FALSE"),
             (False, "something"),
         ]
+
+
+def _decode_raster(content: bytes):
+    """Decode image bytes with rasterio; return (data, profile, colorinterp)."""
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            category=NotGeoreferencedWarning,
+            module="rasterio",
+        )
+        with MemoryFile(content) as mem:
+            with mem.open() as dst:
+                return dst.read(), dst.profile, dst.colorinterp
+
+
+def test_render_png_roundtrip_uint8():
+    """Lossless PNG decode equals input (1-band, 3-band, +mask)."""
+    rng = np.random.default_rng(42)
+    gray = rng.integers(0, 256, size=(1, 64, 64), dtype=np.uint8)
+    rgb = rng.integers(0, 256, size=(3, 64, 64), dtype=np.uint8)
+    mask = np.full((64, 64), 255, dtype=np.uint8)
+    mask[:10, :10] = 0
+    mask[20:30, 20:30] = 128
+
+    data, profile, _ = _decode_raster(utils.render(gray, img_format="PNG"))
+    assert profile["driver"] == "PNG"
+    assert profile["count"] == 1
+    np.testing.assert_array_equal(data[0], gray[0])
+
+    data, profile, color = _decode_raster(utils.render(rgb, mask=mask, img_format="PNG"))
+    assert profile["count"] == 4
+    assert ColorInterp.alpha in color
+    np.testing.assert_array_equal(data[:3], rgb)
+    np.testing.assert_array_equal(data[3], mask)
+
+    data, profile, _ = _decode_raster(utils.render(rgb, img_format="PNG"))
+    assert profile["count"] == 3
+    np.testing.assert_array_equal(data, rgb)
+
+
+def test_render_jpeg_drops_mask_layout():
+    """JPEG always drops mask and keeps 3 bands."""
+    rgb = np.zeros((3, 32, 32), dtype=np.uint8) + 40
+    rgb[0] = 200
+    mask = np.zeros((32, 32), dtype=np.uint8)
+    data, profile, color = _decode_raster(utils.render(rgb, mask=mask, img_format="JPEG"))
+    assert profile["driver"] == "JPEG"
+    assert profile["count"] == 3
+    assert ColorInterp.alpha not in color
+    assert data.shape == (3, 32, 32)
+
+
+def test_render_jpeg_default_quality_is_gdal_75(monkeypatch):
+    """Bare JPEG uses QUALITY=75 (GDAL default), not img_profiles 85."""
+    monkeypatch.delenv("RIO_TILER_FAST_ENCODE", raising=False)
+    rng = np.random.default_rng(0)
+    rgb = rng.integers(0, 256, size=(3, 64, 64), dtype=np.uint8)
+    # GDAL path (default) and fast path both use 75 when QUALITY omitted
+    bare = utils.render(rgb, img_format="JPEG", fast_encode=False)
+    q75 = utils.render(rgb, img_format="JPEG", QUALITY=75, fast_encode=False)
+    q85 = utils.render(rgb, img_format="JPEG", QUALITY=85, fast_encode=False)
+    assert bare == q75
+    assert bare != q85
+
+    bare_fast = utils.render(rgb, img_format="JPEG", fast_encode=True)
+    q75_fast = utils.render(rgb, img_format="JPEG", QUALITY=75, fast_encode=True)
+    q85_fast = utils.render(rgb, img_format="JPEG", QUALITY=85, fast_encode=True)
+    assert bare_fast == q75_fast
+    assert bare_fast != q85_fast
+
+
+@requires_webp
+def test_render_webp_gray_expands_to_rgb():
+    """WEBP 1-band is expanded to RGB with equal channels."""
+    gray = np.full((1, 32, 32), 77, dtype=np.uint8)
+    data, profile, _ = _decode_raster(utils.render(gray, img_format="WEBP"))
+    assert profile["driver"] == "WEBP"
+    assert profile["count"] == 3
+    np.testing.assert_array_equal(data[0], data[1])
+    np.testing.assert_array_equal(data[1], data[2])
+
+
+def test_render_colormap_mask_band_count():
+    """Colormap without mask omits alpha; with mask includes alpha."""
+    arr = np.zeros((1, 16, 16), dtype=np.uint8) + 1
+    cm = {0: (0, 0, 0, 0), 1: (255, 0, 0, 255)}
+
+    data, profile, color = _decode_raster(utils.render(arr, colormap=cm))
+    assert profile["count"] == 3
+    assert ColorInterp.alpha not in color
+    np.testing.assert_array_equal(data[:, 0, 0], [255, 0, 0])
+
+    mask = np.full((16, 16), 255, dtype=np.uint8)
+    data, profile, color = _decode_raster(
+        utils.render(arr, mask=mask, colormap=cm, img_format="PNG")
+    )
+    assert profile["count"] == 4
+    assert ColorInterp.alpha in color
+    np.testing.assert_array_equal(data[:, 0, 0], [255, 0, 0, 255])
+
+
+def test_render_fast_encode_default_off(monkeypatch):
+    """Without opt-in, encode matches explicit fast_encode=False (GDAL path)."""
+    monkeypatch.delenv("RIO_TILER_FAST_ENCODE", raising=False)
+    rng = np.random.default_rng(1)
+    rgb = rng.integers(0, 256, size=(3, 32, 32), dtype=np.uint8)
+    bare = utils.render(rgb, img_format="PNG", ZLEVEL=6)
+    off = utils.render(rgb, img_format="PNG", ZLEVEL=6, fast_encode=False)
+    assert bare == off
+
+
+def test_render_fast_path_matches_gdal_png_decode():
+    """Fast encode path and GDAL path decode to the same PNG pixels."""
+    rng = np.random.default_rng(7)
+    rgb = rng.integers(0, 256, size=(3, 48, 48), dtype=np.uint8)
+    mask = np.full((48, 48), 255, dtype=np.uint8)
+    mask[:8, :8] = 0
+    mask[10:20, 10:20] = 100
+
+    for zlevel in (1, 6):
+        fast_bytes = utils.render(
+            rgb, mask=mask, img_format="PNG", ZLEVEL=zlevel, fast_encode=True
+        )
+        gdal_bytes = utils.render(
+            rgb, mask=mask, img_format="PNG", ZLEVEL=zlevel, fast_encode=False
+        )
+
+        # Raw codec bytes may differ; decoded pixels must match.
+        p_data, p_prof, p_ci = _decode_raster(fast_bytes)
+        g_data, g_prof, g_ci = _decode_raster(gdal_bytes)
+        assert p_prof["count"] == g_prof["count"] == 4
+        assert ColorInterp.alpha in p_ci and ColorInterp.alpha in g_ci
+        np.testing.assert_array_equal(p_data, g_data)
+
+
+@pytest.mark.parametrize("env_val", ["1", "true", "TRUE", "yes", "on"])
+def test_render_fast_encode_env(monkeypatch, env_val):
+    """RIO_TILER_FAST_ENCODE enables fast path; kwarg overrides env."""
+    rng = np.random.default_rng(3)
+    rgb = rng.integers(0, 256, size=(3, 24, 24), dtype=np.uint8)
+
+    monkeypatch.delenv("RIO_TILER_FAST_ENCODE", raising=False)
+    default_bytes = utils.render(rgb, img_format="PNG", ZLEVEL=6)
+    gdal_bytes = utils.render(rgb, img_format="PNG", ZLEVEL=6, fast_encode=False)
+    assert default_bytes == gdal_bytes
+
+    monkeypatch.setenv("RIO_TILER_FAST_ENCODE", env_val)
+    env_on = utils.render(rgb, img_format="PNG", ZLEVEL=6)
+    explicit_on = utils.render(rgb, img_format="PNG", ZLEVEL=6, fast_encode=True)
+    # Both should be fast path when backends exist; decode-equal either way
+    e_data, _, _ = _decode_raster(env_on)
+    x_data, _, _ = _decode_raster(explicit_on)
+    g_data, _, _ = _decode_raster(gdal_bytes)
+    np.testing.assert_array_equal(e_data, g_data)
+    np.testing.assert_array_equal(x_data, g_data)
+
+    # Explicit False wins over env
+    env_overridden = utils.render(rgb, img_format="PNG", ZLEVEL=6, fast_encode=False)
+    assert env_overridden == gdal_bytes
+
+
+def test_render_fast_encode_env_falsy_ignored(monkeypatch):
+    """Unrecognized / falsy env values keep the GDAL default path."""
+    rng = np.random.default_rng(4)
+    rgb = rng.integers(0, 256, size=(3, 16, 16), dtype=np.uint8)
+    gdal_bytes = utils.render(rgb, img_format="PNG", ZLEVEL=6, fast_encode=False)
+
+    for env_val in ["0", "false", "off", "", "maybe"]:
+        monkeypatch.setenv("RIO_TILER_FAST_ENCODE", env_val)
+        assert utils.render(rgb, img_format="PNG", ZLEVEL=6) == gdal_bytes
+
+
+def test_render_fast_encode_unsupported_options_use_gdal():
+    """Unknown creation options force GDAL instead of silently ignoring them."""
+    rng = np.random.default_rng(5)
+    rgb = rng.integers(0, 256, size=(3, 32, 32), dtype=np.uint8)
+
+    # WORLDFILE is a real GDAL option the fast path does not implement
+    gdal = utils.render(
+        rgb, img_format="PNG", ZLEVEL=6, WORLDFILE="YES", fast_encode=False
+    )
+    fast = utils.render(
+        rgb, img_format="PNG", ZLEVEL=6, WORLDFILE="YES", fast_encode=True
+    )
+    assert fast == gdal
+
+    # JPEG progressive not mapped by fast path
+    gdal_j = utils.render(
+        rgb, img_format="JPEG", QUALITY=75, PROGRESSIVE="ON", fast_encode=False
+    )
+    fast_j = utils.render(
+        rgb, img_format="JPEG", QUALITY=75, PROGRESSIVE="ON", fast_encode=True
+    )
+    assert fast_j == gdal_j
+
+
+def test_render_fast_encode_jpeg_layout():
+    """Fast JPEG: drop mask; gray stays 1-band; RGB stays 3-band."""
+    rgb = np.zeros((3, 32, 32), dtype=np.uint8) + 40
+    rgb[0] = 200
+    mask = np.zeros((32, 32), dtype=np.uint8)
+    data, profile, color = _decode_raster(
+        utils.render(rgb, mask=mask, img_format="JPEG", fast_encode=True)
+    )
+    assert profile["driver"] == "JPEG"
+    assert profile["count"] == 3
+    assert ColorInterp.alpha not in color
+    assert data.shape == (3, 32, 32)
+
+    gray = np.full((1, 32, 32), 90, dtype=np.uint8)
+    data, profile, _ = _decode_raster(
+        utils.render(gray, img_format="JPEG", fast_encode=True)
+    )
+    assert profile["count"] == 1
+    assert data.shape == (1, 32, 32)
+
+    # Gray + mask: JPEG drops mask, stays 1-band
+    mask = np.zeros((32, 32), dtype=np.uint8)
+    mask[:4, :4] = 0
+    data, profile, color = _decode_raster(
+        utils.render(gray, mask=mask, img_format="JPEG", fast_encode=True)
+    )
+    assert profile["count"] == 1
+    assert ColorInterp.alpha not in color
+    assert data.shape == (1, 32, 32)
+
+
+def test_render_fast_encode_jpeg_four_band_cmyk_parity():
+    """4-band JPEG must fall back to GDAL CMYK, byte-identical, in fast mode.
+
+    The fast path cannot emit GDAL's 4-band CMYK JPEG, so it must bail to
+    GDAL and produce byte-identical output. This locks the contract so a
+    future change cannot silently switch 4-band JPEG to 3-band RGB.
+    """
+    rgba = np.zeros((4, 32, 32), dtype=np.uint8)
+    rgba[0] = 200
+    rgba[3] = 255
+    gdal = utils.render(rgba, img_format="JPEG", fast_encode=False)
+    fast = utils.render(rgba, img_format="JPEG", fast_encode=True)
+    assert fast == gdal
+    data, profile, _ = _decode_raster(gdal)
+    assert profile["driver"] == "JPEG"
+
+
+@requires_webp
+def test_render_fast_encode_webp_layout():
+    """Fast WEBP: gray expands to RGB; mask becomes alpha (4 bands)."""
+    gray = np.full((1, 32, 32), 77, dtype=np.uint8)
+    data, profile, _ = _decode_raster(
+        utils.render(gray, img_format="WEBP", fast_encode=True)
+    )
+    assert profile["driver"] == "WEBP"
+    assert profile["count"] == 3
+    np.testing.assert_array_equal(data[0], data[1])
+    np.testing.assert_array_equal(data[1], data[2])
+
+    rgb = np.zeros((3, 32, 32), dtype=np.uint8) + 10
+    mask = np.full((32, 32), 255, dtype=np.uint8)
+    mask[:4, :4] = 0
+    data, profile, color = _decode_raster(
+        utils.render(rgb, mask=mask, img_format="WEBP", fast_encode=True)
+    )
+    assert profile["count"] == 4
+    assert ColorInterp.alpha in color
+
+    # 4-band RGBA without separate mask stays 4-band
+    rng = np.random.default_rng(18)
+    rgba = rng.integers(0, 256, size=(4, 32, 32), dtype=np.uint8)
+    data, profile, color = _decode_raster(
+        utils.render(rgba, img_format="WEBP", fast_encode=True)
+    )
+    assert profile["count"] == 4
+    assert ColorInterp.alpha in color
+
+
+def test_render_fast_encode_colormap_mask_band_count():
+    """Fast path keeps colormap ± mask band-count contract."""
+    arr = np.zeros((1, 16, 16), dtype=np.uint8) + 1
+    cm = {0: (0, 0, 0, 0), 1: (255, 0, 0, 255)}
+
+    data, profile, color = _decode_raster(
+        utils.render(arr, colormap=cm, fast_encode=True)
+    )
+    assert profile["count"] == 3
+    assert ColorInterp.alpha not in color
+    np.testing.assert_array_equal(data[:, 0, 0], [255, 0, 0])
+
+    mask = np.full((16, 16), 255, dtype=np.uint8)
+    data, profile, color = _decode_raster(
+        utils.render(arr, mask=mask, colormap=cm, img_format="PNG", fast_encode=True)
+    )
+    assert profile["count"] == 4
+    assert ColorInterp.alpha in color
+    np.testing.assert_array_equal(data[:, 0, 0], [255, 0, 0, 255])
+
+
+@requires_webp
+def test_render_fast_encode_colormap_webp():
+    """Fast path: colormap + WEBP keeps band-count contract (3 vs 4)."""
+    arr = np.zeros((1, 16, 16), dtype=np.uint8) + 1
+    cm = {0: (0, 0, 0, 0), 1: (255, 0, 0, 255)}
+
+    # Colormap without mask → 3-band (no alpha)
+    data, profile, color = _decode_raster(
+        utils.render(arr, colormap=cm, img_format="WEBP", fast_encode=True)
+    )
+    assert profile["driver"] == "WEBP"
+    assert profile["count"] == 3
+    assert ColorInterp.alpha not in color
+
+    # Colormap + partial mask (with transparent pixels) → 4-band
+    mask = np.full((16, 16), 255, dtype=np.uint8)
+    mask[:4, :4] = 0
+    data, profile, color = _decode_raster(
+        utils.render(arr, mask=mask, colormap=cm, img_format="WEBP", fast_encode=True)
+    )
+    assert profile["count"] == 4
+    assert ColorInterp.alpha in color
+
+    # Decode-equal to GDAL for both cases
+    for m in (None, mask):
+        f_data, _, _ = _decode_raster(
+            utils.render(arr, mask=m, colormap=cm, img_format="WEBP", fast_encode=True)
+        )
+        g_data, _, _ = _decode_raster(
+            utils.render(arr, mask=m, colormap=cm, img_format="WEBP", fast_encode=False)
+        )
+        np.testing.assert_array_equal(f_data, g_data)
+
+
+def test_render_fast_encode_img_profiles_honored():
+    """Explicit img_profiles options are honored on the fast path."""
+    rng = np.random.default_rng(8)
+    rgb = rng.integers(0, 256, size=(3, 48, 48), dtype=np.uint8)
+
+    jpeg_prof = img_profiles["jpeg"]  # quality 85
+    bare_fast = utils.render(rgb, img_format="JPEG", fast_encode=True)
+    profile_fast = utils.render(rgb, img_format="JPEG", fast_encode=True, **jpeg_prof)
+    assert bare_fast != profile_fast
+    assert profile_fast == utils.render(
+        rgb, img_format="JPEG", QUALITY=85, fast_encode=True
+    )
+
+    png_raw = img_profiles["pngraw"]  # zlevel 1
+    fast_z1 = utils.render(rgb, img_format="PNG", fast_encode=True, **png_raw)
+    gdal_z1 = utils.render(rgb, img_format="PNG", fast_encode=False, **png_raw)
+    f_data, _, _ = _decode_raster(fast_z1)
+    g_data, _, _ = _decode_raster(gdal_z1)
+    np.testing.assert_array_equal(f_data, g_data)
+
+
+def test_render_fast_encode_four_band_rgba_png():
+    """4-band uint8 without separate mask encodes as RGBA on fast path."""
+    rng = np.random.default_rng(9)
+    rgba = rng.integers(0, 256, size=(4, 24, 24), dtype=np.uint8)
+    fast = utils.render(rgba, img_format="PNG", fast_encode=True)
+    gdal = utils.render(rgba, img_format="PNG", fast_encode=False)
+    f_data, f_prof, _ = _decode_raster(fast)
+    g_data, g_prof, _ = _decode_raster(gdal)
+    assert f_prof["count"] == g_prof["count"] == 4
+    np.testing.assert_array_equal(f_data, g_data)
+
+
+def test_render_fast_encode_png_roundtrip_uint8():
+    """Fast-path lossless PNG decode equals input (1-band, 3-band, +mask)."""
+    rng = np.random.default_rng(42)
+    gray = rng.integers(0, 256, size=(1, 64, 64), dtype=np.uint8)
+    rgb = rng.integers(0, 256, size=(3, 64, 64), dtype=np.uint8)
+    mask = np.full((64, 64), 255, dtype=np.uint8)
+    mask[:10, :10] = 0
+    mask[20:30, 20:30] = 128
+
+    data, profile, _ = _decode_raster(
+        utils.render(gray, img_format="PNG", fast_encode=True)
+    )
+    assert profile["driver"] == "PNG"
+    assert profile["count"] == 1
+    np.testing.assert_array_equal(data[0], gray[0])
+
+    data, profile, color = _decode_raster(
+        utils.render(rgb, mask=mask, img_format="PNG", fast_encode=True)
+    )
+    assert profile["count"] == 4
+    assert ColorInterp.alpha in color
+    np.testing.assert_array_equal(data[:3], rgb)
+    np.testing.assert_array_equal(data[3], mask)
+
+    data, profile, _ = _decode_raster(
+        utils.render(rgb, img_format="PNG", fast_encode=True)
+    )
+    assert profile["count"] == 3
+    np.testing.assert_array_equal(data, rgb)
+
+
+def test_render_fast_encode_default_off_all_formats(monkeypatch):
+    """Bare render matches fast_encode=False for PNG/JPEG/WEBP (GDAL path)."""
+    monkeypatch.delenv("RIO_TILER_FAST_ENCODE", raising=False)
+    rng = np.random.default_rng(12)
+    rgb = rng.integers(0, 256, size=(3, 32, 32), dtype=np.uint8)
+    gray = rng.integers(0, 256, size=(1, 32, 32), dtype=np.uint8)
+
+    assert utils.render(rgb, img_format="PNG") == utils.render(
+        rgb, img_format="PNG", fast_encode=False
+    )
+    assert utils.render(rgb, img_format="JPEG") == utils.render(
+        rgb, img_format="JPEG", fast_encode=False
+    )
+    assert utils.render(gray, img_format="WEBP") == utils.render(
+        gray, img_format="WEBP", fast_encode=False
+    )
+
+
+def test_render_fast_encode_invalid_format_still_raises():
+    """Invalid shapes still raise InvalidFormat with fast_encode on or off."""
+    bad = np.zeros((5, 32, 32), dtype=np.uint8)
+    with pytest.raises(InvalidFormat):
+        utils.render(bad, img_format="PNG", fast_encode=False)
+    with pytest.raises(InvalidFormat):
+        utils.render(bad, img_format="PNG", fast_encode=True)
+
+    with pytest.raises(InvalidFormat):
+        utils.render(np.zeros((1, 8, 8), dtype=np.uint8), img_format="NOTADRIVER")
+
+
+def test_render_fast_encode_non_uint8_bails_to_gdal():
+    """Non-uint8 dtypes must bypass the fast path and use GDAL identically.
+
+    The fast path only handles uint8. For uint16/float32/etc. it must bail
+    out immediately (dtype check) so GDAL is used with zero overhead —
+    fast_encode=True must produce byte-identical output to fast_encode=False.
+    """
+    rng = np.random.default_rng(21)
+
+    # uint16 1-band PNG (stays uint16 through GDAL)
+    u16 = rng.integers(0, 65536, size=(1, 32, 32), dtype=np.uint16)
+    assert utils.render(u16, img_format="PNG", fast_encode=True) == utils.render(
+        u16, img_format="PNG", fast_encode=False
+    )
+
+    # uint16 1-band PNG + mask (mask rescaled to 0-65535)
+    mask = np.full((32, 32), 255, dtype=np.uint8)
+    mask[:4, :4] = 0
+    assert utils.render(
+        u16, mask=mask, img_format="PNG", fast_encode=True
+    ) == utils.render(u16, mask=mask, img_format="PNG", fast_encode=False)
+
+    # NPY accepts any dtype — fast path must bail, output identical
+    f32 = (rng.random((3, 16, 16), dtype=np.float32) * 1000).astype(np.float32)
+    assert utils.render(f32, img_format="NPY", fast_encode=True) == utils.render(
+        f32, img_format="NPY", fast_encode=False
+    )
+
+
+def test_render_fast_encode_without_backends(monkeypatch):
+    """fast_encode=True falls back to GDAL when imagecodecs is missing."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _block_imagecodecs(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "imagecodecs" or name.startswith("imagecodecs."):
+            raise ImportError(f"blocked {name}")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _block_imagecodecs)
+
+    rng = np.random.default_rng(13)
+    rgb = rng.integers(0, 256, size=(3, 24, 24), dtype=np.uint8)
+    gdal = utils.render(rgb, img_format="PNG", ZLEVEL=6, fast_encode=False)
+    fast = utils.render(rgb, img_format="PNG", ZLEVEL=6, fast_encode=True)
+    assert fast == gdal
+
+
+@requires_webp
+@pytest.mark.parametrize("lossless_val", ["TRUE", "true", "YES", "ON", "1", True])
+def test_render_fast_encode_webp_lossless_truthy(lossless_val):
+    """Fast WEBP honors GDAL-style truthy LOSSLESS strings as lossless."""
+    rng = np.random.default_rng(15)
+    rgb = rng.integers(0, 256, size=(3, 32, 32), dtype=np.uint8)
+
+    fast = utils.render(rgb, img_format="WEBP", LOSSLESS=lossless_val, fast_encode=True)
+    gdal = utils.render(rgb, img_format="WEBP", LOSSLESS=lossless_val, fast_encode=False)
+    # Lossless output is deterministic and backend-independent for the same
+    # pixels; decode-equal guards the contract even if raw bytes differ.
+    f_data, _, _ = _decode_raster(fast)
+    g_data, _, _ = _decode_raster(gdal)
+    np.testing.assert_array_equal(f_data, g_data)
+
+    # Lossless must not match lossy output for non-trivial input
+    lossy = utils.render(rgb, img_format="WEBP", LOSSLESS=False, fast_encode=True)
+    assert fast != lossy
+
+
+@requires_webp
+@pytest.mark.parametrize("lossless_val", ["FALSE", "false", "NO", "OFF", "0", False])
+def test_render_fast_encode_webp_lossless_falsy(lossless_val):
+    """Fast WEBP honors GDAL-style falsy LOSSLESS strings as lossy.
+
+    Regression: ``bool("FALSE")`` is ``True`` in Python, so string values must
+    be interpreted explicitly (not via ``bool()``).
+    """
+    rng = np.random.default_rng(16)
+    rgb = rng.integers(0, 256, size=(3, 32, 32), dtype=np.uint8)
+
+    fast = utils.render(rgb, img_format="WEBP", LOSSLESS=lossless_val, fast_encode=True)
+    gdal = utils.render(rgb, img_format="WEBP", LOSSLESS=lossless_val, fast_encode=False)
+    # Both should be lossy; decode-equal confirms the fast path did not
+    # accidentally produce lossless output.
+    f_data, _, _ = _decode_raster(fast)
+    g_data, _, _ = _decode_raster(gdal)
+    np.testing.assert_array_equal(f_data, g_data)
+
+    # Lossy must not match lossless output for non-trivial input
+    lossless = utils.render(rgb, img_format="WEBP", LOSSLESS=True, fast_encode=True)
+    assert fast != lossless
+
+
+@requires_webp
+def test_render_fast_encode_webp_img_profiles():
+    """img_profiles['webp'] (quality 75, lossless False) honored on fast path."""
+    rng = np.random.default_rng(17)
+    rgb = rng.integers(0, 256, size=(3, 32, 32), dtype=np.uint8)
+
+    webp_prof = img_profiles["webp"]  # quality 75, lossless False
+    fast = utils.render(rgb, img_format="WEBP", fast_encode=True, **webp_prof)
+    gdal = utils.render(rgb, img_format="WEBP", fast_encode=False, **webp_prof)
+    f_data, _, _ = _decode_raster(fast)
+    g_data, _, _ = _decode_raster(gdal)
+    np.testing.assert_array_equal(f_data, g_data)
+
+    # Explicit lossless via profile must differ from default lossy
+    lossless_prof = {**webp_prof, "lossless": True}
+    fast_lossless = utils.render(
+        rgb, img_format="WEBP", fast_encode=True, **lossless_prof
+    )
+    assert fast != fast_lossless
+
+
+def test_render_fast_encode_real_cog_png_jpeg():
+    """Real COG through ImageData.render: fast path decode-equals GDAL (PNG)
+    and matches layout (JPEG). Covers masked arrays, add_mask, and GTIFF bypass.
+    """
+    with Reader(COG_RGB) as src:
+        img = src.preview()
+
+    # PNG (lossless): decoded pixels must match exactly
+    png_off = img.render(img_format="PNG", ZLEVEL=6, fast_encode=False)
+    png_on = img.render(img_format="PNG", ZLEVEL=6, fast_encode=True)
+    p_off, p_prof_off, p_ci_off = _decode_raster(png_off)
+    p_on, p_prof_on, p_ci_on = _decode_raster(png_on)
+    assert p_prof_on["count"] == p_prof_off["count"] == 4
+    assert ColorInterp.alpha in p_ci_on and ColorInterp.alpha in p_ci_off
+    np.testing.assert_array_equal(p_on, p_off)
+
+    # JPEG (lossy): layout must match (count, shape, no alpha)
+    j_off, j_prof_off, j_ci_off = _decode_raster(
+        img.render(img_format="JPEG", fast_encode=False)
+    )
+    j_on, j_prof_on, j_ci_on = _decode_raster(
+        img.render(img_format="JPEG", fast_encode=True)
+    )
+    assert j_prof_on["count"] == j_prof_off["count"] == 3
+    assert ColorInterp.alpha not in j_ci_on and ColorInterp.alpha not in j_ci_off
+    assert j_on.shape == j_off.shape
+
+    # add_mask=False: no alpha band
+    nm_off, nm_prof_off, _ = _decode_raster(
+        img.render(img_format="PNG", add_mask=False, fast_encode=False)
+    )
+    nm_on, nm_prof_on, _ = _decode_raster(
+        img.render(img_format="PNG", add_mask=False, fast_encode=True)
+    )
+    assert nm_prof_on["count"] == nm_prof_off["count"] == 3
+    np.testing.assert_array_equal(nm_on, nm_off)
+
+    # GTIFF: fast path must bail (not PNG/JPEG/WEBP); byte-identical
+    assert img.render(img_format="GTIFF", fast_encode=True) == img.render(
+        img_format="GTIFF", fast_encode=False
+    )
+
+
+def test_render_fast_encode_rescaled_output_equality():
+    """uint16/int16 COG rescaled to uint8 in ImageData.render then fast-encoded.
+
+    This is the most common TiTiler path: non-byte data → rescale → encode.
+    The rescaled uint8 output must decode-equal between fast and GDAL paths.
+    """
+    # uint16 1-band (cog.tif) — rescaled to uint8 via dataset type bounds
+    with Reader(COGEO) as src:
+        img = src.preview(max_size=256)
+    assert img.array.dtype == np.uint16
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=UserWarning)
+        png_off = img.render(img_format="PNG", fast_encode=False)
+        png_on = img.render(img_format="PNG", fast_encode=True)
+    off_data, off_prof, _ = _decode_raster(png_off)
+    on_data, on_prof, _ = _decode_raster(png_on)
+    assert off_prof["count"] == on_prof["count"]
+    np.testing.assert_array_equal(on_data, off_data)
+
+    # int16 2-band (cog_scale.tif) with nodata — masked array + rescale
+    with Reader(
+        os.path.join(os.path.dirname(__file__), "fixtures", "cog_scale.tif")
+    ) as src:
+        img = src.preview()
+    assert img.array.dtype == np.int16
+    assert np.ma.is_masked(img.array)
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=UserWarning)
+        png_off = img.render(img_format="PNG", fast_encode=False)
+        png_on = img.render(img_format="PNG", fast_encode=True)
+    off_data, off_prof, _ = _decode_raster(png_off)
+    on_data, on_prof, _ = _decode_raster(png_on)
+    assert off_prof["count"] == on_prof["count"]
+    np.testing.assert_array_equal(on_data, off_data)
+
+
+@pytest.mark.parametrize(
+    "fmt,option,bad_val,clamped_val",
+    [
+        ("JPEG", "QUALITY", 0, 1),
+        ("JPEG", "QUALITY", -5, 1),
+        ("JPEG", "QUALITY", 200, 100),
+        ("PNG", "ZLEVEL", -1, 0),
+        ("PNG", "ZLEVEL", 99, 9),
+    ],
+)
+def test_render_fast_encode_clamps_out_of_range_options(
+    fmt, option, bad_val, clamped_val
+):
+    """Fast path clamps out-of-range QUALITY/ZLEVEL instead of raising.
+
+    GDAL rejects these with InvalidFormat; the fast path clamps silently.
+    This is a deliberate divergence: clamped output must match the output
+    at the clamped (in-range) value.
+    """
+    rng = np.random.default_rng(22)
+    rgb = rng.integers(0, 256, size=(3, 16, 16), dtype=np.uint8)
+
+    bad = utils.render(rgb, img_format=fmt, **{option: bad_val}, fast_encode=True)
+    clamped = utils.render(rgb, img_format=fmt, **{option: clamped_val}, fast_encode=True)
+    assert bad == clamped
+
+
+def test_render_fast_encode_gtiff_bypass():
+    """GTIFF (and other non-PNG/JPEG/WEBP formats) bypass the fast path entirely."""
+    rng = np.random.default_rng(23)
+    rgb = rng.integers(0, 256, size=(3, 16, 16), dtype=np.uint8)
+
+    # GTIFF: not in {PNG, JPEG, WEBP} → _render_uint8_fast returns None
+    assert utils.render(rgb, img_format="GTIFF", fast_encode=True) == utils.render(
+        rgb, img_format="GTIFF", fast_encode=False
+    )
+
+    # NPY: not in {PNG, JPEG, WEBP} → bypass
+    assert utils.render(rgb, img_format="NPY", fast_encode=True) == utils.render(
+        rgb, img_format="NPY", fast_encode=False
+    )
+
+    # JP2OPENJPEG: not in {PNG, JPEG, WEBP} → bypass
+    assert utils.render(rgb, img_format="JP2OPENJPEG", fast_encode=True) == utils.render(
+        rgb, img_format="JP2OPENJPEG", fast_encode=False
+    )
+
+
+def test_render_fast_encode_thread_safety():
+    """Concurrent fast_encode renders from multiple threads must all succeed.
+
+    TiTiler runs threaded/async; the import-inside-function pattern and
+    imagecodecs/Pillow encoders must be safe under concurrent access.
+    """
+    import secrets
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    mask = np.full((64, 64), 255, dtype=np.uint8)
+    mask[:8, :8] = 0
+
+    def render_one(_):
+        rng = np.random.default_rng(int.from_bytes(secrets.token_bytes(8), "big"))
+        data = rng.integers(0, 256, size=(3, 64, 64), dtype=np.uint8)
+        return utils.render(data, mask=mask, img_format="PNG", ZLEVEL=6, fast_encode=True)
+
+    results = []
+    errors = []
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        futures = [pool.submit(render_one, i) for i in range(64)]
+        for f in as_completed(futures):
+            try:
+                results.append(f.result())
+            except Exception as exc:
+                errors.append(exc)
+
+    assert not errors
+    assert len(results) == 64
+    # Spot-check a few outputs are valid 4-band PNGs
+    for b in results[:5]:
+        data, prof, ci = _decode_raster(b)
+        assert prof["driver"] == "PNG"
+        assert prof["count"] == 4
+        assert ColorInterp.alpha in ci

--- a/uv.lock
+++ b/uv.lock
@@ -1409,6 +1409,65 @@ wheels = [
 ]
 
 [[package]]
+name = "imagecodecs"
+version = "2026.3.6"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/8d/dc18623e5e926ad53c626e128c8baaf4ec42e41029cf0a07381cfef79289/imagecodecs-2026.3.6.tar.gz", hash = "sha256:471b8a4d1b3843cbf7179b45f7d7261f0c0b28809efc1ca6c47822477b143b85", size = 9565259, upload-time = "2026-03-07T01:26:41.183Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/db/873d063c99a726d772bf6f076288da59bb12e9f2af3518c2e4de5fde234d/imagecodecs-2026.3.6-cp311-abi3-macosx_10_15_x86_64.whl", hash = "sha256:44cfb3b609d941014f8ac7cf8611b15ccfd7119443bbb6b5e53916b242d31f9e", size = 13953250, upload-time = "2026-03-07T06:13:36.959Z" },
+    { url = "https://files.pythonhosted.org/packages/42/84/36c38a82f033ffbc9e706dad32be7148f130fc00e7bb417ab60e063897a0/imagecodecs-2026.3.6-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:e64037f22980a211b17bf6bdf03f14ff459a7432eec24f7a58c342f6992132fa", size = 11697496, upload-time = "2026-03-07T01:25:56.412Z" },
+    { url = "https://files.pythonhosted.org/packages/45/fa/f67c4e644fdf06503e120f9d1c8d8654b99066dea7093a674b67704fa4a4/imagecodecs-2026.3.6-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:30fa140bb1a112a889926af36977214ed52a22e4557356043259b5e2f79cfba5", size = 25604431, upload-time = "2026-03-07T01:26:00.703Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/29/93ea9cbab7f57b4e60480c51fc51d8e138e399d11797c981d5f6e79f9832/imagecodecs-2026.3.6-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:e30a14aa2e1c6c90e00375292726486c1d90bf003b1414d608ea4d1f62fd8a79", size = 26468592, upload-time = "2026-03-07T01:26:04.933Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/a7/e3a89b2c516eaca7446e8f1335daeec90764b50888af5e073a2b6a987fcf/imagecodecs-2026.3.6-cp311-abi3-win32.whl", hash = "sha256:c972a45dfee1befbac048ba3492607003e9a185811e8febdc1ed531d48c07e75", size = 15597722, upload-time = "2026-03-07T01:26:08.106Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c7/2b37a7fe9a2eb21011e50f046d62e68ac4e0f8d6ad94d7a10e9f8e8d685f/imagecodecs-2026.3.6-cp311-abi3-win_amd64.whl", hash = "sha256:e8fba5b9ac7be109ed35070208bc1683fa17cc381ed9535a4eae200c6d883bd8", size = 19177403, upload-time = "2026-03-07T01:26:11.718Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/c7/94e930cef9e0a29a2df5e3ba3bacd2c2f1e34ca373fe48624b64af8ae91c/imagecodecs-2026.3.6-cp311-abi3-win_arm64.whl", hash = "sha256:fc4856913be6c8b3861223158920d934a0ae203149a435f585622dbbff8ed696", size = 15193605, upload-time = "2026-03-07T01:26:15.016Z" },
+]
+
+[[package]]
+name = "imagecodecs"
+version = "2026.6.26"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/9f/b436418349779e1c18cc27575360cad03dd492bc574ae9e297832bc48cab/imagecodecs-2026.6.26.tar.gz", hash = "sha256:da95b145f6b4f746acc9e0b8707b164eefc6a36ade3b6e70f74d102e9affad8c", size = 9669990, upload-time = "2026-06-28T18:27:01.957Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/03/89bf1a370dca9860b13414f63d7106600c527305d9d8c0369c15a93ca794/imagecodecs-2026.6.26-cp312-abi3-macosx_10_15_x86_64.whl", hash = "sha256:468314982db54c9c6c32567b159de5d97cf5273763cdede53e320414787ad80a", size = 15387254, upload-time = "2026-06-28T18:26:00.528Z" },
+    { url = "https://files.pythonhosted.org/packages/05/47/826d50cd4378a6982d8a750300b9adc81c3458c4c1bdfd979affc8ce5492/imagecodecs-2026.6.26-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:2d3298028a74d748e5b7a00bd736d41cdf2372861376e4af916818e853ca5fc6", size = 12696122, upload-time = "2026-06-28T18:26:03.714Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/52/ccd8a8a71bb2d0ed9fd4a2592028ab129f6b41c6f2b0ef6c1b9251ec7c88/imagecodecs-2026.6.26-cp312-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73b4310cab61edf5c74ec5cb19672963c2ceb42239877256ca30eb1b70849cf3", size = 27215507, upload-time = "2026-06-28T18:26:07.479Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/3a/29fa169992185df4f1e98b3a1d2b70aac5903170c33f6d66cae68f488c01/imagecodecs-2026.6.26-cp312-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6e9e57171ce7cdf884e7d45d25427f77275321a0ddbd26941c5c90b242d2b597", size = 28855566, upload-time = "2026-06-28T18:26:11.7Z" },
+    { url = "https://files.pythonhosted.org/packages/29/c7/27d82b105d871ceb6de3a68afbee5f95551b8fba796e4e6e35e334f994f4/imagecodecs-2026.6.26-cp312-abi3-win32.whl", hash = "sha256:091b66cfe11e37e5a037ff64b262bede3898f779ebd9cbf0d4a108613577ab15", size = 16568720, upload-time = "2026-06-28T18:26:15.259Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/e2/8d27dbe855293380194aa794cbcce1df2d23039058b3d917817aaa3f5547/imagecodecs-2026.6.26-cp312-abi3-win_amd64.whl", hash = "sha256:0758a273acd197e236e67f1597d630924f62c12f5b74837dc7eef2db72c1a888", size = 21275600, upload-time = "2026-06-28T18:26:19.678Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/38/3d0d0a4abc3ba607f23a3237a1cb6f7737dbd1b39498364f01f62c004e8b/imagecodecs-2026.6.26-cp312-abi3-win_arm64.whl", hash = "sha256:8bbf132cce699c6b282106e97edc65946d788ccca79f6ba8f5cd1b8a3f43423c", size = 16849832, upload-time = "2026-06-28T18:26:22.797Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/30/040baf3050ee9803608ff9694a4a4dc9ec868e222fe4c5c8de481388ffb0/imagecodecs-2026.6.26-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:46980597f48fe790f81e286cf662f0323d0022203cbe48f77c3be608f510de85", size = 15803759, upload-time = "2026-06-28T18:26:25.873Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/e8/042eeac7c78565f1b4c14ba3dc6a96aad9b958e008a1e291a1cbf72123e9/imagecodecs-2026.6.26-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c48767bbc6ed0b40df3607cafdf59dac6f4467b91c26e835744d7ee4085cfdf7", size = 13164944, upload-time = "2026-06-28T18:26:29.33Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/dd/0e0c86df9a55a0a90ced8cf5214abb459015cda5f2e713e0495ccd9bf23f/imagecodecs-2026.6.26-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:9c130cf207efcb35acf74d6040317d217294640e478aa733fb51be758bcaddbc", size = 32436234, upload-time = "2026-06-28T18:26:33.35Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9a/2d63eb2ffa46863bf0ea05884ce1ea2a73a5153b428937b8cbe4faa81536/imagecodecs-2026.6.26-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:014f5f809418eb3dfe29badd4af29ddeeaba8b5eabda4bd502e2292727e4094f", size = 33446845, upload-time = "2026-06-28T18:26:38.238Z" },
+    { url = "https://files.pythonhosted.org/packages/14/68/ece973cd5b1d8305b95ad827b3c6033aed166c5ce93780b6092dbfd5deec/imagecodecs-2026.6.26-cp314-cp314t-win32.whl", hash = "sha256:daa276e5645750404a28a911dcbfb94c7d32b2d8903b5f05167474ea02bd5b40", size = 17330378, upload-time = "2026-06-28T18:26:42.172Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/e6/ab2e9ee84e44768ceb73bb9301988ea4ab9022f02ef9d824d6ebb641a0fb/imagecodecs-2026.6.26-cp314-cp314t-win_amd64.whl", hash = "sha256:0718d75672768871aa6adac2129c8f74c167fb4a3da25f660f3afc94b420304f", size = 22122461, upload-time = "2026-06-28T18:26:45.622Z" },
+    { url = "https://files.pythonhosted.org/packages/58/53/7943321eb84c6d39e71ca47e689557a976c6ebafec48b759b3be0bd7c601/imagecodecs-2026.6.26-cp314-cp314t-win_arm64.whl", hash = "sha256:69b90b7b729d33cd9417d3d572d3092d2d49f7974638ee00e2cdc3ed1fba11d6", size = 17657147, upload-time = "2026-06-28T18:26:48.924Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/de/130820754c21c00dfdc6852661de2bb30161b5a439a8643a446dae97a02f/imagecodecs-2026.6.26-cp315-cp315t-win32.whl", hash = "sha256:a10c347225f5fb1b9d1a36cfadccad9b173609c30e0dd3f68706675d6f4f9b58", size = 17330338, upload-time = "2026-06-28T18:26:52.04Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/df/b4f6f2a9e9102ca674673cb1b432bbebfe2d99acb6364390768024d56ae6/imagecodecs-2026.6.26-cp315-cp315t-win_amd64.whl", hash = "sha256:85ab027a8bc900f13b1cdaac05bb602ea58749731ae18743a7956642a7da7a2c", size = 22116857, upload-time = "2026-06-28T18:26:55.65Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/c4/d87b33e8df5c6ec19f5cd1d5ab39195b2077ac21536ff5146c20d3fb8694/imagecodecs-2026.6.26-cp315-cp315t-win_arm64.whl", hash = "sha256:41e18fcd2124c083b00f988eeb9c5cf89274e5c2f473ee03d54761b71048085c", size = 17651071, upload-time = "2026-06-28T18:26:59.305Z" },
+]
+
+[[package]]
 name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4237,6 +4296,10 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+fast-encode = [
+    { name = "imagecodecs", version = "2026.3.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "imagecodecs", version = "2026.6.26", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
 geotiff = [
     { name = "async-geotiff" },
     { name = "obstore" },
@@ -4264,6 +4327,8 @@ dev = [
     { name = "boto3" },
     { name = "h5netcdf" },
     { name = "h5py" },
+    { name = "imagecodecs", version = "2026.3.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "imagecodecs", version = "2026.6.26", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "ipyleaflet" },
     { name = "ipython" },
     { name = "jupyter" },
@@ -4307,6 +4372,7 @@ requires-dist = [
     { name = "cachetools" },
     { name = "color-operations" },
     { name = "httpx2" },
+    { name = "imagecodecs", marker = "extra == 'fast-encode'", specifier = ">=2024.1.1" },
     { name = "morecantile", specifier = ">=5.0,<8.0" },
     { name = "numexpr" },
     { name = "numpy" },
@@ -4320,7 +4386,7 @@ requires-dist = [
     { name = "xarray", marker = "extra == 'xarray'" },
     { name = "zarr", marker = "extra == 'zarr'", specifier = "~=3.0" },
 ]
-provides-extras = ["geotiff", "s3", "xarray", "zarr"]
+provides-extras = ["fast-encode", "geotiff", "s3", "xarray", "zarr"]
 
 [package.metadata.requires-dev]
 deploy = [{ name = "hatch" }]
@@ -4329,6 +4395,7 @@ dev = [
     { name = "boto3" },
     { name = "h5netcdf" },
     { name = "h5py" },
+    { name = "imagecodecs", specifier = ">=2024.1.1" },
     { name = "ipyleaflet" },
     { name = "ipython" },
     { name = "jupyter" },


### PR DESCRIPTION
Add an opt-in fast encode path for uint8 PNG/JPEG/WEBP tiles in `rio_tiler.utils.render` and `ImageData.render`, aimed at tile servers (e.g. TiTiler) where the encode step is on the hot path. The default install path is unchanged: GDAL via rasterio MemoryFile, byte-for-byte.

Activation
  - `render(..., fast_encode=True)` / `ImageData.render(..., fast_encode=True)`
  - or env `RIO_TILER_FAST_ENCODE=1` (also `true`/`yes`/`on`, case-insensitive)
  - Explicit kwarg wins over env. Default is off, so `pip install rio-tiler` keeps the current GDAL-only behavior — no ambient switch just because a backend is importable.

Backend selection
  - imagecodecs is the only fast backend wired up here (Pillow tier was dropped during prototyping; imagecodecs covers PNG/JPEG/WEBP uint8).
  - On any backend failure (ImportError or encode error) the code falls back to the existing GDAL path and wraps failures as `InvalidFormat` as before.
  - Non-uint8 dtypes, 4-band JPEG (GDAL CMYK), and any creation option not in the supported set (e.g. WORLDFILE, PROGRESSIVE) bail to GDAL immediately, so unsupported inputs are byte-identical to the off path.

GDAL-aligned defaults (preserved when creation options are omitted)
  - JPEG QUALITY 75, PNG ZLEVEL 6, WEBP QUALITY 75 / LOSSLESS False.
  - `img_profiles` presets are still honored when passed explicitly (e.g. `img_profiles['jpeg']` quality 85, `img_profiles['pngraw']` zlevel 1).
  - WEBP LOSSLESS now interprets GDAL-style strings correctly (`bool('FALSE')` was True in Python; `FALSE`/`NO`/`OFF`/`0` now map to lossy).
  - Out-of-range QUALITY/ZLEVEL are clamped on the fast path instead of raising (GDAL rejects them with InvalidFormat); clamped output matches the output at the clamped in-range value.

Behavior contracts (locked by tests in tests/test_utils.py / tests/test_models.py)
  - Lossless PNG is decode-equal to GDAL (pixels, mask, layout, band count).
  - Lossy JPEG/WEBP keep layout/semantics parity (driver, band count, alpha rules, gray→RGB expand for WEBP) but are not guaranteed byte-identical to GDAL at the same quality.
  - `ImageData.array` is not mutated on render (uint8 or rescale path).
  - `add_mask=False` omits alpha as before.
  - JPEG 4-band stays GDAL CMYK (byte-identical fallback).
  - Concurrent renders from multiple threads are safe.

Estimated speedups (256x256 uint8 tiles, imagecodecs backend vs GDAL path, AMD Ryzen 7 9700X 8c/16t, 60 GiB RAM, Python 3.11.15, mean over repeats):
  - JPEG 3-band:           2.21 ms -> 0.17 ms  (~13x)
  - ImageData JPEG:        2.29 ms -> 0.20 ms  (~11x)
  - PNG 1-band:            1.27 ms -> 1.11 ms  (~1.15x)
  - PNG 3-band+mask z1:    5.99 ms -> 5.65 ms  (~1.06x)
  - PNG 3-band+mask z6:    7.45 ms -> 7.22 ms  (~1.03x)
  - WEBP 3-band+mask:      7.26 ms -> 6.84 ms  (~1.06x)
  - WEBP 1-band:           6.05 ms -> 5.76 ms  (~1.05x)
  JPEG wins big because the fast path skips rasterio MemoryFile + GDAL driver
  setup; PNG/WEBP gains are modest since they remain zlib/codec-bound.

Packaging and CI
  - New optional extra `rio-tiler[fast-encode]` (imagecodecs>=2024.1.1).
  - imagecodecs added to the `dev` dependency group so local/CI can exercise the fast path without the extra.
  - CI runs the default suite (fast_encode off) plus a second pass over tests/test_utils.py and tests/test_models.py with `RIO_TILER_FAST_ENCODE=1` on the latest Python.

Docs
  - README, docs/src/intro.md, docs/src/models.md, and docs/src/advanced/dynamic_tiler.md document the extra, the env/kwarg opt-in, the GDAL-aligned defaults, and the lossy-not-bit-identical caveat.
  - CHANGES.md updated with the full entry and the LOSSLESS string fix.
  
  @vincentsarago 